### PR TITLE
Small improvement of proper HTML

### DIFF
--- a/templates/layouts/default.twig
+++ b/templates/layouts/default.twig
@@ -13,7 +13,7 @@
         <link href="{{ site.url }}/assets/css/bootstrap.min.css" rel="stylesheet" media="screen">
         <link href="{{ site.url }}/assets/css/site.css" rel="stylesheet" media="screen">
         <link href="{{ site.url }}/assets/css/font-awesome.min.css" rel="stylesheet" media="screen">
-        <link href='//fonts.googleapis.com/css?family=Open+Sans:300,700|Open+Sans+Condensed:700,300|Sanchez' rel='stylesheet' type='text/css'>
+        <link href="https//fonts.googleapis.com/css?family=Open+Sans:300,700|Open+Sans+Condensed:700,300|Sanchez" rel="stylesheet" type="text/css">
     </head>
     <body{% if "/" == current_page %} class="home-page"{% endif %}>
         <div class="navbar navbar-lsp navbar-fixed-top" role="navigation">


### PR DESCRIPTION
Improvement: replaced single quote for HTML argument value by double quotes.
Improvement: added "https" in front of the google fonts link
