### PR TITLE
Additional cleanup from centralized cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ NOTE: Use development or production naming as appropriate.
 
 9. May need to edit directory permissions for some of the vendor packages. (your mileage may vary)
 
-    NOTE: We're looking at you ezyang htmlpurifier.
+    NOTE: If you are enabling template / htmlpurifier caching, you should create a directory with appropriate file
+    permissions and configure accordingly in your `config.*.ini`.
 
 10. Update directory permissions to allow for headshot upload.
 

--- a/config/config.development.ini.dist
+++ b/config/config.development.ini.dist
@@ -41,10 +41,3 @@ port = "25"
 ; available options are "tls", "ssl"
 ; for Gmail set encryption = "ssl"
 ;encryption = "ssl"
-
-[htmlpurifier]
-; absolute path to cache the serialized definitions
-; path must be writeable
-; path must not have trailing slash
-; if not set will default to html purifier library folder
-;cachedir = "/path/to/htmlpurifier/cache"

--- a/config/config.production.ini.dist
+++ b/config/config.production.ini.dist
@@ -41,10 +41,3 @@ port = "25"
 ; available options are "tls", "ssl"
 ; for Gmail set encryption = "ssl"
 ;encryption = "ssl"
-
-[htmlpurifier]
-; absolute path to cache the serialized definitions
-; path must be writeable
-; path must not have trailing slash
-; if not set will default to html purifier library folder
-;cachedir = "/path/to/htmlpurifier/cache"

--- a/config/config.travis.ini.dist
+++ b/config/config.travis.ini.dist
@@ -35,10 +35,3 @@ port = "2525"
 ; available options are "tls", "ssl"
 ; for Gmail set encryption = "ssl"
 ;encryption = "ssl"
-
-[htmlpurifier]
-; absolute path to cache the serialized definitions
-; path must be writeable
-; path must not have trailing slash
-; if not set will default to html purifier library folder
-;cachedir = "/path/to/htmlpurifier/cache"


### PR DESCRIPTION
This is additional cleanup from #133.  
- Adds note on cache directory and appropriate permissions.
- Removes `htmlpurifier` sections from distributable config inis.
