### PR TITLE
Fix: Remove unused parameter

### DIFF
--- a/classes/Http/Controller/Admin/AdminAccessTrait.php
+++ b/classes/Http/Controller/Admin/AdminAccessTrait.php
@@ -8,7 +8,7 @@ trait AdminAccessTrait
     {
         if (method_exists($this, $method)) {
             // Check if user is an logged in and an Admin
-            if ( ! $this->userHasAccess($this->app)) {
+            if ( ! $this->userHasAccess()) {
                 return $this->redirectTo('dashboard');
             }
 
@@ -16,7 +16,7 @@ trait AdminAccessTrait
         }
     }
 
-    protected function userHasAccess($app)
+    protected function userHasAccess()
     {
         if (!$this->app['sentry']->check()) {
             return false;

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -59,7 +59,7 @@ class SpeakersController extends BaseController
     private function viewAction(Request $req)
     {
         // Check if user is an logged in and an Admin
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('dashboard');
         }
 
@@ -88,7 +88,7 @@ class SpeakersController extends BaseController
     private function deleteAction(Request $req)
     {
         // Check if user is an logged in and an Admin
-        if ( ! $this->userHasAccess($this->app)) {
+        if ( ! $this->userHasAccess()) {
             return $this->redirectTo('dashboard');
         }
 

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -12,7 +12,7 @@ class TalksController extends BaseController
 
     public function indexAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('login');
         }
 
@@ -68,7 +68,7 @@ class TalksController extends BaseController
 
     public function viewAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('login');
         }
 
@@ -111,7 +111,7 @@ class TalksController extends BaseController
      */
     private function favoriteAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return false;
         }
 
@@ -158,7 +158,7 @@ class TalksController extends BaseController
      */
     private function selectAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return false;
         }
 


### PR DESCRIPTION
This PR

* [x] removes an unused parameter from `AdminAccessTrait::userHasAccess()`

:person_with_pouting_face: The method never uses it, so no need to pass it in, either.