### PR TITLE
Fix: Clean up Travis configuration and build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,16 @@ cache:
 addons:
   code_climate:
     repo_token: 9deb249b01a414d979959cfd05a4c351b19a5959858653b20276454d4189edc3
-    
+
 before_install:
   - composer self-update
-  
+
+install:
+  - composer install
+
 before_script:
   - sh tools/travis/setup-mail.sh
   - cp phinx.yml.dist phinx.yml
-  - composer install
 
 script:
   - sh tools/travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ php:
   - 5.5
   - 5.4
 
+env:
+  - TRAVIS_DB=cfp_travis
+
 # cache composer downloads so installing is quicker
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,13 @@ addons:
 before_install:
   - composer self-update
 
-
 install:
   - composer install
 
 before_script:
   - sh tools/travis/setup-mail.sh
-  - cp phinx.yml.dist phinx.yml
   - mysql -e "CREATE DATABASE $TRAVIS_DB" -uroot
+  - vendor/bin/phinx --configuration=phinx.yml.dist migrate -e testing
 
 script:
   - sh tools/travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,14 @@ addons:
 before_install:
   - composer self-update
 
+
 install:
   - composer install
 
 before_script:
   - sh tools/travis/setup-mail.sh
   - cp phinx.yml.dist phinx.yml
+  - mysql -e "CREATE DATABASE $TRAVIS_DB" -uroot
 
 script:
   - sh tools/travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
   - vendor/bin/phinx --configuration=phinx.yml.dist migrate -e testing
 
 script:
-  - sh tools/travis/build.sh
+  - phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
   - vendor/bin/test-reporter --stdout > codeclimate.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ cache:
 addons:
   code_climate:
     repo_token: 9deb249b01a414d979959cfd05a4c351b19a5959858653b20276454d4189edc3
-
+    
+before_install:
+  - composer self-update
+  
 before_script:
   - sh tools/travis/setup-mail.sh
   - cp phinx.yml.dist phinx.yml
-  - composer self-update
   - composer install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
   - vendor/bin/phinx --configuration=phinx.yml.dist migrate -e testing
 
 script:
-  - phpunit --coverage-clover build/logs/clover.xml
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
   - vendor/bin/test-reporter --stdout > codeclimate.json

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -3,6 +3,4 @@
 # Get a path to the project's root.
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
-sh $PROJECT_ROOT/tools/travis/reset-database.sh
-
 phpunit --coverage-clover build/logs/clover.xml

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Get a path to the project's root.
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-
-phpunit --coverage-clover build/logs/clover.xml

--- a/tools/travis/reset-database.sh
+++ b/tools/travis/reset-database.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Note that this is also specified in the Phinx testing environment.
-TRAVIS_DB="cfp_travis"
-
 # Get a path to the project's root.
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 

--- a/tools/travis/reset-database.sh
+++ b/tools/travis/reset-database.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# Get a path to the project's root.
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-
-# Run Phinx migrations.
-echo "Running migrations..."
-$PROJECT_ROOT/vendor/bin/phinx --configuration="$PROJECT_ROOT/phinx.yml" migrate -e testing

--- a/tools/travis/reset-database.sh
+++ b/tools/travis/reset-database.sh
@@ -3,11 +3,6 @@
 # Get a path to the project's root.
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
-# Set up testing database.
-echo "Setting up testing database..."
-mysql -e "DROP DATABASE IF EXISTS $TRAVIS_DB" -uroot
-mysql -e "CREATE DATABASE $TRAVIS_DB" -uroot
-
 # Run Phinx migrations.
 echo "Running migrations..."
 $PROJECT_ROOT/vendor/bin/phinx --configuration="$PROJECT_ROOT/phinx.yml" migrate -e testing


### PR DESCRIPTION
This PR

* [x] updates the Composer binary in the `before_install` section
* [x] installs dependencies with Composer in the `install` section
* [x] defines the environment variable `TRAVIS_DB` in the `env` section
* [x] creates database in `before_script` section (and doesn't worry about dropping it)
* [x] runs database migrations in `before_script` section (and doesn't worry about renaming the migration configuration file)
* [x] runs `phpunit` in `script` section
* [x] uses `phpunit` as installed with development dependencies (rather than the version provided on Travis)
* [x] removes unused scripts `tools/travis/build.sh` and `tools/travis/reset-database.sh`
 