### PR TITLE
Moved composer.json into APP_DIR; changed my namespace to conform with that of the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .vagrant
-web/vendor/*
-web/composer.lock
-web/tests/coverage/*
+vendor/*
+composer.lock
+tests/coverage/*
+.idea
+opencfp.iml

--- a/classes/OpenCFP/Configuration.php
+++ b/classes/OpenCFP/Configuration.php
@@ -1,5 +1,5 @@
 <?php
-namespace TrueNorth\OpenCFP;
+namespace OpenCFP;
 
 class Configuration
 {

--- a/classes/OpenCFP/Database.php
+++ b/classes/OpenCFP/Database.php
@@ -1,5 +1,5 @@
 <?php
-namespace TrueNorth\OpenCFP;
+namespace OpenCFP;
 
 class Database
 {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "ezyang/htmlpurifier": "dev-master"
     },
     "autoload": {
-        "psr-0": {"TrueNorth\\OpenCFP": "classes/"},
         "psr-0": {"OpenCFP": "classes/"}
     },
     "require-dev": {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,8 +1,5 @@
 <?php
-
-namespace TrueNorth\OpenCFP;
-
-require_once '../web/vendor/autoload.php';
+namespace OpenCFP;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase {
 


### PR DESCRIPTION
It looked to me like you moved the vendor folder but not the composer files, so I moved them into APP_DIR. Also, composer.json can't have duplicate psr-0 keys, so yours won and mine was ignored. I had to move my classes into your folder and change their namespace. No big deal.

Myself, I leave the vendor folder in place in my projects because psr-0 requires it, plus that way I can combine sources from other vendors which aren't managed by composer if I want to. Again - no big deal, I'm happy to conform with what you've started. 

I just wanted to send you this so that I can have a good foundation to merge with my login page stuff. For me all the tests pass now, and it seems to still work from a browser.
