### PR TITLE
Removed typo from talk_form.

### DIFF
--- a/templates/talk_form.twig
+++ b/templates/talk_form.twig
@@ -7,7 +7,7 @@
 <select name="type" class="search-query">
     <option value="regular" {% if type == 'regular' %}selected {% endif %}>Regular Talk</option>
     <option value="half-day-tutorial" {% if type == 'half-day-tutorial' %}selected {% endif %}>Half-day Tutorial</option>
-    <option value="full-day-tutorial"> {% if type == 'full-day-tutorial' %}selected {% endif %}Full-day Tutorial</option>
+    <option value="full-day-tutorial" {% if type == 'full-day-tutorial' %}selected {% endif %}>Full-day Tutorial</option>
 </select>
 <br><br>
 <button type="submit" class="btn">{{ buttonInfo }}</button>


### PR DESCRIPTION
A premature right angle bracket caused the loss of selection state for the “Full-day Tutorial” option. The angle bracket has been placed in the correct position.
