### PR TITLE
Adds capability for speaker to view talk after deadline.

### DIFF
--- a/classes/OpenCFP/Application/NotAuthorizedException.php
+++ b/classes/OpenCFP/Application/NotAuthorizedException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace OpenCFP\Application;
+
+class NotAuthorizedException extends \Exception {}

--- a/classes/OpenCFP/Application/Speakers.php
+++ b/classes/OpenCFP/Application/Speakers.php
@@ -26,4 +26,31 @@ final class Speakers
         $speaker = $this->speakerRepository->findById($speakerId);
         return new SpeakerProfile($speaker);
     }
+
+    /**
+     * Retrieves a talk owned by a speaker.
+     *
+     * @param $speakerId
+     * @param $talkId
+     *
+     * @return Talk
+     * @throws NotAuthorizedException
+     */
+    public function getTalk($speakerId, $talkId)
+    {
+        $speaker = $this->speakerRepository->findById($speakerId);
+        $talk = $speaker->talks->where(['id' => $talkId])->execute()->first();
+
+        // If it can't grab by relation, it's likely not their talk.
+        if (!$talk) {
+            throw new NotAuthorizedException;
+        }
+
+        // Do an explicit check of ownership because why not.
+        if ($talk->user_id !== $speaker->id) {
+            throw new NotAuthorizedException;
+        }
+
+        return $talk;
+    }
 }

--- a/classes/OpenCFP/Http/Controller/DashboardController.php
+++ b/classes/OpenCFP/Http/Controller/DashboardController.php
@@ -32,7 +32,28 @@ class DashboardController extends BaseController
         $profile = $speakers->findProfile($user->getId());
 
         return $this->render('dashboard.twig', [
-            'profile' => $profile
+            'profile' => $profile,
+            'cfp_open' => $this->isCfpOpen()
         ]);
+    }
+
+    /**
+     * Check to see if the CfP for this app is still open
+     *
+     * @param  integer $currentTime
+     *
+     * @return boolean
+     */
+    public function isCfpOpen($currentTime = null)
+    {
+        if (!$currentTime) {
+            $currentTime = strtotime('now');
+        }
+
+        if ($currentTime < strtotime($this->app->config('application.enddate') . ' 11:59 PM')) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/templates/dashboard.twig
+++ b/templates/dashboard.twig
@@ -69,7 +69,11 @@ function deleteTalk(tid) {
                 <td>{{ talk.type }}</td>
                 <td>{{ talk.category }}</td>
                 <td>{{ talk.created_at|date("F jS \\a\\t g:ia T") }}</td>
-                <td><a href="{{ url('talk_edit', { id: talk.id }) }}">Edit</a></td>
+                {% if cfp_open %}
+                    <td><a href="{{ url('talk_edit', { id: talk.id }) }}">Edit</a></td>
+                {% else %}
+                    <td><a href="{{ url('talk_view', { id: talk.id }) }}">View</a></td>
+                {% endif %}
                 <td><a href="#" onClick="deleteTalk('{{ talk.id }}');return false;">Delete</a></td>
             </tr>
         {% endfor %}

--- a/tests/OpenCFP/Application/SpeakersTest.php
+++ b/tests/OpenCFP/Application/SpeakersTest.php
@@ -5,6 +5,7 @@ namespace OpenCFP\Application;
 use Mockery as m;
 use Mockery\MockInterface;
 use OpenCFP\Domain\Entity\SpeakerRepository;
+use OpenCFP\Domain\Entity\Talk;
 use OpenCFP\Domain\Entity\User;
 
 class SpeakersTest extends \PHPUnit_Framework_TestCase 
@@ -46,6 +47,31 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
         $this->sut->findProfile('does not exist');
     }
 
+    /** @test */
+    public function it_retrieves_a_specific_talk_owned_by_speaker()
+    {
+    }
+
+    /** @test */
+    public function it_disallows_speakers_viewing_talks_other_than_their_own()
+    {
+        // We use relation to grab speakers talks. So if they have none, someone is doing
+        // something screwy attempting to get a talk they should be able to.
+        $this->trainStudentRepositoryToReturnSampleSpeaker($this->getSpeakerWithNoTalks());
+
+        $this->setExpectedException('OpenCFP\Application\NotAuthorizedException');
+        $this->sut->getTalk(self::SPEAKER_ID, 1);
+    }
+
+    /** @test */
+    public function it_guards_if_spot_relation_ever_returns_talks_that_arent_owned_by_speaker()
+    {
+        $this->trainStudentRepositoryToReturnSampleSpeaker($this->getSpeakerFromMisbehavingSpot());
+
+        $this->setExpectedException('OpenCFP\Application\NotAuthorizedException');
+        $this->sut->getTalk(self::SPEAKER_ID, 1);
+    }
+
     private function trainStudentRepositoryToReturnSampleSpeaker($speaker)
     {
         $this->speakerRepository->shouldReceive('findById')
@@ -67,6 +93,37 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
             'first_name' => 'Fake',
             'last_name' => 'Speaker'
         ]);
+    }
+
+    private function getSpeakerWithNoTalks()
+    {
+        // Set up stub speaker.
+        $stub = m::mock('stdClass');
+
+        // Set up talks.
+        $stub->talks = m::mock('stdClass');
+        $stub->talks->shouldReceive('where->execute->first')->andReturnNull();
+
+        return $stub;
+    }
+
+    private function getSpeakerFromMisbehavingSpot()
+    {
+        // Set up stub speaker.
+        $stub = m::mock('stdClass');
+        $stub->id = self::SPEAKER_ID;
+
+        // Set up talks.
+        $stub->talks = m::mock('stdClass');
+        $stub->talks->shouldReceive('where->execute->first')->andReturn(
+            new Talk([
+                'id' => 1,
+                'title' => 'Testy Talk',
+                'user_id' => self::SPEAKER_ID + 1 // Not the speaker!
+            ])
+        );
+
+        return $stub;
     }
 }
  


### PR DESCRIPTION
This was **technically** already possible if I'm understanding #153 correctly. What would happen is that you'd click "Edit" and be redirected with flash errors to the "View Talk" page. Kind of a round-about way of getting there.

That said, this was another opportunity to refactor logic out of controllers into the service layer so I did that. By doing so, we reduce criticality of coverage on at least that part of `TalkController` by having solid coverage on the service layer. The affected controller method is a refactor or two away from being a really basic "do this; redirect if it fails; otherwise, redirect to success"; which is good!

There's some copy+paste shenanigans to determine whether or not the CFP has ended. This is only important for required for rendering purposes. It would probably be a good idea to register a twig global that makes this available to templates.

**Before CFP has ended:**
![image](https://cloud.githubusercontent.com/assets/2453394/6477575/073bbd96-c1f3-11e4-9dfb-6757d3655f80.png)

**After CFP has ended:**
![image](https://cloud.githubusercontent.com/assets/2453394/6477580/147401a8-c1f3-11e4-9e28-15cdc1c8a5c6.png)

**View Talk**
![image](https://cloud.githubusercontent.com/assets/2453394/6477582/1d9a6baa-c1f3-11e4-9e8d-bee6d63a9170.png)
