### PR TITLE
Fix: Use a whitelist filter instead of blacklisting

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,10 +10,9 @@
          processIsolation="false"
          stopOnFailure="false">
     <filter>
-        <blacklist>
-            <directory>vendor</directory>
-            <directory>classes/OpenCFP/Provider</directory>
-        </blacklist>
+        <whitelist>
+            <directory>classes</directory>
+        </whitelist>
     </filter>
 
     <testsuites>


### PR DESCRIPTION
This PR

* [x] uses a whitelist filter instead of a blacklist filter when collecting coverage

See https://travis-ci.org/opencfp/opencfp/jobs/97889795#L493-L495:

```
Runtime:	PHP 5.5.21 with Xdebug 2.2.7
Configuration:	/home/travis/build/opencfp/opencfp/phpunit.xml.dist
Warning:	No whitelist configured for code coverage
```