### PR TITLE
Fix: Add coverage for AdminAccessTrait

### DIFF
--- a/classes/Http/Controller/Admin/AdminAccessTrait.php
+++ b/classes/Http/Controller/Admin/AdminAccessTrait.php
@@ -4,18 +4,6 @@ namespace OpenCFP\Http\Controller\Admin;
 
 trait AdminAccessTrait
 {
-    public function __call($method,$arguments)
-    {
-        if (method_exists($this, $method)) {
-            // Check if user is an logged in and an Admin
-            if ( ! $this->userHasAccess($this->app)) {
-                return $this->redirectTo('dashboard');
-            }
-
-            return call_user_func_array(array($this, $method), $arguments);
-        }
-    }
-
     protected function userHasAccess($app)
     {
         if (!$this->app['sentry']->check()) {

--- a/classes/Http/Controller/Admin/AdminAccessTrait.php
+++ b/classes/Http/Controller/Admin/AdminAccessTrait.php
@@ -4,7 +4,7 @@ namespace OpenCFP\Http\Controller\Admin;
 
 trait AdminAccessTrait
 {
-    protected function userHasAccess($app)
+    protected function userHasAccess()
     {
         if (!$this->app['sentry']->check()) {
             return false;

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -59,7 +59,7 @@ class SpeakersController extends BaseController
     private function viewAction(Request $req)
     {
         // Check if user is an logged in and an Admin
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('dashboard');
         }
 
@@ -88,7 +88,7 @@ class SpeakersController extends BaseController
     private function deleteAction(Request $req)
     {
         // Check if user is an logged in and an Admin
-        if ( ! $this->userHasAccess($this->app)) {
+        if ( ! $this->userHasAccess()) {
             return $this->redirectTo('dashboard');
         }
 

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -12,7 +12,7 @@ class TalksController extends BaseController
 
     public function indexAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('login');
         }
 
@@ -68,7 +68,7 @@ class TalksController extends BaseController
 
     public function viewAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('login');
         }
 
@@ -111,7 +111,7 @@ class TalksController extends BaseController
      */
     private function favoriteAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return false;
         }
 
@@ -158,7 +158,7 @@ class TalksController extends BaseController
      */
     private function selectAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return false;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
     "autoload": {
         "psr-4": {"OpenCFP\\": "classes/"}
     },
+    "autoload-dev": {
+        "psr-4": {
+            "OpenCFP\\": "tests/OpenCFP/"
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "4.6.6",
         "phpunit/dbunit": "1.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3573351dc5c3b3b494cefade3c6f4fec",
+    "hash": "2af2db8472436ff87f7f64ccfa81daa9",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -639,7 +639,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/bfbf8a9da12131f41ae22b80ccf0e3ca288046a1",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/ae1828d955112356f7677c465f94f7deb7d27a40",
                 "reference": "bfbf8a9da12131f41ae22b80ccf0e3ca288046a1",
                 "shasum": ""
             },
@@ -1443,9 +1443,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Pimple is a simple Dependency Injection Container for PHP 5.3",
@@ -1462,12 +1460,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "1.0.0"
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "1.0.0",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
                 "shasum": ""
             },
             "type": "library",
@@ -1695,12 +1693,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "v5.0.0"
+                "reference": "e2915242824e32e28be3fc699c453c1d16fd6de1"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/e2915242824e32e28be3fc699c453c1d16fd6de1",
-                "reference": "v5.0.0",
+                "reference": "e2915242824e32e28be3fc699c453c1d16fd6de1",
                 "shasum": ""
             },
             "require": {
@@ -1724,7 +1722,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Chris Corbyn"
@@ -3128,7 +3128,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/spot2/zipball/79fe49372977d83453574d53236568c98f8f8cea",
+                "url": "https://api.github.com/repos/vlucas/spot2/zipball/df497f42232741c27443ccc9a96dd0550fa410f7",
                 "reference": "79fe49372977d83453574d53236568c98f8f8cea",
                 "shasum": ""
             },
@@ -3230,7 +3230,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/418ae782307841ac50fe26daa4cfe04520b0de9c",
+                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/f7afa2f80e88faf722167488f47dea0ba6178a45",
                 "reference": "418ae782307841ac50fe26daa4cfe04520b0de9c",
                 "shasum": ""
             },
@@ -3338,12 +3338,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "v1.2.0"
+                "reference": "4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f",
-                "reference": "v1.2.0",
+                "reference": "4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f",
                 "shasum": ""
             },
             "require": {
@@ -3352,7 +3352,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -3376,7 +3376,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2013-06-09 17:55:57"
+            "time": "2013-06-09 18:05:57"
         },
         {
             "name": "guzzle/guzzle",
@@ -3578,7 +3578,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/491d4f3c1792273d73aa851a1330f9050a8257a0",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/e585573c91b0c821e511afd14666b4503ef7255b",
                 "reference": "491d4f3c1792273d73aa851a1330f9050a8257a0",
                 "shasum": ""
             },

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OpenCFP\Http\Controller\Admin;
+
+use OpenCFP\Application;
+
+class AdminAccessTraitFake
+{
+    use AdminAccessTrait;
+
+    /**
+     * @var Application
+     */
+    private $app;
+
+    public function __construct(Application $application)
+    {
+        $this->app = $application;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAdminAccess()
+    {
+        return $this->userHasAccess($this->app);
+    }
+}

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
@@ -25,9 +25,4 @@ class AdminAccessTraitFake
     {
         return $this->userHasAccess($this->app);
     }
-
-    public function callMe()
-    {
-
-    }
 }

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
@@ -23,6 +23,6 @@ class AdminAccessTraitFake
      */
     public function hasAdminAccess()
     {
-        return $this->userHasAccess($this->app);
+        return $this->userHasAccess(null);
     }
 }

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
@@ -23,6 +23,6 @@ class AdminAccessTraitFake
      */
     public function hasAdminAccess()
     {
-        return $this->userHasAccess(null);
+        return $this->userHasAccess();
     }
 }

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
@@ -25,4 +25,9 @@ class AdminAccessTraitFake
     {
         return $this->userHasAccess($this->app);
     }
+
+    public function callMe()
+    {
+
+    }
 }

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace OpenCFP\Http\Controller\Admin;
+
+use Cartalyst\Sentry\Sentry;
+use Cartalyst\Sentry\Users\UserInterface;
+use OpenCFP\Application;
+
+class AdminAccessTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturnsFalseIfCheckFailed()
+    {
+        $sentry = $this->getSentryMock();
+
+        $sentry
+            ->expects($this->once())
+            ->method('check')
+            ->willReturn(false)
+        ;
+
+        $sentry
+            ->expects($this->never())
+            ->method('getUser')
+        ;
+
+        $application = $this->getApplicationMock([
+            'sentry' => $sentry,
+        ]);
+
+        $adminAccess = new AdminAccessTraitFake($application);
+
+        $this->assertFalse($adminAccess->hasAdminAccess());
+    }
+
+    public function testReturnsFalseIfCheckSucceededButUserHasNoAdminPermission()
+    {
+        $userWithoutAdminPermission = $this->getUserMock(false);
+
+        $sentry = $this->getSentryMock();
+
+        $sentry
+            ->expects($this->at(0))
+            ->method('check')
+            ->willReturn(true)
+        ;
+
+        $sentry
+            ->expects($this->at(1))
+            ->method('getUser')
+            ->willReturn($userWithoutAdminPermission)
+        ;
+
+        $application = $this->getApplicationMock([
+            'sentry' => $sentry,
+        ]);
+
+        $adminAccess = new AdminAccessTraitFake($application);
+
+        $this->assertFalse($adminAccess->hasAdminAccess());
+    }
+
+    public function testReturnsTrueIfCheckSucceededAndUserHasAdminPermission()
+    {
+        $userWithAdminPermission = $this->getUserMock(true);
+
+        $sentry = $this->getSentryMock();
+
+        $sentry
+            ->expects($this->at(0))
+            ->method('check')
+            ->willReturn(true)
+        ;
+
+        $sentry
+            ->expects($this->at(1))
+            ->method('getUser')
+            ->willReturn($userWithAdminPermission)
+        ;
+
+        $application = $this->getApplicationMock([
+            'sentry' => $sentry,
+        ]);
+
+        $adminAccess = new AdminAccessTraitFake($application);
+
+        $this->assertTrue($adminAccess->hasAdminAccess());
+
+    }
+
+    /**
+     * @param array $items
+     * @return Application|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getApplicationMock(array $items = [])
+    {
+        $application = $this->getMockBuilder('OpenCFP\Application')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $application
+            ->expects($this->any())
+            ->method('offsetGet')
+            ->willReturnCallback(function ($alias) use ($items) {
+                if (array_key_exists($alias, $items)) {
+                    return $items[$alias];
+                }
+            })
+        ;
+
+        return $application;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Sentry
+     */
+    private function getSentryMock()
+    {
+        return $this->getMockBuilder('Cartalyst\Sentry\Sentry')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param bool $hasAdminPermission
+     * @return UserInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getUserMock($hasAdminPermission = false)
+    {
+        $user = $this->getMockBuilder('Cartalyst\Sentry\Users\UserInterface')->getMock();
+
+        $user
+            ->expects($this->any())
+            ->method('hasPermission')
+            ->with($this->identicalTo('admin'))
+            ->willReturn($hasAdminPermission)
+        ;
+
+        return $user;
+    }
+}

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
@@ -87,6 +87,24 @@ class AdminAccessTraitTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testCanNeverInterceptCallToExistingMethod()
+    {
+        $sentry = $this->getSentryMock();
+
+        $sentry
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        $application = $this->getApplicationMock([
+            'sentry' => $sentry,
+        ]);
+
+        $adminAccess = new AdminAccessTraitFake($application);
+
+        $adminAccess->callMe();
+    }
+
     /**
      * @param array $items
      * @return Application|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
@@ -87,24 +87,6 @@ class AdminAccessTraitTest extends \PHPUnit_Framework_TestCase
 
     }
 
-    public function testCanNeverInterceptCallToExistingMethod()
-    {
-        $sentry = $this->getSentryMock();
-
-        $sentry
-            ->expects($this->never())
-            ->method($this->anything())
-        ;
-
-        $application = $this->getApplicationMock([
-            'sentry' => $sentry,
-        ]);
-
-        $adminAccess = new AdminAccessTraitFake($application);
-
-        $adminAccess->callMe();
-    }
-
     /**
      * @param array $items
      * @return Application|\PHPUnit_Framework_MockObject_MockObject


### PR DESCRIPTION
This PR

* [x] cherry-picks 749c0df so we can autoload test resources
* [x] asserts that the `AdminAccessTrait` works as it claims it does
* [x] asserts that `__call()` never intercepts a method call to an existing method
* [x] removes useless `__call()`
* [x] asserts that method argument is never used
* [x] removes unused method argument
* [x] removes unused method argument from method calls

Follows #249.
Related to #247.