### PR TITLE
Signup form accepts invalid passwords with no error message

### DIFF
--- a/tests/SignupFormTest.php
+++ b/tests/SignupFormTest.php
@@ -154,6 +154,8 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             array('foo', 'foo', "The submitted password must be at least 5 characters long", false),
             array('bar', 'foo', "The submitted passwords do not match", false),
             array(null, null, "Missing passwords", false),
+            array('password with spaces', 'password with spaces', "The submitted password contains invalid characters", false),
+            array('invalidChars&*$', 'invalidChars&*$', "The submitted password contains invalid characters", false),
         );
     }
 


### PR DESCRIPTION
Passwords are sanitized down to alnum but no message is shown to the user if they put non-alnum characters into the "password" fields on the signup form. This can require the new user to reset their password before logging in.
