### PR TITLE
Fixes invalid call to obtain user identifier.

### DIFF
--- a/classes/OpenCFP/Controller/ProfileController.php
+++ b/classes/OpenCFP/Controller/ProfileController.php
@@ -172,7 +172,7 @@ class ProfileController
 
         $form_data['formAction'] = '/profile/edit';
         $form_data['buttonInfo'] = 'Update Profile';
-        $form_data['id'] = $user->getId();
+        $form_data['id'] = $user->id;
         $form_data['user'] = $user;
         $form_data['flash'] = $this->getFlash($app);
         $template = $app['twig']->loadTemplate('user/edit.twig');


### PR DESCRIPTION
Sentry user variable reference is overridden by Spot mapper call and assignment. Following code expected user variable reference to still be the Sentry user.  After updating where it was getting its identifier from, all was well.
