### PR TITLE
Enhancement: Add Makefile with cs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: cs
+
+cs:
+	vendor/bin/php-cs-fixer fix --verbose --diff


### PR DESCRIPTION
This PR

* [x] adds a `Makefile` with a `cs` target, so it's easier to fix issues locally

Follows #242.
### Usage

Run

```
$ make cs
```