### PR TITLE
Fix: Speaker::findProfile() doesn't accept any arguments

### DIFF
--- a/classes/OpenCFP/Application/Speakers.php
+++ b/classes/OpenCFP/Application/Speakers.php
@@ -46,7 +46,7 @@ class Speakers
 
     /**
      * Retrieves the speaker profile for currently authenticated speaker.
-     *d
+     *
      * @return SpeakerProfile
      */
     public function findProfile()

--- a/tests/OpenCFP/Application/SpeakersTest.php
+++ b/tests/OpenCFP/Application/SpeakersTest.php
@@ -64,7 +64,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
         $speaker = $this->getSpeaker();
         $this->trainIdentityProviderToReturnSampleSpeaker($speaker);
 
-        $profile = $this->sut->findProfile(self::SPEAKER_ID);
+        $profile = $this->sut->findProfile();
 
         $this->assertInstanceOf('OpenCFP\Domain\Speaker\SpeakerProfile', $profile);
         $this->assertEquals($speaker->email, $profile->getEmail());
@@ -77,7 +77,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
         $this->trainStudentRepositoryToThrowEntityNotFoundException();
 
         $this->setExpectedException('OpenCFP\Domain\EntityNotFoundException');
-        $this->sut->findProfile('does not exist');
+        $this->sut->findProfile();
     }
 
     /** @test */


### PR DESCRIPTION
This PR

* [x] removes arguments from calls to `Speaker::findProfile()` as the method doesn't accept any
* [x] removes a fat finger