### PR TITLE
Fix: Run php-cs-fixer on PHP5.6 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,16 @@ language: php
 
 sudo: false
 
-php:
-  - 7.0
-  - 5.6
-  - 5.5
+matrix:
+  include:
+    - php: 7.0
+    - php: 5.6
+      env: WITH_CS=true
+    - php: 5.5
 
 env:
-  - TRAVIS_DB=cfp_travis
+  global:
+    - TRAVIS_DB=cfp_travis
 
 # cache composer downloads so installing is quicker
 cache:
@@ -33,7 +36,7 @@ before_script:
 
 script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-  - vendor/bin/php-cs-fixer fix --verbose
+  - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --verbose; fi
 
 after_script:
   - vendor/bin/test-reporter --stdout > codeclimate.json


### PR DESCRIPTION
This PR

* [x] runs `php-cs-fixer` on PHP5.6 only

Related to #288.