### PR TITLE
Photo Upload Vulnerability

### DIFF
--- a/classes/OpenCFP/Domain/Services/ProfileImageProcessor.php
+++ b/classes/OpenCFP/Domain/Services/ProfileImageProcessor.php
@@ -57,7 +57,7 @@ class ProfileImageProcessor
 
         try {
             $file->move($this->publishDir, $tempFilename);
-
+            
             $speakerPhoto = Image::make($this->publishDir . '/' . $tempFilename);
 
             if ($speakerPhoto->height > $speakerPhoto->width) {

--- a/classes/OpenCFP/Domain/Services/ProfileImageProcessor.php
+++ b/classes/OpenCFP/Domain/Services/ProfileImageProcessor.php
@@ -19,6 +19,11 @@ class ProfileImageProcessor
     protected $publishDir;
 
     /**
+     * @var RandomStringGenerator
+     */
+    private $generator;
+
+    /**
      * @var int
      */
     protected $size;
@@ -26,40 +31,49 @@ class ProfileImageProcessor
     /**
      * Constructor
      *
-     * @param $publishDir
-     * @param int $size
+     * @param string                $publishDir
+     * @param RandomStringGenerator $generator
+     * @param int                   $size
      */
-    public function __construct($publishDir, $size = 250)
+    public function __construct($publishDir, RandomStringGenerator $generator, $size = 250)
     {
         $this->publishDir = $publishDir;
         $this->size = $size;
+        $this->generator = $generator;
     }
 
     /**
      * Process an uploaded file and store it in a web-accessible place.
      *
      * @param UploadedFile $file
-     * @param $publishFilename
+     * @param string       $publishFilename
+     *
+     * @throws \Exception
      */
     public function process(UploadedFile $file, $publishFilename)
     {
         // Temporary filename to work with.
-        $fileName = uniqid() . '_' . $file->getClientOriginalName();
+        $tempFilename = $this->generator->generate(40);
 
-        $file->move($this->publishDir, $fileName);
+        try {
+            $file->move($this->publishDir, $tempFilename);
 
-        $speakerPhoto = Image::make($this->publishDir . '/' . $fileName);
+            $speakerPhoto = Image::make($this->publishDir . '/' . $tempFilename);
 
-        if ($speakerPhoto->height > $speakerPhoto->width) {
-            $speakerPhoto->resize($this->size, null, true);
-        } else {
-            $speakerPhoto->resize(null, $this->size, true);
-        }
+            if ($speakerPhoto->height > $speakerPhoto->width) {
+                $speakerPhoto->resize($this->size, null, true);
+            } else {
+                $speakerPhoto->resize(null, $this->size, true);
+            }
 
-        $speakerPhoto->crop($this->size, $this->size);
+            $speakerPhoto->crop($this->size, $this->size);
 
-        if ($speakerPhoto->save($this->publishDir . '/' . $publishFilename)) {
-            unlink($this->publishDir . '/' . $fileName);
+            if ($speakerPhoto->save($this->publishDir . '/' . $publishFilename)) {
+                unlink($this->publishDir . '/' . $tempFilename);
+            }
+        } catch (\Exception $e) {
+            unlink($this->publishDir . '/' . $tempFilename);
+            throw $e;
         }
     }
 }

--- a/classes/OpenCFP/Domain/Services/RandomStringGenerator.php
+++ b/classes/OpenCFP/Domain/Services/RandomStringGenerator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenCFP\Domain\Services; 
+
+interface RandomStringGenerator
+{
+    public function generate($length = 40);
+}

--- a/classes/OpenCFP/Http/Controller/ProfileController.php
+++ b/classes/OpenCFP/Http/Controller/ProfileController.php
@@ -103,8 +103,13 @@ class ProfileController extends BaseController
                 $file = $form_data['speaker_photo'];
                 /** @var \OpenCFP\ProfileImageProcessor $processor */
                 $processor = $this->app['profile_image_processor'];
+                /** @var PseudoRandomStringGenerator $generator */
+                $generator = $this->app['security.random'];
 
-                $sanitized_data['speaker_photo'] = $form_data['first_name'] . '.' . $form_data['last_name'] . uniqid() . '.' . $file->getClientOriginalExtension();
+                /**
+                 * The extension technically is not required. We guess the extension using a trusted method.
+                 */
+                $sanitized_data['speaker_photo'] = $generator->generate(40) . '.' . $file->guessExtension();
 
                 $processor->process($file, $sanitized_data['speaker_photo']);
             }

--- a/classes/OpenCFP/Http/Controller/SignupController.php
+++ b/classes/OpenCFP/Http/Controller/SignupController.php
@@ -3,6 +3,8 @@
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Http\Form\SignupForm;
+use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
+use OpenCFP\ProfileImageProcessor;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Cartalyst\Sentry\Users\UserExistsException;
@@ -68,10 +70,15 @@ class SignupController extends BaseController
             if (isset($form_data['speaker_photo'])) {
                 /** @var \Symfony\Component\HttpFoundation\File\UploadedFile $file */
                 $file = $form_data['speaker_photo'];
-                /** @var \OpenCFP\ProfileImageProcessor $processor */
+                /** @var ProfileImageProcessor $processor */
                 $processor = $app['profile_image_processor'];
+                /** @var PseudoRandomStringGenerator $generator */
+                $generator = $app['security.random'];
 
-                $sanitized_data['speaker_photo'] = $form_data['first_name'] . '.' . $form_data['last_name'] . uniqid() . '.' . $file->getClientOriginalExtension();
+                /**
+                 * The extension technically is not required. We guess the extension using a trusted method.
+                 */
+                $sanitized_data['speaker_photo'] = $generator->generate(40) . '.' . $file->guessExtension();
 
                 $processor->process($file, $sanitized_data['speaker_photo']);
             }

--- a/classes/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGenerator.php
+++ b/classes/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OpenCFP\Infrastructure\Crypto; 
+
+use OpenCFP\Domain\Services\RandomStringGenerator;
+use RandomLib\Factory;
+
+class PseudoRandomStringGenerator implements RandomStringGenerator
+{
+    /**
+     * @var Generator
+     */
+    private $generator;
+
+    public function __construct(Factory $factory)
+    {
+        $this->generator = $factory->getMediumStrengthGenerator();
+    }
+
+    public function generate($length = 40)
+    {
+        return $this->generator->generateString($length, $this->getCharacterSet());
+    }
+
+    private function getCharacterSet()
+    {
+        return '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    }
+}

--- a/classes/OpenCFP/Provider/ApplicationServiceProvider.php
+++ b/classes/OpenCFP/Provider/ApplicationServiceProvider.php
@@ -1,7 +1,9 @@
 <?php namespace OpenCFP\Provider; 
 
 use OpenCFP\Application\Speakers;
+use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
 use OpenCFP\Infrastructure\Persistence\SpotSpeakerRepository;
+use RandomLib\Factory;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -19,6 +21,10 @@ class ApplicationServiceProvider implements ServiceProviderInterface
             return new Speakers(
                 new SpotSpeakerRepository($mapper)
             );
+        });
+
+        $app['security.random'] = $app->share(function($app) {
+            return new PseudoRandomStringGenerator(new Factory());
         });
     }
 

--- a/classes/OpenCFP/Provider/ImageProcessorProvider.php
+++ b/classes/OpenCFP/Provider/ImageProcessorProvider.php
@@ -15,7 +15,7 @@ class ImageProcessorProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['profile_image_processor'] = $app->share(function($app) {
-            return new ProfileImageProcessor($app->uploadPath());
+            return new ProfileImageProcessor($app->uploadPath(), $app['security.random']);
         });
     }
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "kzykhys/ciconia": "~1.0",
         "aptoma/twig-markdown": "0.2.*",
         "igorw/config-service-provider": "~1.2",
-        "symfony/yaml": "~2.5"
+        "symfony/yaml": "~2.5",
+        "ircmaxell/random-lib": "^1.1"
     },
     "autoload": {
         "psr-0": {"OpenCFP": "classes/"}

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "eae4b8573aff550b6522be3ad5ce6358",
+    "hash": "ab6cf59242a01b32679749dc0f95a6e1",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -1029,6 +1029,101 @@
                 "password"
             ],
             "time": "2014-11-20 19:18:42"
+        },
+        {
+            "name": "ircmaxell/random-lib",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/RandomLib.git",
+                "reference": "13efa4368bb2ac88bb3b1459b487d907de4dbf7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/RandomLib/zipball/13efa4368bb2ac88bb3b1459b487d907de4dbf7c",
+                "reference": "13efa4368bb2ac88bb3b1459b487d907de4dbf7c",
+                "shasum": ""
+            },
+            "require": {
+                "ircmaxell/security-lib": "1.0.*@dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "1.1.*",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "RandomLib": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@ircmaxell.com",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A Library For Generating Secure Random Numbers",
+            "homepage": "https://github.com/ircmaxell/RandomLib",
+            "keywords": [
+                "cryptography",
+                "random",
+                "random-numbers",
+                "random-strings"
+            ],
+            "time": "2015-01-15 16:31:45"
+        },
+        {
+            "name": "ircmaxell/security-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/SecurityLib.git",
+                "reference": "80934de3c482dcafb46b5756e59ebece082b6dc7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/SecurityLib/zipball/80934de3c482dcafb46b5756e59ebece082b6dc7",
+                "reference": "80934de3c482dcafb46b5756e59ebece082b6dc7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "1.1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "SecurityLib": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@ircmaxell.com",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A Base Security Library",
+            "homepage": "https://github.com/ircmaxell/PHP-SecurityLib",
+            "time": "2013-04-30 18:00:34"
         },
         {
             "name": "kzykhys/ciconia",
@@ -2924,7 +3019,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/spot2/zipball/3744a4a05e45c8f3e2ecb5557b00dee79e93cd7c",
+                "url": "https://api.github.com/repos/vlucas/spot2/zipball/79fe49372977d83453574d53236568c98f8f8cea",
                 "reference": "3744a4a05e45c8f3e2ecb5557b00dee79e93cd7c",
                 "shasum": ""
             },
@@ -3272,7 +3367,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/MinkExtension/zipball/9bff0ae65f32f9bf9df0afef91057a7bfeeeafc6",
+                "url": "https://api.github.com/repos/Behat/MinkExtension/zipball/c7fb932533292567aa57bfbe4ec40f1490ae6d58",
                 "reference": "9bff0ae65f32f9bf9df0afef91057a7bfeeeafc6",
                 "shasum": ""
             },
@@ -3991,7 +4086,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/dbe3cfe736bb1d3e319c4cd0c310c140737028a0",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/a4817105ee32b8a05056986ad23ce3a54781f693",
                 "reference": "dbe3cfe736bb1d3e319c4cd0c310c140737028a0",
                 "shasum": ""
             },
@@ -4056,7 +4151,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/dbunit/zipball/1507040c2541bdffd7fbd71fc792cecdea6a7c61",
+                "url": "https://api.github.com/repos/sebastianbergmann/dbunit/zipball/ef2231c309f94409ccf759698e0feea0ff11398a",
                 "reference": "1507040c2541bdffd7fbd71fc792cecdea6a7c61",
                 "shasum": ""
             },

--- a/migrations/20150519122926_reset_photo_paths.php
+++ b/migrations/20150519122926_reset_photo_paths.php
@@ -1,0 +1,106 @@
+<?php
+
+use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
+use Phinx\Migration\AbstractMigration;
+use RandomLib\Factory;
+use Symfony\Component\HttpFoundation\File\File;
+
+class ResetPhotoPaths extends AbstractMigration
+{
+
+
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $generator = new PseudoRandomStringGenerator(new Factory);
+
+        // Cleans out "orphaned" files that we have no record of.
+        foreach ($this->photosNotPartOfProfile() as $fileName) {
+            echo "[info] Removing {$fileName} as it is not registered with any user." . PHP_EOL;
+            unlink($fileName);
+        }
+
+        foreach ($this->getSpeakers() as $speaker) {
+            echo "[info] Attempting to regenerate photo path for {$speaker['name']}." . PHP_EOL;
+            $this->regenerateSpeakerPhotoPath($speaker);
+        }
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        // This is a data-migration for which there should be no reverse for.
+    }
+
+    private function photosNotPartOfProfile()
+    {
+        $registeredPhotos = [];
+        $fileNamesFlaggedForRemoval = [];
+
+        // Get registered photos from users table.
+        foreach ($this->fetchAll("SELECT photo_path FROM users WHERE photo_path <> ''") as $result) {
+            $registeredPhotos[] = $result['photo_path'];
+        }
+
+        // Crawl uploads directory.
+        // If filename is not registered, flag it for removal.
+        $iterator = new DirectoryIterator(__DIR__ . '/../web/uploads');
+        foreach ($iterator as $file) {
+            if ($file->isDot() || in_array($file->getFilename(), ['dummyphoto.jpg'])) continue;
+
+            if (!in_array($file->getFilename(), $registeredPhotos)) {
+                $fileNamesFlaggedForRemoval[] = $file->getRealPath();
+            }
+        }
+
+        return $fileNamesFlaggedForRemoval;
+    }
+
+    private function getSpeakers()
+    {
+        // Return structure that is collection of [id, photo_path]
+        return $this->fetchAll("SELECT id, photo_path, CONCAT(first_name, ' ', last_name) as name FROM users WHERE photo_path <> ''");
+    }
+
+    private function regenerateSpeakerPhotoPath($speaker)
+    {
+        // If speaker photo does not exist, null it out and return.
+        if (! $this->fileExists($speaker['photo_path'])) {
+            echo "[info] {$speaker['name']}'s photo was not found in file system. Removing record of it from profile." . PHP_EOL;
+            $this->execute("UPDATE users SET photo_path = '' WHERE id = {$speaker['id']}");
+            return;
+        }
+
+        // Need to guess extension. Cannot trust current file extensions.
+        $file = new File(__DIR__ . '/../web/uploads/' . $speaker['photo_path']);
+        $extension = $file->guessExtension();
+
+        // Otherwise, generate a new filename.
+        $generator = new PseudoRandomStringGenerator(new Factory);
+        $newFileName = $generator->generate(40) . '.' . $extension;
+
+        $oldFilePath = __DIR__ . '/../web/uploads/' . $speaker['photo_path'];
+        $newFilePath = __DIR__ . '/../web/uploads/' . $newFileName;
+
+        // If photo name is changed in file system, update record in database.
+        if (rename($oldFilePath, $newFilePath)) {
+            try {
+                $this->execute("UPDATE users SET photo_path = '{$newFileName}' WHERE id = '{$speaker['id']}'");
+
+                echo "[info] Regenerated photo path for {$speaker['name']}." . PHP_EOL;
+            } catch (\Exception $e) {
+                // If update fails for any reason, revert filename in file system.
+                rename($newFilePath, $oldFilePath);
+            }
+        }
+    }
+
+    private function fileExists($photoPath)
+    {
+        return file_exists(__DIR__ . '/../web/uploads/' . $photoPath);
+    }
+}

--- a/tests/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
+use RandomLib\Factory;
+
+class PseudoRandomStringGeneratorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PseudoRandomStringGenerator
+     */
+    private $sut;
+
+    public function setup()
+    {
+        $this->sut = new PseudoRandomStringGenerator(new Factory());
+    }
+
+    /** @test */
+    function it_should_generate_a_random_string_of_given_length()
+    {
+        $this->assertEquals(10, strlen($this->sut->generate(10)));
+        $this->assertEquals(18, strlen($this->sut->generate(18)));
+        $this->assertEquals(35, strlen($this->sut->generate(35)));
+        $this->assertEquals(40, strlen($this->sut->generate(40)));
+    }
+}
+ 


### PR DESCRIPTION
This pull request patches a flaw in how profile images are managed that creates risk of a persistent remote code execution vulnerability. Details of the vulnerability may be released at the maintainers' discretion.

- Uses `ircmaxell/random-lib` to generate reasonably random filenames whereby no part of the filename, at-rest, is controlled by a user of OpenCFP.
- Adds additional checks to cleanup profile photo uploads that have yet to be cropped and permanently stored.
- Adds a migration to clean existing installs of OpenCFP with regards to this vulnerability; bringing stored profile photos inline with proposed storage scheme.

**Potential Future Work**

- Would like to implement tests that attempt to exploit this vulnerability from an e2e perspective as well as tests that force exceptions to occur at various points in the upload/cropping process to verify that things are kept clean.
- We are currently implicitly protecting ourselves from this vulnerability by executing a cropping process that removes the RCE vector. It would be nice to implement a service responsible for explicitly detecting and cleaning uploaded profile images so that in the event we ever stopped cropping, we would not become exposed again. 