### PR TITLE
Fix: Reduce visibility from public to protected

### DIFF
--- a/tests/OpenCFP/Application/SpeakersTest.php
+++ b/tests/OpenCFP/Application/SpeakersTest.php
@@ -48,7 +48,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
         $this->sut = new Speakers($this->callForProposal, $this->identityProvider, $this->speakerRepository, $this->talkRepository, $this->dispatcher);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         m::close();

--- a/tests/OpenCFP/Domain/Entity/FavoriteTest.php
+++ b/tests/OpenCFP/Domain/Entity/FavoriteTest.php
@@ -8,7 +8,7 @@ class FavoriteEntityTest extends \PHPUnit_Framework_TestCase
     public $mapper;
     public $talk;
 
-    public function setup()
+    protected function setup()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
         // Create an in-memory database

--- a/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
@@ -7,7 +7,7 @@ class TalkMapperTest extends \PHPUnit_Framework_TestCase
 {
     public $app;
 
-    public function setup()
+    protected function setup()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
         $cfp = new \Spot\Config;

--- a/tests/OpenCFP/Domain/Entity/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/TalkTest.php
@@ -7,7 +7,7 @@ class TalkEntityTest extends \PHPUnit_Framework_TestCase
     public $app;
     public $mapper;
 
-    public function setup()
+    protected function setup()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
         // Create an in-memory database

--- a/tests/OpenCFP/Http/API/ApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ApiControllerTest.php
@@ -9,7 +9,7 @@ class ApiControllerTest extends PHPUnit_Framework_TestCase
      */
     private $sut;
 
-    public function setup()
+    protected function setup()
     {
         $this->sut = new StubApiController();
     }

--- a/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
@@ -20,7 +20,7 @@ class ProfileApiControllerTest extends PHPUnit_Framework_TestCase
      */
     private $speakers;
 
-    public function setup()
+    protected function setup()
     {
         $this->speakers = m::mock('OpenCFP\Application\Speakers');
         $this->sut = new ProfileController($this->speakers);

--- a/tests/OpenCFP/Http/API/TalkApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/TalkApiControllerTest.php
@@ -20,7 +20,7 @@ class TalkApiControllerTest extends PHPUnit_Framework_TestCase
      */
     private $speakers;
 
-    public function setup()
+    protected function setup()
     {
         $this->speakers = m::mock('OpenCFP\Application\Speakers');
         $this->sut = new TalkController($this->speakers);

--- a/tests/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -10,7 +10,7 @@ class PseudoRandomStringGeneratorTest extends PHPUnit_Framework_TestCase
      */
     private $sut;
 
-    public function setup()
+    protected function setup()
     {
         $this->sut = new PseudoRandomStringGenerator(new Factory());
     }

--- a/tests/unit/controllers/TalkControllerTest.php
+++ b/tests/unit/controllers/TalkControllerTest.php
@@ -9,7 +9,7 @@ class TalkControllerTest extends PHPUnit_Framework_TestCase
     protected $app;
     protected $req;
 
-    public function setup()
+    protected function setup()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
         ob_start();


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setup()` and `tearDown()` from `public` to `protected`, as this is the visibility used in `PHPUnit_Framework_Testcase`