### PR TITLE
Missing query alias

### DIFF
--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -162,7 +162,7 @@ class Talk extends Mapper
         }
 
         $talks = $this->query(
-            "SELECT t.*, SUM(m.rating) FROM talks t "
+            "SELECT t.*, SUM(m.rating) AS total_rating FROM talks t "
             . "LEFT JOIN talk_meta m ON t.id = m.talk_id "
             . "WHERE rating > 0 "
             . "GROUP BY m.`talk_id` "

--- a/classes/Http/Controller/Admin/ReviewController.php
+++ b/classes/Http/Controller/Admin/ReviewController.php
@@ -22,7 +22,7 @@ class ReviewController extends BaseController
         ];
 
         $per_page = (int) $req->get('per_page') ?: 20;
-        $talks = $mapper->getTopRatedByUserId($user->id, $options);
+        $talks = $mapper->getTopRatedByUserId($user->getId(), $options);
 
         // Set up our page stuff
         $adapter = new \Pagerfanta\Adapter\ArrayAdapter($talks);


### PR DESCRIPTION
The missing alias, total_rating, was causing an uncaught exception. I'm assuming this snuck it from an old version of the application.

Also, I added the use of getId instead of just the id property for consistency sake.