### PR TITLE
speakers list makes more sense alphabetized by first name

### DIFF
--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -20,7 +20,7 @@ class SpeakersController extends BaseController
         $rawSpeakers = $this->app['spot']
             ->mapper('OpenCFP\Domain\Entity\User')
             ->all()
-            ->order(['last_name' => 'ASC'])
+            ->order(['first_name' => 'ASC'])
             ->toArray();
 
         // Set up our page stuff

--- a/templates/layouts/dashboard.twig
+++ b/templates/layouts/dashboard.twig
@@ -11,7 +11,7 @@
     </head>
     <body class="dashboard">
         <div class="navbar navbar-opencfp navbar-fixed-top section--full" role="navigation">
-            <a href="{{ url('dashboard') }}" class="logo pull-left"><img data-src="/assets/img/logo.svg" class="svg-inject" alt="OpenCFP"></a>
+            <a href="{{ url('homepage') }}" class="logo pull-left"><img data-src="/assets/img/logo.svg" class="svg-inject" alt="OpenCFP"></a>
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                     <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
The speakers names in the admin speaker listing are displayed as full name (first last) format but are sorted on last name, causing some confusion when attempting to find the speakers in the list. I altered the order to be on firstname and it makes finding speakers much easier.