### PR TITLE
Add user as global Twig var so pages properly render top/nav bar.

### DIFF
--- a/classes/OpenCFP/Bootstrap.php
+++ b/classes/OpenCFP/Bootstrap.php
@@ -105,6 +105,11 @@ class Bootstrap
             return $sentry;
         });
 
+        $app['twig'] = $app->share($app->extend('twig', function($twig, $app) {
+            $twig->addGlobal('user', $app['sentry']->getUser());
+            return $twig;
+        }));
+
         // Configure our flash messages functionality
         $app->before(function() use ($app) {
             $flash = $app['session']->get('flash');
@@ -323,7 +328,7 @@ class Bootstrap
     private function initializeAutoLoader()
     {
         if (!file_exists(APP_DIR . '/vendor/autoload.php')) {
-            throw new Exception('Autoload file does not exist.  Did you run composer install?');
+            throw new \Exception('Autoload file does not exist.  Did you run composer install?');
         }
 
         require APP_DIR . '/vendor/autoload.php';

--- a/classes/OpenCFP/Controller/DashboardController.php
+++ b/classes/OpenCFP/Controller/DashboardController.php
@@ -25,7 +25,6 @@ class DashboardController
         $template = $app['twig']->loadTemplate('dashboard.twig');
         $template_data = array(
             'myTalks' => $my_talks,
-            'user' => $user_info,
             'first_name' => $user_info['first_name'],
             'last_name' => $user_info['last_name'],
             'company' => $user_info['company'] ?: null,

--- a/classes/OpenCFP/Controller/ProfileController.php
+++ b/classes/OpenCFP/Controller/ProfileController.php
@@ -57,7 +57,6 @@ class ProfileController
             'id' => $user->getId(),
             'formAction' => '/profile/edit',
             'buttonInfo' => 'Update Profile',
-            'user' => $user,
         );
 
         return $template->render($form_data) ;
@@ -190,7 +189,7 @@ class ProfileController
 
         $template = $app['twig']->loadTemplate('user/change_password.twig');
 
-        return $template->render(array('user' => $user));
+        return $template->render(array());
     }
 
     public function passwordProcessAction(Request $req, Application $app)

--- a/classes/OpenCFP/Controller/SecurityController.php
+++ b/classes/OpenCFP/Controller/SecurityController.php
@@ -42,14 +42,12 @@ class SecurityController
             $errorMessage = $page->getAuthenticationMessage();
 
             $template_data = array(
-                'user' => $app['sentry']->getUser(),
                 'email' => $req->get('email'),
             );
             $code = 400;
         } catch (Exception $e) {
             $errorMessage = $e->getMessage();
             $template_data = array(
-                'user' => $app['sentry']->getUser(),
                 'email' => $req->get('email'),
             );
             $code = 400;

--- a/classes/OpenCFP/Controller/TalkController.php
+++ b/classes/OpenCFP/Controller/TalkController.php
@@ -81,7 +81,6 @@ class TalkController
         $data = array(
             'id' => $talk_id,
             'talk' => $talk_info,
-            'user' => $user
         );
 
         return $template->render($data);
@@ -142,7 +141,6 @@ class TalkController
             'other' => $talk_info['other'],
             'sponsor' => $talk_info['sponsor'],
             'buttonInfo' => 'Update my talk!',
-            'user' => $user
         );
 
         return $template->render($data);
@@ -187,7 +185,6 @@ class TalkController
             'other' => $req->get('other'),
             'sponsor' => $req->get('sponsor'),
             'buttonInfo' => 'Submit my talk!',
-            'user' => $user
         );
 
         return $template->render($data);
@@ -280,7 +277,6 @@ class TalkController
                 'other' => $req->get('other'),
                 'sponsor' => $req->get('sponsor'),
                 'buttonInfo' => 'Submit my talk!',
-                'user' => $user,
             );
 
             $app['session']->set('flash', array(
@@ -369,7 +365,6 @@ class TalkController
                 'other' => $req->get('other'),
                 'sponsor' => $req->get('sponsor'),
                 'buttonInfo' => 'Update my talk!',
-                'user' => $user,
             );
 
             $app['session']->set('flash', array(


### PR DESCRIPTION
A number of pages were not including the Sentry user which when clicking around resulted in it appearing as if one were randomly logged in our out depending on the route being hit.  It probably makes sense to just give all templates access to user.

Commit also contains a trivial bug fix PHPStorm caught.  If you'd like this in a separate PR @chartjes, let me know.
