### PR TITLE
Fix: Avoid magic numbers

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -293,13 +293,13 @@ class Application extends SilexApplication
             }
 
             switch ($code) {
-                case 401:
+                case Response::HTTP_UNAUTHORIZED:
                     $message = $app['twig']->render('error/401.twig');
                     break;
-                case 403:
+                case Response::HTTP_FORBIDDEN:
                     $message = $app['twig']->render('error/403.twig');
                     break;
-                case 404:
+                case Response::HTTP_NOT_FOUND:
                     $message = $app['twig']->render('error/404.twig');
                     break;
                 default:

--- a/classes/Http/API/ApiController.php
+++ b/classes/Http/API/ApiController.php
@@ -132,7 +132,7 @@ class ApiController
      *
      * @return RedirectResponse
      */
-    public function redirectTo($route, $status = 302)
+    public function redirectTo($route, $status = Response::HTTP_FOUND)
     {
         return $this->app->redirect($this->url($route), $status);
     }

--- a/classes/Http/Controller/BaseController.php
+++ b/classes/Http/Controller/BaseController.php
@@ -33,7 +33,7 @@ abstract class BaseController
      *
      * @return mixed
      */
-    public function render($name, array $context = [], $status = 200)
+    public function render($name, array $context = [], $status = Response::HTTP_OK)
     {
         return new Response($this->app['twig']->render($name, $context), $status);
     }
@@ -44,7 +44,7 @@ abstract class BaseController
      *
      * @return RedirectResponse
      */
-    public function redirectTo($route, $status = 302)
+    public function redirectTo($route, $status = Response::HTTP_FOUND)
     {
         return $this->app->redirect($this->url($route), $status);
     }

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -6,6 +6,7 @@ use Silex\Application;
 use OpenCFP\Domain\Services\Login;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class SecurityController extends BaseController
 {
@@ -19,7 +20,7 @@ class SecurityController extends BaseController
     public function processAction(Request $req, Application $app)
     {
         $template_data = array();
-        $code = 200;
+        $code = Response::HTTP_OK;
 
         try {
             $page = new Login($app['sentry']);
@@ -39,13 +40,13 @@ class SecurityController extends BaseController
             $template_data = array(
                 'email' => $req->get('email'),
             );
-            $code = 400;
+            $code = Response::HTTP_BAD_REQUEST;
         } catch (Exception $e) {
             $errorMessage = $e->getMessage();
             $template_data = array(
                 'email' => $req->get('email'),
             );
-            $code = 400;
+            $code = Response::HTTP_BAD_REQUEST;
         }
 
         // Set Success Flash Message

--- a/classes/Http/OAuth/AuthorizationController.php
+++ b/classes/Http/OAuth/AuthorizationController.php
@@ -11,6 +11,7 @@ use OpenCFP\Domain\Services\NotAuthenticatedException;
 use OpenCFP\Http\API\ApiController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class AuthorizationController extends ApiController
 {
@@ -81,7 +82,7 @@ class AuthorizationController extends ApiController
             $redirectUri = $this->server->getGrantType('authorization_code')
                 ->newAuthorizeRequest('user', $user->id, $authParams);
 
-            return $this->setStatusCode(302)->respond('', ['Location' => $redirectUri]);
+            return $this->setStatusCode(Response::HTTP_FOUND)->respond('', ['Location' => $redirectUri]);
         } else {
             $error = new AccessDeniedException;
 
@@ -90,7 +91,7 @@ class AuthorizationController extends ApiController
                 'message' => $error->getMessage()
             ]);
 
-            return $this->setStatusCode(302)->respond('', ['Location' => $redirectUri]);
+            return $this->setStatusCode(Response::HTTP_FOUND)->respond('', ['Location' => $redirectUri]);
         }
     }
 


### PR DESCRIPTION
This PR

* [x] uses constants instead of magic numbers for response status codes