### PR TITLE
Adds visual indication of CFP ending on the homepage

### DIFF
--- a/classes/OpenCFP/Http/Controller/PagesController.php
+++ b/classes/OpenCFP/Http/Controller/PagesController.php
@@ -6,16 +6,24 @@ class PagesController extends BaseController
 {
     public function showHomepage()
     {
-        return $this->render('home.twig');
+        return $this->render('home.twig', $this->getContextWithTalksCount());
     }
 
     public function showSpeakerPackage()
     {
-        return $this->render('package.twig');
+        return $this->render('package.twig', $this->getContextWithTalksCount());
     }
 
     public function showTalkIdeas()
     {
-        return $this->render('ideas.twig');
+        return $this->render('ideas.twig', $this->getContextWithTalksCount());
+    }
+
+    private function getContextWithTalksCount()
+    {
+        $numberOfTalks = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk')->all()->count();
+        return [
+            'number_of_talks' => $numberOfTalks
+        ];
     }
 }

--- a/classes/OpenCFP/Provider/TwigServiceProvider.php
+++ b/classes/OpenCFP/Provider/TwigServiceProvider.php
@@ -76,6 +76,7 @@ class TwigServiceProvider implements ServiceProviderInterface
     {
         $app->before(function (Request $request, Application $app) {
             $app['twig']->addGlobal('current_page', $request->getRequestUri());
+            $app['twig']->addGlobal('cfp_open', strtotime('now') < strtotime($app->config('application.enddate') . ' 11:59 PM'));
         });
 
         if ($app['sentry']->check()) {

--- a/config/development.dist.yml
+++ b/config/development.dist.yml
@@ -4,6 +4,7 @@ application:
   email: contact@openconf.com
   eventurl: http://localhost
   enddate: Oct. 14th, 2016
+  show_submission_count: false
   airport: MIA
   arrival: 2014-10-26
   departure: 2014-10-31

--- a/config/production.dist.yml
+++ b/config/production.dist.yml
@@ -4,6 +4,7 @@ application:
   email: contact@openconf.com
   eventurl: http://myenvent.com
   enddate: Oct. 14th, 2016
+  show_submission_count: false
   airport: MIA
   arrival: 2014-10-26
   departure: 2014-10-31

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -4,6 +4,7 @@ application:
   email: contact@openconf.com
   eventurl: http://localhost
   enddate: Oct. 14th, 2016
+  show_submission_count: false
   airport: MIA
   arrival: 2014-10-26
   departure: 2014-10-31

--- a/templates/_header.twig
+++ b/templates/_header.twig
@@ -19,7 +19,7 @@
                         <h3 class="headline headline-alpha">Submissions were accepted until {{ site.enddate }}</h3>
                     {% endif %}
                     <p>
-                        <a class="btn-opencfp btn-opencfp-medium btn-opencfp--outlined" href="{{ url('user_new') }}">Register Now</a>
+                        {% if cfp_open %}<a class="btn-opencfp btn-opencfp-medium btn-opencfp--outlined" href="{{ url('user_new') }}">Register Now</a>{% endif %}
                         <a class="btn-opencfp btn-opencfp-medium btn-opencfp--primary" href="{{ url('dashboard') }}">View Submissions</a>
                     </p>
                 </div>

--- a/templates/_header.twig
+++ b/templates/_header.twig
@@ -5,8 +5,13 @@
                     <img data-src="/assets/img/logo_round.svg" class="svg-inject event-logo" alt="Event Logo">
                 </div>
                 <div class="col-md-9">
-                    <h1 class="headline headline-alpha">Call For Papers Now Open!</h1>
-                    <h3 class="headline headline-alpha">Submissions accepted until {{ site.enddate }}</h3>
+                    {% if cfp_open %}
+                        <h1 class="headline headline-alpha">Call For Papers Now Open!</h1>
+                        <h3 class="headline headline-alpha">Submissions accepted until {{ site.enddate }}</h3>
+                    {% else %}
+                        <h1 class="headline headline-alpha">Call for Papers Ended with {{ number_of_talks }} Submissions!</h1>
+                        <h3 class="headline headline-alpha">Submissions were accepted until {{ site.enddate }}</h3>
+                    {% endif %}
                     <p>
                         <a class="btn-opencfp btn-opencfp-medium btn-opencfp--outlined" href="{{ url('user_new') }}">Register Now</a>
                         <a class="btn-opencfp btn-opencfp-medium btn-opencfp--primary" href="{{ url('dashboard') }}">View Submissions</a>

--- a/templates/_header.twig
+++ b/templates/_header.twig
@@ -9,7 +9,13 @@
                         <h1 class="headline headline-alpha">Call For Papers Now Open!</h1>
                         <h3 class="headline headline-alpha">Submissions accepted until {{ site.enddate }}</h3>
                     {% else %}
-                        <h1 class="headline headline-alpha">Call for Papers Ended with {{ number_of_talks }} Submissions!</h1>
+                        <h1 class="headline headline-alpha">
+                            {% if site.show_submission_count %}
+                                Call for Papers ended with {{ number_of_talks }} Submissions!
+                            {% else %}
+                                Call for Papers has ended!
+                            {% endif %}
+                        </h1>
                         <h3 class="headline headline-alpha">Submissions were accepted until {{ site.enddate }}</h3>
                     {% endif %}
                     <p>


### PR DESCRIPTION
When the CFP is on-going, everything is rendered as currently in `master`. When CFP has closed, an alternative message is shown on the homepage that includes how many talks were submitted. Took queue from [phptek](http://tek.phparch.com/call-for-papers-ended-with-620-submissions/) as far as whether or not number of submissions was "a standard thing to report".

Fixes part of #107.

This also implements a global Twig variable that indicates whether or not the CFP is open (`cfp_open`). This would be helpful for #183 to use rather than [sending it in the Twig context manually](https://github.com/mdwheele/opencfp/commit/2a2b3b0eb4a086defff0e265c502a1a115b99b94).

![image](https://cloud.githubusercontent.com/assets/2453394/6478005/466283d8-c1f8-11e4-8b18-a0e28a6dcd9d.png)