### PR TITLE
Specifies 5.4+ as minimum supported version of PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "chartjes/opencfp",
     "require": {
+        "php": ">=5.4",
         "twig/twig": "1.*",
         "pagerfanta/pagerfanta": "1.0.*@dev",
         "cartalyst/sentry": "2.0.*@dev",


### PR DESCRIPTION
I was looking to cleanup in preparations for end-to-end tests and noted that no "official" minimum supported version of PHP was specified in the composer configuration.  I based 5.4 on `.travis.yml` and usage of `"vlucas/spot2": "dev-master"`, which is requiring 5.4+
