### PR TITLE
[discuss] Adds port to application url if it is not 80 or 443.

### DIFF
--- a/classes/OpenCFP/Bootstrap.php
+++ b/classes/OpenCFP/Bootstrap.php
@@ -392,7 +392,7 @@ class Bootstrap
      */
     private function getPort()
     {
-        if (!in_array($_SERVER['SERVER_PORT'], array(80, 443))) {
+        if (isset($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'], array(80, 443))) {
             return ':' . $_SERVER['SERVER_PORT'];
         }
 


### PR DESCRIPTION
This is a sort of 'hack' to work around an issue with end-to-end tests based on PhantomJS. There are better ways of doing this for sure; just wanted to send something along to discuss before spending time on it.  This is being done in Bootstrap because current configuration is ini-based and cannot have values dynamically generated. As this "comes as a solution before a problem", here's pretty much what's going on (and, for sure, advise if you think there's a better way to go about this as far as Selenium / Phantom go).

So, firstly, I'm working in a Vagrant environment forwarding host `8080` to `80` on the guest. In my development configuration, I specify `http://localhost:8080` as the application `url`.  When I start PhantomJS on the guest vm, I'm running it with the `--webdriver` option running on port `4444`.  Behat / Mink is configured to drive PhantomJS by that port and PhantomJS is expecting to interact with the application over port `80` (hitting Apache running inside the virtualized environment).  Because `8080` is hard-coded in my development configuration, links are generated with that port (`{{ site.url }}/ideas`, etc) and when PhantomJS attempts to follow those links (with Apache is not listening on `8080` inside the virtual environment) things start going awry.

This pull request adds a `REMOTE_PORT` to the application url that is used to build links if it is not `80` or `443`.  This allows a developer to work with the application normally in a browser as well as have PhantomJS do its thing for end-to-end tests.

**Alternative Solutions / Implementations**
- Developer can suck-it-up and just change the configuration when they run tests. Always an option :smile: 
- Proposed implementation **should** parse or build the URL rather than simple concatenation of strings. Current implementation fails if port is specified in configuration (`http://localhost:80808080`)
- An alternative config loader could be written to use PHP arrays for configuration instead of ini-files. Probably the most work of the three, but would allow developer to handle this weird stuff at the configuration level rather than in Bootstrap.

If we want to go forward with this, I want to clean up the simple concat implementation and replace with suggestion above.
