### PR TITLE
Restrict admins from creating talks

### DIFF
--- a/classes/OpenCFP/Http/Controller/BaseController.php
+++ b/classes/OpenCFP/Http/Controller/BaseController.php
@@ -56,4 +56,24 @@ abstract class BaseController
     {
         return $this->app->redirect($this->url($route), $status);
     }
+
+    /**
+     * Check to see if the CfP for this app is still open
+     *
+     * @param  integer $currentTime
+     *
+     * @return boolean
+     */
+    public function isCfpOpen($currentTime = null)
+    {
+        if (!$currentTime) {
+            $currentTime = strtotime('now');
+        }
+
+        if ($currentTime < strtotime($this->app->config('application.enddate') . ' 11:59 PM')) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/classes/OpenCFP/Http/Controller/DashboardController.php
+++ b/classes/OpenCFP/Http/Controller/DashboardController.php
@@ -33,7 +33,8 @@ class DashboardController extends BaseController
 
         return $this->render('dashboard.twig', [
             'profile' => $profile,
-            'cfp_open' => $this->isCfpOpen()
+            'cfp_open' => $this->isCfpOpen(),
+            'can_submit' => ! $user->hasPermission('admin')
         ]);
     }
 }

--- a/classes/OpenCFP/Http/Controller/DashboardController.php
+++ b/classes/OpenCFP/Http/Controller/DashboardController.php
@@ -36,24 +36,4 @@ class DashboardController extends BaseController
             'cfp_open' => $this->isCfpOpen()
         ]);
     }
-
-    /**
-     * Check to see if the CfP for this app is still open
-     *
-     * @param  integer $currentTime
-     *
-     * @return boolean
-     */
-    public function isCfpOpen($currentTime = null)
-    {
-        if (!$currentTime) {
-            $currentTime = strtotime('now');
-        }
-
-        if ($currentTime < strtotime($this->app->config('application.enddate') . ' 11:59 PM')) {
-            return true;
-        }
-
-        return false;
-    }
 }

--- a/classes/OpenCFP/Http/Controller/TalkController.php
+++ b/classes/OpenCFP/Http/Controller/TalkController.php
@@ -13,7 +13,6 @@ class TalkController extends BaseController
 {
     use FlashableTrait;
 
-
     /**
      * Controller action for viewing a specific talk
      *
@@ -22,13 +21,24 @@ class TalkController extends BaseController
      */
     public function viewAction(Request $req)
     {
-        /* @var Speakers $speakers */
-        $speakers = $this->app['application.speakers'];
-
         /////////
         if (!$this->app['sentry']->check()) {
             return $this->redirectTo('login');
         }
+
+        if ($this->isAdmin()){
+
+            $this->app['session']->set('flash', [
+                    'type' => 'error',
+                    'short' => 'Admin Error',
+                    'ext' => 'You cannot submit talks as an Admin']
+            );
+
+            return $this->redirectTo('dashboard');
+        }
+
+        /* @var Speakers $speakers */
+        $speakers = $this->app['application.speakers'];
 
         $user = $this->app['sentry']->getUser();
         /////////
@@ -54,6 +64,18 @@ class TalkController extends BaseController
         if (!$this->app['sentry']->check()) {
             return $this->redirectTo('login');
         }
+
+        if ($this->isAdmin()){
+
+            $this->app['session']->set('flash', [
+                    'type' => 'error',
+                    'short' => 'Admin Error',
+                    'ext' => 'You cannot submit talks as an Admin']
+            );
+
+            return $this->redirectTo('dashboard');
+        }
+
 
         $id = $req->get('id');
         $talk_id = filter_var($id, FILTER_VALIDATE_INT);
@@ -113,6 +135,17 @@ class TalkController extends BaseController
             return $this->redirectTo('login');
         }
 
+        if ($this->isAdmin()){
+
+            $this->app['session']->set('flash', [
+                    'type' => 'error',
+                    'short' => 'Admin Error',
+                    'ext' => 'You cannot submit talks as an Admin']
+            );
+
+            return $this->redirectTo('dashboard');
+        }
+
         // You can only create talks while the CfP is open
         if ( ! $this->isCfpOpen(strtotime('now'))) {
             $this->app['session']->set('flash', [
@@ -152,6 +185,17 @@ class TalkController extends BaseController
     {
         if ( ! $this->app['sentry']->check()) {
             return $this->redirectTo('login');
+        }
+
+        if ($this->isAdmin()){
+
+            $this->app['session']->set('flash', [
+                    'type' => 'error',
+                    'short' => 'Admin Error',
+                    'ext' => 'You cannot submit talks as an Admin']
+            );
+
+            return $this->redirectTo('dashboard');
         }
 
         // You can only create talks while the CfP is open
@@ -246,6 +290,18 @@ class TalkController extends BaseController
         if ( ! $this->app['sentry']->check()) {
             return $this->redirectTo('login');
         }
+
+        if ($this->isAdmin()){
+
+            $this->app['session']->set('flash', [
+                    'type' => 'error',
+                    'short' => 'Admin Error',
+                    'ext' => 'You cannot submit talks as an Admin']
+            );
+
+            return $this->redirectTo('dashboard');
+        }
+
 
         $user = $this->app['sentry']->getUser();
 
@@ -396,5 +452,10 @@ class TalkController extends BaseController
         } catch (\Exception $e) {
             echo $e;die();
         }
+    }
+
+    private function isAdmin()
+    {
+        return ($this->app['sentry']->getUser()->hasPermission('admin'));
     }
 }

--- a/classes/OpenCFP/Http/Controller/TalkController.php
+++ b/classes/OpenCFP/Http/Controller/TalkController.php
@@ -13,20 +13,6 @@ class TalkController extends BaseController
 {
     use FlashableTrait;
 
-    /**
-     * Check to see if the CfP for this app is still open
-     *
-     * @param  integer $current_time
-     * @return boolean
-     */
-    public function isCfpOpen($current_time)
-    {
-        if ($current_time < strtotime($this->app->config('application.enddate') . ' 11:59 PM')) {
-            return true;
-        }
-
-        return false;
-    }
 
     /**
      * Controller action for viewing a specific talk

--- a/templates/dashboard.twig
+++ b/templates/dashboard.twig
@@ -49,6 +49,7 @@ function deleteTalk(tid) {
         </div>
     </div>
 
+    {% if can_submit %}
     <h2 class="headline">My Talks</h2>
     {% if profile.talks is not empty %}
     <table class="table table-striped">
@@ -83,4 +84,5 @@ function deleteTalk(tid) {
         You currently have no talks submitted.
     {% endif %}
     <p><a class="btn btn-success" href="{{ url('talk_new') }}">Submit a talk</a></p>
+    {%  endif %}
 {% endblock %}


### PR DESCRIPTION
Currently admins are able to submit talks. This PR restricts them by not showing the "Submit a talk" button on the dashboard, and by denying access to any talk management pages. 