### PR TITLE
View-Only Proposal for when CFP period expires

### DIFF
--- a/classes/OpenCFP/Bootstrap.php
+++ b/classes/OpenCFP/Bootstrap.php
@@ -173,6 +173,7 @@ class Bootstrap
         $app->post('/talk/create', 'OpenCFP\Controller\TalkController::processCreateAction');
         $app->post('/talk/update', 'OpenCFP\Controller\TalkController::updateAction');
         $app->post('/talk/delete', 'OpenCFP\Controller\TalkController::deleteAction');
+        $app->get('/talk/{id}', 'OpenCFP\Controller\TalkController::viewAction');
 
         // Login/Logout
         $app->get('/login', 'OpenCFP\Controller\SecurityController::indexAction');

--- a/templates/talk/view.twig
+++ b/templates/talk/view.twig
@@ -1,0 +1,16 @@
+{% extends "layouts/default.twig" %}
+{% block content %}
+    <h2 class="headline">{{ talk.title }}</h2>
+
+    <p>{{ talk.description|raw|nl2br }}</p>
+
+    <p><strong>Other Info:</strong> {{ talk.other|nl2br }}</p>
+
+    <p><strong>Slides:</strong> <a href="{{ talk.slides }}">{{ talk.slides }}</a></p>
+    <p><strong>Type:</strong> {{ talk.type }}</p>
+    <p><strong>Level:</strong> {{ talk.level }}</p>
+    <p><strong>Category:</strong> {{ talk.category }}</p>
+    <p><strong>Desired:</strong> {{ talk.desired ? 'true' : 'false' }}</p>
+    <p><strong>Sponsor:</strong> {{ talk.sponsor ? 'true' : 'false' }}</p>
+
+{% endblock %}


### PR DESCRIPTION
Hi Chris!

I noticed on TrueNorthPHP site that I couldn't edit my CFP after the CFP period is over - this makes perfect sense. However I wanted to **view** it to help with another CFP I'm submitting to SunshinePHP.

I've created a PR which redirects users to a View-Only page of their RFP when they attempt to edit a proposal after the RFP period is over. This read-only proposal is locked down only for the current user, just like editing a proposal.
- New "view" talk template
- New controller action
- New route for viewing talks (only for current user) in Bootstrap file
- No additional tests, repeating current functionality (and mostly "just controller code")

Let me know of any feedback or additional work I can put into this, or if  you'd prefer PR's to another branch.

Here's what it looks like:
![image](https://cloud.githubusercontent.com/assets/467411/4112229/6c65a7a8-3220-11e4-90c7-ac7962fcf9b2.png)
