### PR TITLE
Fix: Remove import for non-existent class

### DIFF
--- a/classes/OpenCFP/Http/Controller/ProfileController.php
+++ b/classes/OpenCFP/Http/Controller/ProfileController.php
@@ -101,7 +101,7 @@ class ProfileController extends BaseController
             if (isset($form_data['speaker_photo'])) {
                 /** @var \Symfony\Component\HttpFoundation\File\UploadedFile $file */
                 $file = $form_data['speaker_photo'];
-                /** @var \OpenCFP\ProfileImageProcessor $processor */
+                /** @var \OpenCFP\Domain\Services\ProfileImageProcessor $processor */
                 $processor = $this->app['profile_image_processor'];
                 /** @var PseudoRandomStringGenerator $generator */
                 $generator = $this->app['security.random'];

--- a/classes/OpenCFP/Http/Controller/SignupController.php
+++ b/classes/OpenCFP/Http/Controller/SignupController.php
@@ -4,7 +4,6 @@ namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Http\Form\SignupForm;
 use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
-use OpenCFP\ProfileImageProcessor;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
This PR

* [x] removes an import for a non-existent class `OpenCFP\ProfileImageProcessor`
* [x] fixes an inline comment referring to a non-existent class `OpenCFP\ProfileImageProcessor`

:bulb: `OpenCFP\ProfileImageProcessor` doesn't exist, but `OpenCFP\Domain\Services\ProfileImageProcessor` does.