### PR TITLE
Adds pre-flight check to DatabaseServiceProvider

### DIFF
--- a/classes/OpenCFP/Provider/DatabaseServiceProvider.php
+++ b/classes/OpenCFP/Provider/DatabaseServiceProvider.php
@@ -10,11 +10,16 @@ class DatabaseServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app['db'] = new \PDO(
+        $pdo = new \PDO(
             $app->config('database.dsn'),
             $app->config('database.user'),
-            $app->config('database.password')
+            $app->config('database.password'),
+            [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
         );
+
+        $this->checkConnection($pdo);
+
+        $app['db'] = $pdo;
     }
 
     /**
@@ -22,5 +27,15 @@ class DatabaseServiceProvider implements ServiceProviderInterface
      */
     public function boot(Application $app)
     {
+    }
+
+    private function checkConnection($pdo)
+    {
+        $check = $pdo->query('select database() as db')->fetch(\PDO::FETCH_ASSOC);
+
+        if ( ! $check['db']) {
+            throw new \Exception('There was a problem connecting to the database. Make
+                sure to use proper DSN format. See: http://php.net/manual/en/pdo.connections.php');
+        }
     }
 }

--- a/tests/OpenCFP/Provider/DatabaseServiceProviderTest.php
+++ b/tests/OpenCFP/Provider/DatabaseServiceProviderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace OpenCFP\Provider;
+
+use Mockery as m;
+
+/**
+ * @covers OpenCFP\Application
+ */
+class DatabaseServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DatabaseServiceProvider
+     */
+    private $sut;
+
+    public function setup()
+    {
+        $this->sut = new DatabaseServiceProvider();
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDatabaseConnections
+     */
+    public function it_should_throw_exception_if_dsn_is_invalid($dsn, $user, $password)
+    {
+        $app = $this->trainApplicationWithDatabaseConfig($dsn, $user, $password);
+
+        $this->setExpectedException('\Exception', 'There was a problem connecting to the database.');
+        $this->sut->register($app);
+    }
+
+    public function invalidDatabaseConnections()
+    {
+        return [
+            ['mysql://root@localhost/cfp', 'root', null],
+            ['mysql://root@localhost/cfp', null, null],
+        ];
+    }
+
+    /** @test */
+    public function it_should_work_just_fine_when_given_valid_dsn()
+    {
+        $app = $this->trainApplicationWithDatabaseConfig('mysql:dbname=cfp_travis;host=127.0.0.1', 'root', null);
+
+        // Set expectation that database should be registered in the container.
+        // $app['db'] = new PDO(...)
+        $app->shouldReceive('offsetSet')->with('db', m::type('PDO'));
+
+        $this->sut->register($app);
+    }
+
+    /**
+     * @param $dsn
+     * @param $user
+     * @param $password
+     *
+     * @return m\MockInterface|\Yay_MockObject
+     */
+    private function trainApplicationWithDatabaseConfig($dsn, $user, $password)
+    {
+        $app = m::mock('OpenCFP\Application');
+        $app->shouldReceive('config')->with('database.dsn')->andReturn($dsn);
+        $app->shouldReceive('config')->with('database.user')->andReturn($user);
+        $app->shouldReceive('config')->with('database.password')->andReturn($password);
+
+        return $app;
+    }
+} 


### PR DESCRIPTION
This is quality-of-life work in response to the issues in #179. The service provider for our database connection through PDO now does a final check on the connection before registering PDO in the service container.

I implemented this as a "unit" test, but it's not really a unit test because PDO isn't mocked. I think that in this case (because we're getting some odd behaviour out of PDO regarding "invalid" DSNs) it is appropriate to not mock it.  If you would like me to move the test somewhere else or put it in an "integration" group, let me know and I'll adjust.

Current implementation fatally errors when invalid DSN provided (similar to what happens if you forget to `composer install` etc etc.):
```
Fatal error: Uncaught exception 'Exception' with message 'There was a problem connecting to the
 database. Make sure to use proper DSN format. See: http://php.net/manual/en/pdo.connections.php' 
in /var/www/html/opencfp/classes/OpenCFP/Provider/DatabaseServiceProvider.php:37 Stack trace: 
#0 /var/www/html/opencfp/classes/OpenCFP/Provider/DatabaseServiceProvider.php(20): OpenCFP\Provider\DatabaseServiceProvider->checkConnection(Object(PDO)) 
#1 /var/www/html/opencfp/vendor/silex/silex/src/Silex/Application.php(169): OpenCFP\Provider\DatabaseServiceProvider->register(Object(OpenCFP\Application)) 
#2 /var/www/html/opencfp/classes/OpenCFP/Application.php(51): Silex\Application->register(Object(OpenCFP\Provider\DatabaseServiceProvider)) 
#3 /var/www/html/opencfp/web/index.php(11): OpenCFP\Application->__construct('/var/www/html/o...', Object(OpenCFP\Environment)) 
#4 {main} thrown in /var/www/html/opencfp/classes/OpenCFP/Provider/DatabaseServiceProvider.php on line 37
```

Hope this helps!