### PR TITLE
Re-adding Sorting and Rating UI

### DIFF
--- a/templates/admin/talks/_table.twig
+++ b/templates/admin/talks/_table.twig
@@ -1,12 +1,12 @@
 <table class="table table-striped">
     <thead>
         <tr>
-            <th align='left'><b><a href="/admin/talks?order_by=title">Title</a></b></th>
-            <th align='left'><b><a href="/admin/talks?order_by=type">Type</a></b></th>
-            <th align='left'><b><a href="/admin/talks?order_by=category">Category</a></b></th>
-            <th align='left'><b><a href="/admin/talks">Created On</a></b></th>
-            <th align='left'><b>Submitted by</b></th>
-            <th>&nbsp;</th>
+            <th width="45%" class="sort" data-field="title">Title</th>
+            <th width="7%" class="sort" data-field="type">Type</th>
+            <th width="8%" class="sort" data-field="category">Category</th>
+            <th width="20%" class="sort" data-field="created_at">Created On</th>
+            <th width="12%" class="sort" data-field="first_name">Submitted by</th>
+            <th width="8%">&nbsp;</th>
         </tr>
     </thead>
     <tbody>
@@ -15,7 +15,7 @@
                 <td><a href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a></td>
                 <td>{{ talk.type }}</td>
                 <td>{{ talk.category }}</td>
-                <td>{{ talk.created_at|date("F jS Y \\a\\t g:ia T") }}</td>
+                <td>{{ talk.created_at|date("M jS Y \\a\\t g:ia T") }}</td>
                 {% if false == talk.user %}
                 <td><em>Unknown User</em></td>
                 {% else %}

--- a/templates/admin/talks/_table.twig
+++ b/templates/admin/talks/_table.twig
@@ -22,8 +22,10 @@
                 <td><a href="{{ url('admin_speaker_view', { id: talk.user.id }) }}">{{ talk.user.first_name }} {{ talk.user.last_name }}</a></td>
                 {% endif %}
                 <td>
-                    <a href="#" id="talk-favorite-{{ talk.id }}" class="js-talk-favorite" data-id="{{ talk.id }}"><i class="fa fa-star star-favorite{% if talk.favorite == 1 %} star-favorite--selected{% endif %}"></i></a>
-                    <a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}"><i class="fa fa-check-square check-select{% if talk.selected == 1 %} check-select--selected{% endif %}"></i></a>
+                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1"><i class="fa fa-thumbs-up admin-icon{% if talk.meta.rating == 1 %} admin-icon--selected{% endif %}"></i></a>
+                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1"><i class="fa fa-thumbs-down admin-icon{% if talk.meta.rating == -1 %} admin-icon--selected{% endif %}"></i></a>
+                    <a href="#" id="talk-favorite-{{ talk.id }}" class="js-talk-favorite" data-id="{{ talk.id }}"><i class="fa fa-star admin-icon{% if talk.favorite == 1 %} admin-icon--selected{% endif %}"></i></a>
+                    <a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}"><i class="fa fa-check-square admin-icon{% if talk.selected == 1 %} admin-icon--selected{% endif %}"></i></a>
                 </td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
Per issue: https://github.com/opencfp/opencfp/issues/285

Sorting UI was removed and a different one added instead. I don't believe this was done on purpose, but merely product of an older version of OpenCFP being worked on. This PR re-adds the sort UI that has sort direction arrows.

Also, the up and down vote rating icons are being re-added in this PR.