### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -7,7 +7,6 @@ use Cartalyst\Sentry\Users\UserNotFoundException;
 use OpenCFP\Console\BaseCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class AdminDemoteCommand extends BaseCommand

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -5,10 +5,8 @@ namespace OpenCFP\Console\Command;
 use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users\UserNotFoundException;
 use OpenCFP\Console\BaseCommand;
-use OpenCFP\Environment;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class AdminPromoteCommand extends BaseCommand

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -3,7 +3,6 @@
 namespace OpenCFP\Http\Controller;
 
 use Cartalyst\Sentry\Users\UserNotFoundException;
-use OpenCFP\Domain\Services\ResetEmailer;
 use OpenCFP\Http\Form\ResetForm;
 use OpenCFP\Application;
 use Symfony\Component\HttpFoundation\Request;

--- a/classes/Infrastructure/Auth/SentryIdentityProvider.php
+++ b/classes/Infrastructure/Auth/SentryIdentityProvider.php
@@ -7,7 +7,6 @@ use OpenCFP\Domain\Entity\User;
 use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
 use OpenCFP\Domain\Speaker\SpeakerRepository;
-use Spot\Mapper;
 
 class SentryIdentityProvider implements IdentityProvider
 {


### PR DESCRIPTION
This PR

* [x] removes unused imports

:information_desk_person: Alternatively, one could add the `unused_use` fixer in #242.