### PR TITLE
Fixes profile photo breakpoint oddity.

### DIFF
--- a/templates/dashboard.twig
+++ b/templates/dashboard.twig
@@ -29,9 +29,9 @@ function deleteTalk(tid) {
     <div class="row">
         <div class="col-md-3">
             {% if speaker_photo is defined and speaker_photo is not empty %}
-                <img src="{{ preview_photo }}" class="profile-photo" />
+                <img src="{{ preview_photo }}" class="profile-photo img-responsive" />
             {% else %}
-                <img src="/uploads/dummyphoto.jpg" class="profile-photo" />
+                <img src="/uploads/dummyphoto.jpg" class="profile-photo img-responsive" />
             {% endif %}
         </div>
         <div class="col-md-9">

--- a/web/assets/css/site.css
+++ b/web/assets/css/site.css
@@ -121,8 +121,6 @@ a:hover {
 .profile-photo {
   border: 6px solid #eee;
   margin: 1rem 0;
-  width: 250px;
-  height: 250px;
 }
 
 /**


### PR DESCRIPTION
Corrects this issue by adding `.img-responsive` bootstrap class to profile images on dashboard.  Also removes explicit heights off the `.profile-photo` class. 

**Demonstrated breakpoint issue because I can't words**

![image](https://cloud.githubusercontent.com/assets/2453394/4379631/64d8aa00-4362-11e4-97d3-41ef5d74c0ca.png)
