### PR TITLE
Fix: Do not bother reporting coverage if the build failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
   - vendor/bin/php-cs-fixer fix --verbose
 
-after_script:
+after_success:
   - vendor/bin/test-reporter --stdout > codeclimate.json
   - "curl -X POST -d @codeclimate.json -H 'Content-Type: application/json' -H 'User-Agent: Code Climate (PHP Test Reporter v0.1.1)' https://codeclimate.com/test_reports"


### PR DESCRIPTION
This PR

* [x] moves coverage reporting to the `after_success` section

Related to #288.

:information_desk_person: There's no use for reporting coverage if the build failed, eh?

For reference, see https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle.