### PR TITLE
Fix: Add coverage for ContainerAware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
     "autoload": {
         "psr-4": {"OpenCFP\\": "classes/"}
     },
+    "autoload-dev": {
+        "psr-4": {
+            "OpenCFP\\": "tests/OpenCFP/"
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "4.6.6",
         "phpunit/dbunit": "1.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3573351dc5c3b3b494cefade3c6f4fec",
+    "hash": "2af2db8472436ff87f7f64ccfa81daa9",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -639,7 +639,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/bfbf8a9da12131f41ae22b80ccf0e3ca288046a1",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/ae1828d955112356f7677c465f94f7deb7d27a40",
                 "reference": "bfbf8a9da12131f41ae22b80ccf0e3ca288046a1",
                 "shasum": ""
             },
@@ -1443,9 +1443,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Pimple is a simple Dependency Injection Container for PHP 5.3",
@@ -1462,12 +1460,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "1.0.0"
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "1.0.0",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
                 "shasum": ""
             },
             "type": "library",
@@ -1695,12 +1693,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "v5.0.0"
+                "reference": "e2915242824e32e28be3fc699c453c1d16fd6de1"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/e2915242824e32e28be3fc699c453c1d16fd6de1",
-                "reference": "v5.0.0",
+                "reference": "e2915242824e32e28be3fc699c453c1d16fd6de1",
                 "shasum": ""
             },
             "require": {
@@ -1724,7 +1722,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Chris Corbyn"
@@ -3128,7 +3128,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/spot2/zipball/79fe49372977d83453574d53236568c98f8f8cea",
+                "url": "https://api.github.com/repos/vlucas/spot2/zipball/df497f42232741c27443ccc9a96dd0550fa410f7",
                 "reference": "79fe49372977d83453574d53236568c98f8f8cea",
                 "shasum": ""
             },
@@ -3230,7 +3230,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/418ae782307841ac50fe26daa4cfe04520b0de9c",
+                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/f7afa2f80e88faf722167488f47dea0ba6178a45",
                 "reference": "418ae782307841ac50fe26daa4cfe04520b0de9c",
                 "shasum": ""
             },
@@ -3338,12 +3338,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "v1.2.0"
+                "reference": "4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f",
-                "reference": "v1.2.0",
+                "reference": "4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f",
                 "shasum": ""
             },
             "require": {
@@ -3352,7 +3352,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -3376,7 +3376,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2013-06-09 17:55:57"
+            "time": "2013-06-09 18:05:57"
         },
         {
             "name": "guzzle/guzzle",
@@ -3578,7 +3578,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/491d4f3c1792273d73aa851a1330f9050a8257a0",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/e585573c91b0c821e511afd14666b4503ef7255b",
                 "reference": "491d4f3c1792273d73aa851a1330f9050a8257a0",
                 "shasum": ""
             },

--- a/tests/OpenCFP/ContainerAwareFake.php
+++ b/tests/OpenCFP/ContainerAwareFake.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenCFP;
+
+class ContainerAwareFake
+{
+    use ContainerAware;
+
+    /**
+     * @param string $slug
+     * @return mixed
+     */
+    public function getService($slug)
+    {
+        return $this->service($slug);
+    }
+}

--- a/tests/OpenCFP/ContainerAwareTest.php
+++ b/tests/OpenCFP/ContainerAwareTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace OpenCFP;
+
+use OpenCFP\Application;
+
+class ContainerAwareTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAllowsToRetrieveService()
+    {
+        $slug = 'foo';
+        $service = 'bar';
+
+        $application = $this->getApplicationMock();
+
+        $application
+            ->expects($this->once())
+            ->method('offsetGet')
+            ->with($this->identicalTo($slug))
+            ->willReturn($service)
+        ;
+
+        $containerAware = new ContainerAwareFake();
+
+        $containerAware->setApplication($application);
+
+        $this->assertSame($service, $containerAware->getService($slug));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Application
+     */
+    private function getApplicationMock()
+    {
+        return $this->getMockBuilder('OpenCFP\Application')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds an `autoload-dev` section to `composer.json` so we can autoload test resources
* [x] adds coverage for `ContainerAware`, because it can break, too