### PR TITLE
talk submit template was using bad variable in signature/team link

### DIFF
--- a/templates/emails/talk_submit.twig
+++ b/templates/emails/talk_submit.twig
@@ -23,5 +23,5 @@
 Submitted Talk Title: "{{ talk }}"
 
 Thanks and Good Luck,
-  The {{ site.title }} Team.
+  The {{ title }} Team.
 {% endblock %}


### PR DESCRIPTION
Was getting an error on talk submit, found a bad variable call was the culprit.
