### PR TITLE
Fix: Cover SymfonySentrySession

### DIFF
--- a/classes/Provider/SymfonySentrySession.php
+++ b/classes/Provider/SymfonySentrySession.php
@@ -7,7 +7,14 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface as SymfonySessionI
 
 class SymfonySentrySession implements SentrySessionInterface
 {
+    /**
+     * @var SymfonySessionInterface
+     */
     private $session;
+
+    /**
+     * @var string
+     */
     private $key;
 
     public function __construct(SymfonySessionInterface $session, $key = null)
@@ -16,16 +23,25 @@ class SymfonySentrySession implements SentrySessionInterface
         $this->key = $key ?: 'cartalyst_sentry';
     }
 
+    /**
+     * @return string
+     */
     public function getKey()
     {
         return $this->key;
     }
 
+    /**
+     * @param mixed $value
+     */
     public function put($value)
     {
         $this->session->set($this->key, $value);
     }
 
+    /**
+     * @return mixed
+     */
     public function get()
     {
         return $this->session->get($this->key);

--- a/tests/OpenCFP/Provider/SymfonySentrySessionTest.php
+++ b/tests/OpenCFP/Provider/SymfonySentrySessionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace OpenCFP\Provider;
+
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class SymfonySentrySessionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaults()
+    {
+        $sentrySession = new SymfonySentrySession($this->getSessionMock());
+
+        $this->assertSame('cartalyst_sentry', $sentrySession->getKey());
+    }
+
+    public function testConstructorSetsKey()
+    {
+        $key = 'foo';
+
+        $sentrySession = new SymfonySentrySession(
+            $this->getSessionMock(),
+            $key
+        );
+
+        $this->assertSame($key, $sentrySession->getKey());
+    }
+
+    public function testPutSetsValue()
+    {
+        $key = 'foo';
+        $value = 'bar';
+
+        $session = $this->getSessionMock();
+
+        $session
+            ->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->identicalTo($key),
+                $this->identicalTo($value)
+            )
+        ;
+
+        $sentrySession = new SymfonySentrySession(
+            $session,
+            $key
+        );
+
+        $sentrySession->put($value);
+    }
+
+    public function testGetReturnsValue()
+    {
+        $key = 'foo';
+        $value = 'bar';
+
+        $session = $this->getSessionMock();
+
+        $session
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($key))
+            ->willReturn($value)
+        ;
+
+        $sentrySession = new SymfonySentrySession(
+            $session,
+            $key
+        );
+
+        $this->assertSame($value, $sentrySession->get());
+    }
+
+    public function testForgetRemovesKey()
+    {
+        $key = 'foo';
+
+        $session = $this->getSessionMock();
+
+        $session
+            ->expects($this->once())
+            ->method('remove')
+            ->with($this->identicalTo($key))
+        ;
+
+        $sentrySession = new SymfonySentrySession(
+            $session,
+            $key
+        );
+
+        $sentrySession->forget();
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|SessionInterface
+     */
+    private function getSessionMock()
+    {
+        return $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds coverage for `OpenCFP\Provider\SymfonySentrySession`
* [x] adds docblocks