### PR TITLE
Create CONTRIBUTING.md documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+We accept contributions via Pull Requests on [Github](https://github.com/opencfp/opencfp).
+
+## Pull Requests
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch probably won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Create feature branches** - Feature branches are critically important if you're going to be sending us more than one contribution. Don't send a PR from `master`!
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests. Large pull requests are difficult to review and manage.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. [Appropriate formatting of commit messages](http://chris.beams.io/posts/git-commit/) is also appreciated!
+
+- **Don't close issues via commit message** - We would rather handle these actions ourselves, especially for longer-running issues that may have many PRs submitting against them.
+
+## Running Tests
+
+Having installed all dependencies via `composer install`:
+
+``` bash
+$ ./vendor/bin/phpunit
+```
+
+## Credit
+
+This [CONTRIBUTING.md](CONTRIBUTING.md) format was graciously lifted from The PHP League's [example](https://github.com/thephpleague/skeleton/blob/master/CONTRIBUTING.md). Thanks!
+
+**Happy coding**!


### PR DESCRIPTION
We didn't have one and after grabbing (and whiffing) for one in our project was surprised when it wasn't there.

I lifted this one from The PHP League's skeleton project and made slight modifications in light of some of the conventions I've experienced contributing here. Please correct me if wrong about the last point to "not close issues with GitHub commit-message magic". I'm recollecting us not doing that but if inaccurate, let's remove.