### PR TITLE
Enhancement: Run composer --validate on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
 
 before_install:
   - composer self-update
+  - composer validate
 
 install:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 
 before_install:
   - composer self-update
-  - composer validate
+  - composer validate --no-check-publish
 
 install:
   - composer install


### PR DESCRIPTION
This PR

* [x] runs `composer validate --no-check-publish` in `before_install` section

:information_desk_person: Following https://github.com/composer/composer/pull/4219, this will break the build if `composer.lock` is not up to date.