### PR TITLE
Only adds user as global twig variable if user is authenticated.

### DIFF
--- a/classes/OpenCFP/Bootstrap.php
+++ b/classes/OpenCFP/Bootstrap.php
@@ -111,7 +111,10 @@ class Bootstrap
         });
 
         $app['twig'] = $app->share($app->extend('twig', function($twig, $app) {
-            $twig->addGlobal('user', $app['sentry']->getUser());
+            if ($app['sentry']->check()) {
+                $twig->addGlobal('user', $app['sentry']->getUser());
+            }
+
             return $twig;
         }));
 


### PR DESCRIPTION
The homepage was not showing the "create profile" buttons because after the changes in #134, the user was `defined` (in Twig's terms), it just so happened to be set to `null`.  This PR puts a check for authenticated user in the bootstrap rather than do value-checking in each Twig template.

I don't have a test that backs this change, but my next goal is to write Behat feature descriptions (not tests/contexts) **JUST** to further orient myself to all of what OpenCFP does and then work on some changes to make unit testing controllers a bit more convenient. That said, I'll open an issue to discuss **that** work before I do anything... don't want to clash.

**Homepage before changes**

![image](https://cloud.githubusercontent.com/assets/2453394/4341944/e3f96d3c-403e-11e4-822c-7db9a9de9d9a.png)

**[Relevant Twig](https://github.com/chartjes/opencfp/blob/master/templates/home.twig#L10-L13)**

**Homepage after changes**

![image](https://cloud.githubusercontent.com/assets/2453394/4341951/14fa82b8-403f-11e4-9ce2-b8f69279ba83.png)
