### PR TITLE
Fix defaults for users table.

### DIFF
--- a/migrations/20150702132854_fix_defaults_for_users_table.php
+++ b/migrations/20150702132854_fix_defaults_for_users_table.php
@@ -1,0 +1,78 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class FixDefaultsForUsersTable extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $users = $this->table('users');
+
+        // Stricter MySQL installs have issues with null or empty string
+        // values for columns marked as NOT NULL.
+        //
+        // Updated with defaults from Sentry:
+        //
+        // https://github.com/cartalyst/sentry/blob/2.1/schema/mysql.sql
+        //
+        $users->changeColumn('permissions', 'text', ['null' => true]);
+        $users->changeColumn('activated', 'boolean', ['default' => 0]);
+        $users->changeColumn('activation_code', 'string', ['null' => true]);
+        $users->changeColumn('activated_at', 'datetime', ['null' => true, 'default' => '0000-00-00 00:00:00']);
+        $users->changeColumn('last_login', 'datetime', ['null' => true, 'default' => '0000-00-00 00:00:00']);
+        $users->changeColumn('persist_code', 'string', ['null' => true]);
+        $users->changeColumn('reset_password_code', 'string', ['null' => true]);
+        $users->changeColumn('first_name', 'string', ['null' => true]);
+        $users->changeColumn('last_name', 'string', ['null' => true]);
+        $users->changeColumn('created_at', 'datetime', ['default' => '0000-00-00 00:00:00']);
+        $users->changeColumn('updated_at', 'datetime', ['default' => '0000-00-00 00:00:00']);
+
+        // Custom fields
+        $users->changeColumn('company', 'string', ['null' => true]);
+        $users->changeColumn('twitter', 'string', ['null' => true]);
+        $users->changeColumn('airport', 'string', ['null' => true]);
+        $users->changeColumn('url', 'string', ['null' => true]);
+        $users->changeColumn('hotel', 'integer', ['null' => true]);
+        $users->changeColumn('transportation', 'integer', ['null' => true]);
+        $users->changeColumn('info', 'text', ['null' => true]);
+        $users->changeColumn('bio', 'text', ['null' => true]);
+        $users->changeColumn('photo_path', 'string', ['null' => true]);
+
+        $users->save();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $users = $this->table('users');
+
+        $users->changeColumn('photo_path', 'string');
+        $users->changeColumn('bio', 'text');
+        $users->changeColumn('info', 'text');
+        $users->changeColumn('transportation', 'integer');
+        $users->changeColumn('hotel', 'integer');
+        $users->changeColumn('url', 'string');
+        $users->changeColumn('airport', 'string');
+        $users->changeColumn('twitter', 'string');
+        $users->changeColumn('company', 'string');
+
+        $users->changeColumn('updated_at', 'datetime');
+        $users->changeColumn('created_at', 'datetime');
+        $users->changeColumn('last_name', 'string');
+        $users->changeColumn('first_name', 'string');
+        $users->changeColumn('reset_password_code', 'string');
+        $users->changeColumn('persist_code', 'string');
+        $users->changeColumn('last_login', 'datetime');
+        $users->changeColumn('activated_at', 'datetime');
+        $users->changeColumn('activation_code', 'string');
+        $users->changeColumn('activated', 'boolean');
+        $users->changeColumn('permissions', 'text');
+
+        $users->save();
+    }
+}


### PR DESCRIPTION
When using more strict MySQL settings it is not possible to add records without specifying values for NOT NULL columns unless a default is specified. Phinx creates NOT NULL columns by default so many fields were giving us problems when trying to register a user without giving a proper value for many fields that the signup controller wasn't asking about.

This fixes the problem by altering the database schema such that the fields in question will either allow null values or specify a default value in the case that NULL is used or no value is provided.

# Important Note

For people with strict MySQL settings, this migration will most likely not be reversible as columns will end up with NULL values and reversing this migration results in making those columns NOT NULL.

People with less-strict MySQL settings will not have any problems with this, though.