### PR TITLE
Fix: Cache directory for dependencies installed with Composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 # cache composer downloads so installing is quicker
 cache:
   directories:
-    - $HOME/.composer
+    - $HOME/.composer/cache
 
 addons:
   code_climate:


### PR DESCRIPTION
This PR

* [x] fixes the directory which should be used for caching dependencies installed with Composer on Travis