### PR TITLE
Resolve YAML::parse deprecation notice.

### DIFF
--- a/classes/OpenCFP/Provider/YamlConfigDriver.php
+++ b/classes/OpenCFP/Provider/YamlConfigDriver.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace OpenCFP\Provider;
+
+use Igorw\Silex\YamlConfigDriver as IgorYamlConfigDriver;
+use Symfony\Component\Yaml\Yaml;
+
+class YamlConfigDriver extends IgorYamlConfigDriver
+{
+    public function load($filename)
+    {
+        if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
+            throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
+        }
+        $config = Yaml::parse(file_get_contents($filename));
+        return $config ?: array();
+    }
+}


### PR DESCRIPTION
See https://github.com/igorw/ConfigServiceProvider/pull/46

When the above PR is merged, we can revert this commit. The current code
is throwing errors in the test suite due to deprecation notices from Yaml::parse.
We haven't upgraded this package so no idea why we started getting notices like
this but it is what it is.

Parse method now triggers a warning if you give it a path. It expects the yaml file
contents, not a path. This patch adds a provider that extends Igor's and makes
this change. We then sub this provider into the ChainConfigProvider instead of
using SilexConfigServiceProvider's default.

---

What's odd about this is that I can't for the life of me find that error message in the version of  `symfony/yaml` we're using. I'm overlooking something, clearly... but this fixes the issue regardless, until Igor merges that PR.

*/edit* found where this is pulled in... TIL about `symfony/debug` and `symfony/phpunit-bridge`. They do some runtime determination of deprecated interfaces. There are options to squelch this by adding a `@legacy` annotation to test cases. We can do that instead if we want. This PR resolves the deprecation altogether. 

The reason this hasn't been showing up in past runs of test suite must be environmental differences in error reporting, I imagine. I've got my VM configured to show *all* errors, warnings, notices, etc.