### PR TITLE
Turn off https default for development environment

### DIFF
--- a/config/development.dist.yml
+++ b/config/development.dist.yml
@@ -8,7 +8,7 @@ application:
   airport: MIA
   arrival: 2014-10-26
   departure: 2014-10-31
-  secure_ssl: true
+  secure_ssl: false
 
 api:
   enabled: true


### PR DESCRIPTION
While I agree that https is a sensible default for production, I think that normal http makes more sense in development environments. Feel free to reject this PR if you disagree.