### PR TITLE
Travis CI Config to run PHP Unit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
   - composer install
 
 script:
-  - cd tests; phpunit --configuration ./tests/phpunit.xml
+  - cd tests; phpunit


### PR DESCRIPTION
Here is a Travis CI config to run the PHP Unit tests. The irony is that the tests appear to be failing for me locally and on travis for WebTest.php. I took a look and haven't been able to figure out why that test is failing, but here is the travis config for now. :)
