### PR TITLE
Fixes Spot Exceptions: Database Not Selected

### DIFF
--- a/classes/OpenCFP/Bootstrap.php
+++ b/classes/OpenCFP/Bootstrap.php
@@ -311,7 +311,7 @@ class Bootstrap
     {
         $cfg = new \Spot\Config();
         $cfg->addConnection('mysql', [
-            'dbname' => $this->getConfig('database.database'),
+            'dbname' => $this->getConfig('database.name'),
             'user' => $this->getConfig('database.user'),
             'password' => $this->getConfig('database.password'),
             'host' => $this->getConfig('database.host'),

--- a/config/config.development.ini.dist
+++ b/config/config.development.ini.dist
@@ -14,6 +14,7 @@ path = "/uploads/"
 
 [database]
 dsn = "mysql:dbname=cfp;host=127.0.0.1"
+name = "cfp"
 user = "root"
 password = ""
 

--- a/config/config.production.ini.dist
+++ b/config/config.production.ini.dist
@@ -14,6 +14,7 @@ path = "/uploads/"
 
 [database]
 dsn = "mysql:dbname=cfp;host=127.0.0.1"
+name = "cfp"
 user = "root"
 password = ""
 

--- a/config/config.travis.ini.dist
+++ b/config/config.travis.ini.dist
@@ -14,6 +14,7 @@ path = "/uploads/"
 
 [database]
 dsn = "sqlite::memory:"
+name = "cfp"
 user = "root"
 password = ""
 


### PR DESCRIPTION
The spot configuration was referencing a database configuration key that did not exist. The config was referencing 'database.database' where only the following exist:
- `database.dsn`
- `database.user`
- `database.pass`

I added a fourth configuration setting, 'name', and modified both the spot
configuration and all dist configs to include that property.

A longer-term solution might be to somehow figure out how to get Eloquent (Sentry) and Spot to share a connection or to extract configuration data from the Eloquent connection to not have to duplicate database name in the database.dsn and database.name properties.
