### PR TITLE
[WIP] Discussion on API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ OpenCFP is a PHP-based conference talk submission system.
    * [Run Migrations](#run-migrations)
    * [Final Touches](#final-touches)
  * [JSON API](#json-api)
+   * [Configuration](#json-api-configuration)
+   * [Authorization](#json-api-authorization)
+   * [Endpoints](#json-api-endpoints)
+   * [Using the API](#json-api-usage)
  * [Command-line Utilities](#command-line-utilities)
    * [Admin Group Management](#admin-group-management)
    * [Clear Caches](#clear-caches)
@@ -249,7 +253,7 @@ The Talks API allows you to manage the collection of submitted talks for the cur
 | `GET` | `/api/talks/{id}` | Returns a particular talk for authenticated user. Returns appropriate responses for unauthorized or non-existent talks |
 | `DELETE` | `/api/talks/{id}` | Removes a talk. |
 
-<a name="api-usage" />
+<a name="json-api-usage" />
 ### Using the API
 
 In this scenario, we will submit talks on behalf of a user and we make a few assumptions: we assume that you have **NOT** registered as a Client Application yet and that the user you are submitting talks on behalf of does **NOT** have an account on the target instance of OpenCFP.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ If the user accepts your request, OpenCFP redirects to your site with a `code` q
 ``` json
 {
 	"access_token": "a12834769e4ae7ae178b292c2ee42f710c8316c7",
+	"refresh_token": "24710c8316c7c2ee42fa1ae7ae178b292834769e",
 	"token_type": "bearer",
 	"scope": "public,talks",
 	"expires_in": 3600
@@ -325,46 +326,133 @@ otherwise, we're sending credentials in cleartext.
 Access tokens MUST be sent in an `Authorization` header as follows from our example access token above:
 
 ```
-> GET /api/me HTTP/1.1
-> Host: youropencfp.com
-> Authorization: Bearer a12834769e4ae7ae178b292c2ee42f710c8316c7
+GET /api/me HTTP/1.1
+Host: youropencfp.com
+Authorization: Bearer a12834769e4ae7ae178b292c2ee42f710c8316c7
 ```
-
-The following examples assume you are correctly attaching your access token as part of the request header. We make this
-assumption for brevity of documentation.
 
 > The examples that follow are subject to change. API endpoints and behaviour are still in flux. This should serve more as an example of what to expect as far as interacting with the API, not specifically how the endpoints will work.
 
 **View speaker's profile**
 
-*Request*
 ```
-> GET /api/me HTTP/1.1
-> Host: youropencfp.com
-> Accept: application/json
-> Authorization: Bearer a12834769e4ae7ae178b292c2ee42f710c8316c7
+GET /api/me HTTP/1.1
+Host: youropencfp.com
+Accept: application/json
+Authorization: Bearer a12834769e4ae7ae178b292c2ee42f710c8316c7
 ```
 
-*Response*
 ```
-< HTTP/1.1 200 OK
-< Content-type: application/json
-< --
-< {
-<   "first_name": "Ham",
-<   "last_name": "Burglar",
-<   "email": "hamburglar@youropencfp.com
-<   "company": "ACME Corporation",
-<   "twitter": "@hamburglar",
-<   "bio": "..."
-< }
+HTTP/1.1 200 OK
+Content-type: application/json
+--
+{
+	"first_name": "Ham",
+	"last_name": "Burglar",
+	"email": "hamburglar@youropencfp.com
+	"company": "ACME Corporation",
+	"twitter": "@hamburglar",
+	"bio": "..."
+}
 ```
 
 **Submit a talk**
+
+```
+POST /api/talks HTTP/1.1
+Host: youropencfp.com
+Accept: application/json
+Authorization: Bearer a12834769e4ae7ae178b292c2ee42f710c8316c7
+--
+{
+	"title": "Sample Talk",
+	"description": "...",
+	"type": "regular",
+	"level": "mid",
+	"category": "api"
+}
+```
+
+```
+HTTP/1.1 201 Created
+Content-type: application/json
+--
+{
+	"id": "1"
+	"title": "Sample Talk",
+	"description": "...",
+	"type": "regular",
+	"level": "mid",
+	"category": "api"
+}
+```
+
 **Verify talk was submitted**
+
+```
+GET /api/talks/1 HTTP/1.1
+Host: youropencfp.com
+Accept: application/json
+Authorization: Bearer a12834769e4ae7ae178b292c2ee42f710c8316c7
+```
+
+```
+HTTP/1.1 200 OK
+Content-type: application/json
+--
+{
+	"id": "1"
+	"title": "Sample Talk",
+	"description": "...",
+	"type": "regular",
+	"level": "mid",
+	"category": "api"
+}
+```
+
 **Delete talk**
 
+```
+DELETE /api/talks/1 HTTP/1.1
+Host: youropencfp.com
+Accept: application/json
+Authorization: Bearer a12834769e4ae7ae178b292c2ee42f710c8316c7
+```
+
+```
+HTTP/1.1 200 OK
+```
+
 #### Refresh an access token after it expires
+
+Access tokens have a TTL of one hour. Once expired, you will need to either request another access token or we give you
+the ability to refresh access tokens through use of the Refresh Token Grant. Taking advantage of this is actually pretty simple.
+You'll basically send a request that looks similar to this:
+
+```
+POST /oauth/access_token HTTP/1.1
+Host: youropencfp.com
+Accept: application/json
+Authorization: Bearer a12834769e4ae7ae178b292c2ee42f710c8316c7
+--
+grant_type=refresh_token&refresh_token=24710c8316c7c2ee42fa1ae7ae178b292834769e
+```
+
+```
+HTTP/1.1 200 OK
+Content-type: application/json
+--
+{
+	"access_token": "2ee42f710c8316c7a12834769e4ae7ae178b292c",
+	"refresh_token": "1ae7ae178b292834769e24710c8316c7c2ee42fa",
+	"token_type": "bearer",
+	"scope": "public,talks",
+	"expires_in": 3600
+}
+```
+
+After refreshing the access token, you'll obviously want to update the previous token you've associated with your user.
+Also note that **refresh tokens are rotated** in addition to the access token. You'll want to keep track of this per-user.
 
 <a name="command-line-utilities" />
 ## Command-line Utilities

--- a/README.md
+++ b/README.md
@@ -206,20 +206,31 @@ With all of that out of the way, here are some nuts and bolts about our implemen
 
 ### Endpoints
 
-*Authorization*
+This serves as a high-level overview of the OpenCFP API.
+
+**Authorization**
+
+Authorization endpoints are used as part of the process for obtaining and renewing an Access Token representing a user's
+authorization for you (as a client developer) to act on their behalf. A step-by-step [usage scenario](#api-usage-scenario) is
+described for convenience below.
 
 | method | route | description |
 | --- | --- | --- |
-| `GET` | `/oauth/authorize` | Starts the authorization flow described in-depth in our [Usage Scenario](#api-usage-scenario). |
+| `GET` | `/oauth/authorize` | Starts the authorization flow. |
 | `POST` | `/oauth/access_token` | Used to trade an Authorization Code for an Access Token. |
 
-*Speaker Profile API*
+**Speaker Profile API**
+
+The Speaker Profile API allows you to look up information about the currently authenticated user. You might use this to
+populate attributes in your own custom application based on a user's profile in a target instance of OpenCFP.
 
 | method | route | description |
 | --- | --- | --- |
 | `GET` | `/api/me` | Returns JSON body representing information about the authenticated user. |
 
-*Talks API*
+**Talks API**
+
+The Talks API allows you to manage the collection of submitted talks for the currently authenticated user.
 
 | method | route | description |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ Note: For updating previously installed instances only run migrations as needed.
 OpenCFP has a JSON API that can be used by third-party applications to take advantage of a set of features on behalf
 of a user. The API is enabled by default, but can be disabled if not needed for your instance of OpenCFP.
 
+<a name="json-api-configuration" />
+### API Configuration
+
+Configuration for the API is stored under the `api` namespace of your configuration YAML file. Currently, there is only
+one available configuration setting: whether or not the api is `enabled`.
+
+<a name="json-api-authorization" />
 ### Authorization
 
 In order to use any of the available APIs in order to do work on a OpenCFP user's behalf, an OAuth2 token must be
@@ -204,6 +211,7 @@ With all of that out of the way, here are some nuts and bolts about our implemen
 - Bearer tokens have a time-to-live (TTL) of `3600` seconds (1 hour). Expired tokens will be rejected and you have the option of refreshing or requesting a new token. This may be configurable in the future.
 - Authorization endpoints are described below.
 
+<a name="json-api-endpoints" />
 ### Endpoints
 
 This serves as a high-level overview of the OpenCFP API.
@@ -242,12 +250,9 @@ The Talks API allows you to manage the collection of submitted talks for the cur
 <a name="api-usage-scenario" />
 ### Usage Scenario
 
+> In this scenario, we will submit talks on behalf of a user and we make a few assumptions: we assume that you have **not** registered as a Client Application yet and that the user you are submitting talks on behalf of does **not** have an account on the target instance of OpenCFP.
 
 
-### API Configuration
-
-Configuration for the API is stored under the `api` namespace of your configuration YAML file. Currently, there is only
-one available configuration setting: whether or not the api is `enabled`.
 
 <a name="command-line-utilities" />
 ## Command-line Utilities

--- a/README.md
+++ b/README.md
@@ -250,9 +250,17 @@ The Talks API allows you to manage the collection of submitted talks for the cur
 <a name="api-usage-scenario" />
 ### Usage Scenario
 
-> In this scenario, we will submit talks on behalf of a user and we make a few assumptions: we assume that you have **not** registered as a Client Application yet and that the user you are submitting talks on behalf of does **not** have an account on the target instance of OpenCFP.
+> In this scenario, we will submit talks on behalf of a user and we make a few assumptions: we assume that you have **NOT** registered as a Client Application yet and that the user you are submitting talks on behalf of does **NOT** have an account on the target instance of OpenCFP.
 
-
+**1. Redirect your user to request OpenCFP access**
+2. **User authenticates or creates new account**
+3. **User authorizes access**
+4. **OpenCFP redirects back to your site with Authorization Code**
+5. **Trade Authorization Code for Access Token**
+6. **View speaker's profile**
+7. **Submit a talk**
+8. **Verify talk was submitted**
+9. **Delete talk**
 
 <a name="command-line-utilities" />
 ## Command-line Utilities

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ Note: For updating previously installed instances only run migrations as needed.
 OpenCFP has a JSON API that can be used by third-party applications to take advantage of a set of features on behalf
 of a user. The API is enabled by default, but can be disabled if not needed for your instance of OpenCFP.
 
-### Authentication
+### Authorization
 
 In order to use any of the available APIs in order to do work on a OpenCFP user's behalf, an OAuth2 token must be
-provided and must have an appropriate OAuth2 scope associated with it. Interacting with the authorization endpoints
+provided and must have appropriate OAuth2 scope(s) associated with it. Interacting with the authorization endpoints
 is very much the same as any other OAuth2 implementation; You'll register your custom web application as a Client Application
 with OpenCFP and from there, you can start to send folks through the [Authorization Code Grant Flow](https://tools.ietf.org/html/rfc6749#section-4.1)
 in order to eventually obtain a bearer token to act on their behalf.

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Note: For updating previously installed instances only run migrations as needed.
 <a name="json-api" />
 ## JSON API
 
-OpenCFP has a JSON API that can be used by third-party applications to take advantage of a set of OpenCFP features on behalf
-of an OpenCFP user. The API is enabled by default, but can be disabled if not needed for your instance of OpenCFP.
+OpenCFP has a JSON API that can be used by third-party applications to take advantage of a set of features on behalf
+of a user. The API is enabled by default, but can be disabled if not needed for your instance of OpenCFP.
 
 ### Authentication
 


### PR DESCRIPTION
**Do not merge**

I'm submitting this as a line of work on a first iteration of API documentation. I will be merging this into the implementation branch once finalized. 

The point of this is to put an overview in front of folks of how all of this will fit together. I'm looking to pare this down a bit as I feel it is wordy and, in places, justifies implementation details rather than just saying, "This is how the shit works." for users to consume. Please rip it apart on those terms.

That said, it also suggests a rough technical direction for the API and there are some assumptions being made, for sure. I wish for those to be challenged / questioned where appropriate. Things that come to mind:

1. We're implementing client registration in compliance with the current [OAuth 2.0 Dynamic Client Registration Protocol](https://tools.ietf.org/html/draft-ietf-oauth-dyn-reg-23) draft. This means that we're able to move to a full implementation later, but what we're allowing (at this point) is for any arbitrary web application / client to register client application on any instance of OpenCFP where the API is enabled. There is no approval process. This is a trade-off. On the one hand, it is MUCH simpler to implement for a consuming application as there is no need for a pre-arranged access token / handshake. On the other hand, it leaves an instance of OpenCFP open for exploitation; where the "exploit" is the ability to create infinite client applications. We can actually take measures against this as a compensating control without penalizing nice users. Just don't want to be driven by FUD here, because it is very convenient, as described currently. Also note that simply "having a client application" buys the application nothing. They will still need to put users through an authorization flow before receiving tokens to do anything.
2. I make assumptions on what is valuable to a consumer as part of the API. This should be challenged by potential consumers.

https://github.com/mdwheele/opencfp/blob/json-api-docs/README.md#json-api (link to pretty)

**Additional Thoughts**

- [ ] It'd be nice to have an endpoint dedicated to serving API status. Is it on? Is it off? Does it only allow certain API actions (future)? In this way, a client could branch on how to handle talk submission if the API is turned off. Perhaps it just redirects them to the CFP site after putting talk contents in clipboard and we support some pasting of that encoded content? WHO KNOWS!? Magic!
- [ ] Double check all anchor links for jumping around. A few of the "see below" links are broken because anchor names changed.
- [ ] Will need a method for Client Application to update its Client Metadata in a next iteration, specifically redirect URIs.

I may add to this. I'm on a break and on-the-move.