### PR TITLE
Fixes github issue #272: "bin/opencfp list" has inaccurate description for admin:promote

### DIFF
--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -23,7 +23,7 @@ class AdminPromoteCommand extends BaseCommand
             ->setDefinition([
                 new InputArgument('email', InputArgument::REQUIRED, 'Email address of user to promote to admin')
             ])
-            ->setDescription('Promote an existing (or new) user to be an admin')
+            ->setDescription('Promote an existing user to be an admin')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command promotes a user to the admin group for a given environment:
 


### PR DESCRIPTION
I fixed the issue in #272 by removing the "(or new)" parenthetical from the help text, so no future intrepid programmers will be tripped up by it again.