### PR TITLE
Correct the route for profile update after invalid entry; fixes #214

### DIFF
--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -151,7 +151,7 @@ class ProfileController extends BaseController
             ));
         }
 
-        $form_data['formAction'] = $this->url('user_edit', ['id' => $user->id]);
+        $form_data['formAction'] = $this->url('user_update');
         $form_data['buttonInfo'] = 'Update Profile';
         $form_data['id'] = $user->id;
         $form_data['user'] = $user;


### PR DESCRIPTION
As far as I can tell, the `user_edit` route was always wrong here; there's no reason we would want a form pointing at that route.

This is all in the controller, and there's no controller test at present; not sure whether I should set one up for this small degree of change?