### PR TITLE
End output buffer so that test is not flagged as risky

### DIFF
--- a/tests/unit/controllers/DashboardControllerTest.php
+++ b/tests/unit/controllers/DashboardControllerTest.php
@@ -49,7 +49,7 @@ class DashboardControllerTest extends PHPUnit_Framework_TestCase
 
         ob_start();
         $app->run();  // Fire before handlers... boot...
-        ob_clean();
+        ob_end_clean();
 
         // Instantiate the controller and run the indexAction
         $controller = new \OpenCFP\Http\Controller\DashboardController($app);


### PR DESCRIPTION
Before: 

``` bash
PHPUnit 4.6.4 by Sebastian Bergmann and contributors.

Configuration read from /var/www/html/opencfp/phpunit.xml

................................................................. 65 / 76 ( 85%)
......R....

Time: 1.66 seconds, Memory: 82.75Mb

There was 1 risky test:

1) DashboardControllerTest::indexDisplaysUserAndTalks
Test code or tested code did not (only) close its own output buffers

OK, but incomplete, skipped, or risky tests!
Tests: 76, Assertions: 96, Risky: 1.
```

After: 

``` bash
PHPUnit 4.6.4 by Sebastian Bergmann and contributors.

Configuration read from /var/www/html/opencfp/phpunit.xml

................................................................. 65 / 76 ( 85%)
...........

Time: 1.74 seconds, Memory: 83.00Mb

OK (76 tests, 96 assertions)
```