### PR TITLE
Make it easier to use the PHP built-in web server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ OpenCFP is a PHP-based conference talk submission system.
    * [Admin Group Management](#admin-group-management)
    * [Clear Caches](#clear-caches)
  * [Testing](#testing)
+ * [Developer Environment](#developer-environment)
+   * [PHP Built-in Web Server](#php-built-in-web-server)
  * [Troubleshooting](#troubleshooting)
 
 <a name="features" />
@@ -531,6 +533,22 @@ $ ./vendor/bin/phpunit
 ```
 
 The phpunit.xml file is in the root directory for the project.
+
+
+<a name="developer-environment" />
+## Developer Environment
+
+<a name="php-built-in-web-server" />
+### PHP Built-in Web Server
+
+To run OpenCFP using [PHP's built-in web server](http://php.net/manual/en/features.commandline.webserver.php) the
+following command can be run:
+
+```
+$ php -S localhost:8000 -t web web/index_dev.php
+```
+
+You can choose a port other than `8000`. This is a quick way to get started doing development on OpenCFP itself.
 
 
 <a name="troubleshooting" />

--- a/web/index.php
+++ b/web/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once '../vendor/autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';
 
 use OpenCFP\Application;
 use OpenCFP\Environment;

--- a/web/index_dev.php
+++ b/web/index_dev.php
@@ -1,0 +1,8 @@
+<?php
+
+$filename = __DIR__.preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
+if (php_sapi_name() === 'cli-server' && is_file($filename)) {
+    return false;
+}
+
+require_once __DIR__.'/index.php';


### PR DESCRIPTION
After looking at the requirements for Apache in the htaccess file, we discovered that it would be pretty easy to just run with PHP's built-in web server for development.