### PR TITLE
Fix: Use class keyword

### DIFF
--- a/classes/Domain/Entity/Favorite.php
+++ b/classes/Domain/Entity/Favorite.php
@@ -21,7 +21,7 @@ class Favorite extends Entity
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'talk' => $mapper->belongsTo($entity, 'OpenCFP\Domain\Entity\Talk', 'talk_id'),
+            'talk' => $mapper->belongsTo($entity, \OpenCFP\Domain\Entity\Talk::class, 'talk_id'),
         ];
     }
 }

--- a/classes/Domain/Entity/Group.php
+++ b/classes/Domain/Entity/Group.php
@@ -22,7 +22,7 @@ class Group extends Entity
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'users' => $mapper->hasManyThrough($entity, 'OpenCFP\Domain\Entity\User', 'OpenCFP\Domain\Entity\UserGroup', 'user_id', 'group_id'),
+            'users' => $mapper->hasManyThrough($entity, \OpenCFP\Domain\Entity\User::class, \OpenCFP\Domain\Entity\UserGroup::class, 'user_id', 'group_id'),
         ];
     }
 }

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -389,7 +389,7 @@ class Talk extends Mapper
             }
         }
 
-        $mapper = $this->getMapper('OpenCFP\Domain\Entity\TalkMeta');
+        $mapper = $this->getMapper(\OpenCFP\Domain\Entity\TalkMeta::class);
         $talk_meta = $mapper->where(['talk_id' => $talk->id, 'admin_user_id' => $admin_user_id])
             ->first();
 

--- a/classes/Domain/Entity/Talk.php
+++ b/classes/Domain/Entity/Talk.php
@@ -7,7 +7,7 @@ use Spot\Entity;
 class Talk extends Entity
 {
     protected static $table = 'talks';
-    protected static $mapper = 'OpenCFP\Domain\Entity\Mapper\Talk';
+    protected static $mapper = \OpenCFP\Domain\Entity\Mapper\Talk::class;
 
     public static function fields()
     {
@@ -32,11 +32,11 @@ class Talk extends Entity
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'speaker' => $mapper->belongsTo($entity, 'OpenCFP\Domain\Entity\User', 'user_id'),
-            'favorites' => $mapper->hasMany($entity, 'OpenCFP\Domain\Entity\Favorite', 'talk_id'),
-            'comments' => $mapper->hasMany($entity, 'OpenCFP\Domain\Entity\TalkComment', 'talk_id')
+            'speaker' => $mapper->belongsTo($entity, \OpenCFP\Domain\Entity\User::class, 'user_id'),
+            'favorites' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\Favorite::class, 'talk_id'),
+            'comments' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\TalkComment::class, 'talk_id')
                 ->order(['created' => 'ASC']),
-            'meta' => $mapper->hasMany($entity, 'OpenCFP\Domain\Entity\TalkMeta', 'talk_id'),
+            'meta' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\TalkMeta::class, 'talk_id'),
         ];
     }
 

--- a/classes/Domain/Entity/TalkComment.php
+++ b/classes/Domain/Entity/TalkComment.php
@@ -20,8 +20,8 @@ class TalkComment extends \Spot\Entity
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'talk' => $mapper->belongsTo($entity, 'OpenCFP\Domain\Entity\Talk', 'talk_id'),
-            'user' => $mapper->belongsTo($entity, 'OpenCFP\Domain\Entity\User', 'user_id'),
+            'talk' => $mapper->belongsTo($entity, \OpenCFP\Domain\Entity\Talk::class, 'talk_id'),
+            'user' => $mapper->belongsTo($entity, \OpenCFP\Domain\Entity\User::class, 'user_id'),
         ];
     }
 }

--- a/classes/Domain/Entity/TalkMeta.php
+++ b/classes/Domain/Entity/TalkMeta.php
@@ -21,7 +21,7 @@ class TalkMeta extends \Spot\Entity
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'talk' => $mapper->belongsTo($entity, 'OpenCFP\Domain\Entity\Talk', 'talk_id'),
+            'talk' => $mapper->belongsTo($entity, \OpenCFP\Domain\Entity\Talk::class, 'talk_id'),
         ];
     }
 }

--- a/classes/Domain/Entity/User.php
+++ b/classes/Domain/Entity/User.php
@@ -7,7 +7,7 @@ use Spot\Entity;
 class User extends Entity
 {
     protected static $table = 'users';
-    protected static $mapper = 'OpenCFP\Domain\Entity\Mapper\User';
+    protected static $mapper = \OpenCFP\Domain\Entity\Mapper\User::class;
 
     public static function fields()
     {
@@ -40,9 +40,9 @@ class User extends Entity
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'talks' => $mapper->hasMany($entity, 'OpenCFP\Domain\Entity\Talk', 'user_id'),
-            'groups' => $mapper->hasManyThrough($entity, 'OpenCFP\Domain\Entity\Group', '\OpenCFP\Domain\Entity\UserGroup', 'group_id', 'user_id'),
-            'comments' => $mapper->hasMany($entity, 'OpenCFP\Domain\Entity\TalkComment', 'user_id'),
+            'talks' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\Talk::class, 'user_id'),
+            'groups' => $mapper->hasManyThrough($entity, \OpenCFP\Domain\Entity\Group::class, \OpenCFP\Domain\Entity\UserGroup::class, 'group_id', 'user_id'),
+            'comments' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\TalkComment::class, 'user_id'),
         ];
     }
 

--- a/classes/Domain/OAuth/Client.php
+++ b/classes/Domain/OAuth/Client.php
@@ -22,7 +22,7 @@ class Client extends Entity
     public static function relations(MapperInterface $mapper, EntityInterface $entity)
     {
         return [
-            'endpoints' => $mapper->hasMany($entity, 'OpenCFP\Domain\OAuth\Endpoint', 'client_id'),
+            'endpoints' => $mapper->hasMany($entity, \OpenCFP\Domain\OAuth\Endpoint::class, 'client_id'),
         ];
     }
 

--- a/classes/Http/Controller/Admin/AdminsController.php
+++ b/classes/Http/Controller/Admin/AdminsController.php
@@ -59,7 +59,7 @@ class AdminsController extends BaseController
             return $this->redirectTo('admin_admins');
         }
 
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\User');
+        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
         $user_data = $mapper->get($req->get('id'))->toArray();
         $user = $this->app['sentry']->getUserProvider()->findByLogin($user_data['email']);
 

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -11,11 +11,11 @@ class DashboardController extends BaseController
 
     public function indexAction(Request $req)
     {
-        $user_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\User');
+        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker_total = $user_mapper->all()->count();
 
-        $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
-        $favorite_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Favorite');
+        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $favorite_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
         $recent_talks = $talk_mapper->getRecent($this->app['sentry']->getUser()->getId());
 
         $templateData = [

--- a/classes/Http/Controller/Admin/ReviewController.php
+++ b/classes/Http/Controller/Admin/ReviewController.php
@@ -15,7 +15,7 @@ class ReviewController extends BaseController
         $user = $this->app['sentry']->getUser();
 
         // Get list of talks where majority of admins 'favorited' them
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $options = [
             'order_by' => $req->get('order_by'),
             'sort' => $req->get('sort'),

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -18,7 +18,7 @@ class SpeakersController extends BaseController
     public function indexAction(Request $req)
     {
         $rawSpeakers = $this->app['spot']
-            ->mapper('OpenCFP\Domain\Entity\User')
+            ->mapper(\OpenCFP\Domain\Entity\User::class)
             ->all()
             ->order(['first_name' => 'ASC'])
             ->toArray();
@@ -64,7 +64,7 @@ class SpeakersController extends BaseController
         }
 
         // Get info about the speaker
-        $user_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\User');
+        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker_details = $user_mapper->get($req->get('id'));
 
         if (empty($speaker_details)) {
@@ -78,7 +78,7 @@ class SpeakersController extends BaseController
         }
 
         // Get info about the talks
-        $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talks = $talk_mapper->getByUser($req->get('id'))->toArray();
 
         // Build and render the template
@@ -102,7 +102,7 @@ class SpeakersController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\User');
+        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker = $mapper->get($req->get('id'));
         $response = $mapper->delete($speaker);
 

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -72,7 +72,7 @@ class TalksController extends BaseController
 
     private function getFilteredTalks($filter = null, $admin_user_id, $options = [])
     {
-        $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         if ($filter === null) {
             return $talk_mapper->getAllPagerFormatted($admin_user_id, $options);
         }
@@ -114,8 +114,8 @@ class TalksController extends BaseController
         }
 
         // Get info about the talks
-        $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
-        $meta_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\TalkMeta');
+        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $meta_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
         $talk_id = $req->get('id');
 
         $talk = $talk_mapper->where(['id' => $talk_id])
@@ -155,7 +155,7 @@ class TalksController extends BaseController
             ->toArray();
 
         // Get info about our speaker
-        $user_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\User');
+        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker = $user_mapper->get($talk->user_id)->toArray();
 
         // Grab all the other talks and filter out the one we have
@@ -185,7 +185,7 @@ class TalksController extends BaseController
         }
 
         $admin_user_id = (int)$this->app['sentry']->getUser()->getId();
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\TalkMeta');
+        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
 
         $talk_rating = (int)$req->get('rating');
         $talk_id = (int)$req->get('id');
@@ -232,7 +232,7 @@ class TalksController extends BaseController
             $status = false;
         }
 
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Favorite');
+        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
 
         if ($status == false) {
             // Delete the record that matches
@@ -278,7 +278,7 @@ class TalksController extends BaseController
             $status = false;
         }
 
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk = $mapper->get($req->get('id'));
         $talk->selected = $status;
         $mapper->save($talk);
@@ -295,7 +295,7 @@ class TalksController extends BaseController
         $talk_id = (int)$req->get('id');
         $admin_user_id = (int)$this->app['sentry']->getUser()->getId();
 
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\TalkComment');
+        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\TalkComment::class);
         $comment = $mapper->get();
 
         $comment->talk_id = $talk_id;

--- a/classes/Http/Controller/PagesController.php
+++ b/classes/Http/Controller/PagesController.php
@@ -21,7 +21,7 @@ class PagesController extends BaseController
 
     private function getContextWithTalksCount()
     {
-        $numberOfTalks = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk')->all()->count();
+        $numberOfTalks = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class)->all()->count();
 
         return [
             'number_of_talks' => $numberOfTalks,

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -90,7 +90,7 @@ class TalkController extends BaseController
 
         $user = $this->app['sentry']->getUser();
 
-        $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk_info = $talk_mapper->get($talk_id)->toArray();
 
         if ($talk_info['user_id'] !== (int) $user->getId()) {
@@ -213,7 +213,7 @@ class TalkController extends BaseController
                 'user_id' => (int) $user->getId(),
             ];
 
-            $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+            $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
             $talk = $talk_mapper->create($data);
 
             $this->app['session']->set('flash', [
@@ -297,7 +297,7 @@ class TalkController extends BaseController
                 'user_id' => (int) $user->getId(),
             ];
 
-            $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+            $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
             $talk = $mapper->get($data['id']);
 
             foreach ($data as $field => $value) {
@@ -355,7 +355,7 @@ class TalkController extends BaseController
         }
 
         $user = $app['sentry']->getUser();
-        $talk_mapper = $app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $talk_mapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk = $talk_mapper->get($req->get('tid'));
 
         if ($talk->user_id !== (int) $user->getId()) {
@@ -377,7 +377,7 @@ class TalkController extends BaseController
      */
     protected function sendSubmitEmail(Application $app, $email, $talk_id)
     {
-        $mapper = $app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $mapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk = $mapper->get($talk_id);
 
         // Build our email that we will send

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -27,8 +27,8 @@ class ApplicationServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['application.speakers'] = $app->share(function ($app) {
-            $userMapper = $app['spot']->mapper('OpenCFP\Domain\Entity\User');
-            $talkMapper = $app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+            $userMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+            $talkMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
             $speakerRepository = new SpotSpeakerRepository($userMapper);
 
             return new Speakers(
@@ -61,8 +61,8 @@ class ApplicationServiceProvider implements ServiceProviderInterface
         });
 
         $app['application.speakers.api'] = $app->share(function ($app) {
-            $userMapper = $app['spot']->mapper('OpenCFP\Domain\Entity\User');
-            $talkMapper = $app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+            $userMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+            $talkMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
             $speakerRepository = new SpotSpeakerRepository($userMapper);
 
             return new Speakers(

--- a/classes/Provider/Gateways/OAuthGatewayProvider.php
+++ b/classes/Provider/Gateways/OAuthGatewayProvider.php
@@ -24,7 +24,7 @@ class OAuthGatewayProvider implements ServiceProviderInterface
             $server->addGrantType(new AuthCodeGrant);
             $server->addGrantType(new RefreshTokenGrant);
 
-            $userMapper = $app['spot']->mapper('OpenCFP\Domain\Entity\User');
+            $userMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
             $speakerRepository = new SpotSpeakerRepository($userMapper);
 
             $controller = new AuthorizationController($server, new SentryIdentityProvider($app['sentry'], $speakerRepository));
@@ -35,8 +35,8 @@ class OAuthGatewayProvider implements ServiceProviderInterface
 
         $app['controller.oauth.clients'] = $app->share(function ($app) {
             return new ClientRegistrationController(
-            $app['spot']->mapper('OpenCFP\Domain\OAuth\Client'),
-            $app['spot']->mapper('OpenCFP\Domain\OAuth\Endpoint'),
+            $app['spot']->mapper(\OpenCFP\Domain\OAuth\Client::class),
+            $app['spot']->mapper(\OpenCFP\Domain\OAuth\Endpoint::class),
             $app['security.random']
             );
         });

--- a/tests/OpenCFP/Application/SpeakersTest.php
+++ b/tests/OpenCFP/Application/SpeakersTest.php
@@ -39,11 +39,11 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->identityProvider = m::mock('OpenCFP\Domain\Services\IdentityProvider');
-        $this->speakerRepository = m::mock('OpenCFP\Domain\Speaker\SpeakerRepository');
-        $this->talkRepository = m::mock('OpenCFP\Domain\Talk\TalkRepository');
-        $this->callForProposal = m::mock('OpenCFP\Domain\CallForProposal');
-        $this->dispatcher = m::mock('OpenCFP\Domain\Services\EventDispatcher');
+        $this->identityProvider = m::mock(\OpenCFP\Domain\Services\IdentityProvider::class);
+        $this->speakerRepository = m::mock(\OpenCFP\Domain\Speaker\SpeakerRepository::class);
+        $this->talkRepository = m::mock(\OpenCFP\Domain\Talk\TalkRepository::class);
+        $this->callForProposal = m::mock(\OpenCFP\Domain\CallForProposal::class);
+        $this->dispatcher = m::mock(\OpenCFP\Domain\Services\EventDispatcher::class);
 
         $this->sut = new Speakers($this->callForProposal, $this->identityProvider, $this->speakerRepository, $this->talkRepository, $this->dispatcher);
     }
@@ -66,7 +66,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
 
         $profile = $this->sut->findProfile();
 
-        $this->assertInstanceOf('OpenCFP\Domain\Speaker\SpeakerProfile', $profile);
+        $this->assertInstanceOf(\OpenCFP\Domain\Speaker\SpeakerProfile::class, $profile);
         $this->assertEquals($speaker->email, $profile->getEmail());
         $this->assertEquals($speaker->first_name . ' ' . $speaker->last_name, $profile->getName());
     }
@@ -76,7 +76,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
     {
         $this->trainStudentRepositoryToThrowEntityNotFoundException();
 
-        $this->setExpectedException('OpenCFP\Domain\EntityNotFoundException');
+        $this->setExpectedException(\OpenCFP\Domain\EntityNotFoundException::class);
         $this->sut->findProfile();
     }
 
@@ -97,7 +97,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
         // something screwy attempting to get a talk they should be able to.
         $this->trainIdentityProviderToReturnSampleSpeaker($this->getSpeakerWithNoTalks());
 
-        $this->setExpectedException('OpenCFP\Application\NotAuthorizedException');
+        $this->setExpectedException(\OpenCFP\Application\NotAuthorizedException::class);
         $this->sut->getTalk(1);
     }
 
@@ -120,7 +120,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
     {
         $this->trainIdentityProviderToReturnSampleSpeaker($this->getSpeakerFromMisbehavingSpot());
 
-        $this->setExpectedException('OpenCFP\Application\NotAuthorizedException');
+        $this->setExpectedException(\OpenCFP\Application\NotAuthorizedException::class);
         $this->sut->getTalk(1);
     }
 
@@ -140,11 +140,11 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
             ->andReturn($this->getSpeaker());
 
         $this->talkRepository->shouldReceive('persist')
-            ->with(m::type('OpenCFP\Domain\Entity\Talk'))
+            ->with(m::type(\OpenCFP\Domain\Entity\Talk::class))
             ->once();
 
         $this->dispatcher->shouldReceive('dispatch')
-            ->with('opencfp.talk.submit', m::type('OpenCFP\Domain\Talk\TalkWasSubmitted'))
+            ->with('opencfp.talk.submit', m::type(\OpenCFP\Domain\Talk\TalkWasSubmitted::class))
             ->once();
 
         $submission = TalkSubmission::fromNative([
@@ -197,7 +197,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
     private function trainStudentRepositoryToThrowEntityNotFoundException()
     {
         $this->identityProvider->shouldReceive('getCurrentUser')
-            ->andThrow('OpenCFP\Domain\EntityNotFoundException');
+            ->andThrow(\OpenCFP\Domain\EntityNotFoundException::class);
     }
 
     private function getSpeaker()

--- a/tests/OpenCFP/Domain/Entity/FavoriteTest.php
+++ b/tests/OpenCFP/Domain/Entity/FavoriteTest.php
@@ -18,11 +18,11 @@ class FavoriteEntityTest extends \PHPUnit_Framework_TestCase
             'driver' => 'pdo_sqlite',
         ]);
         $this->app['spot'] = new \Spot\Locator($cfg);
-        $this->mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Favorite');
+        $this->mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
         $this->mapper->migrate();
 
         // Create a talk
-        $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $data = [
             'title' => 'Favorite Entity Test',
             'description' => 'This is a stubbed talk for a Favorite Entity Test',

--- a/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
@@ -17,7 +17,7 @@ class TalkMapperTest extends \PHPUnit_Framework_TestCase
             'driver' => 'pdo_sqlite',
         ]);
         $this->app['spot'] = new \Spot\Locator($cfg);
-        $this->mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $this->mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
 
         foreach ($this->entities as $entity) {
             $this->app['spot']->mapper('OpenCFP\Domain\Entity\\' . $entity)->migrate();
@@ -32,7 +32,7 @@ class TalkMapperTest extends \PHPUnit_Framework_TestCase
         // Create a test talk
         $admin_user_id = 1;
         $admin_majority = 3;
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
 
         $talk_data = [
             'title' => 'Admin Favorite Talk',
@@ -58,7 +58,7 @@ class TalkMapperTest extends \PHPUnit_Framework_TestCase
 
     private function createViewedTalks($talk_data, $total)
     {
-        $meta_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\TalkMeta');
+        $meta_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
         for ($i = 0; $i <= $total; $i++) {
             $talk = $this->mapper->create($talk_data);
             $meta_mapper->create([
@@ -72,7 +72,7 @@ class TalkMapperTest extends \PHPUnit_Framework_TestCase
     private function createAdminFavoredTalks($admin_user_id, $admin_majority, $talk)
     {
         // Create a test user
-        $user_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\User');
+        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
         $user_mapper->create([
             'id' => $admin_user_id,
             'email' => 'test@test.com',
@@ -82,7 +82,7 @@ class TalkMapperTest extends \PHPUnit_Framework_TestCase
         ]);
 
         // Create $admin_majority favorite records linked to that talk
-        $favorite_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Favorite');
+        $favorite_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
         $favorite_mapper->create(['admin_user_id' => $admin_user_id, 'talk_id' => $talk->id]);
 
         for ($x = 1; $x <= $admin_majority; $x++) {

--- a/tests/OpenCFP/Domain/Entity/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/TalkTest.php
@@ -18,7 +18,7 @@ class TalkEntityTest extends \PHPUnit_Framework_TestCase
         ]);
         $this->app['spot'] = new \Spot\Locator($cfg);
 
-        $this->mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $this->mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
 
         foreach ($this->entities as $entity) {
             $this->app['spot']->mapper('OpenCFP\Domain\Entity\\' . $entity)->migrate();
@@ -51,11 +51,11 @@ class TalkEntityTest extends \PHPUnit_Framework_TestCase
     public function getRecentFindsMostRecentTalks()
     {
         // Create a favorites table, can be empty
-        $favorite_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Favorite');
+        $favorite_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
         $favorite_mapper->migrate();
 
         // Create users entity
-        $user_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\User');
+        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
         $user_mapper->migrate();
 
         // Create 11 talks

--- a/tests/OpenCFP/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/OpenCFP/Domain/Talk/TalkSubmissionTest.php
@@ -37,7 +37,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
      */
     public function it_guards_that_title_is_appropriate_length($title)
     {
-        $this->setExpectedException('OpenCFP\Domain\Talk\InvalidTalkSubmissionException', 'title');
+        $this->setExpectedException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class, 'title');
         TalkSubmission::fromNative(['title' => $title]);
     }
 
@@ -52,7 +52,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_guards_that_description_is_provided()
     {
-        $this->setExpectedException('OpenCFP\Domain\Talk\InvalidTalkSubmissionException', 'description');
+        $this->setExpectedException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class, 'description');
         TalkSubmission::fromNative([
             'title' => 'Talk With No Description',
             'description' => '',
@@ -62,7 +62,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_guards_that_invalid_talk_types_cannot_be_used()
     {
-        $this->setExpectedException('OpenCFP\Domain\Talk\InvalidTalkSubmissionException', 'talk type');
+        $this->setExpectedException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class, 'talk type');
         TalkSubmission::fromNative([
             'title' => 'Some off-the-wall Talk Type',
             'description' => 'I do not play by the rules.',
@@ -73,7 +73,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_guards_that_invalid_level_cannot_be_used()
     {
-        $this->setExpectedException('OpenCFP\Domain\Talk\InvalidTalkSubmissionException', 'level');
+        $this->setExpectedException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class, 'level');
         TalkSubmission::fromNative([
             'title' => 'Invalid Skill Level Talk',
             'description' => 'I do not play by the rules.',
@@ -85,7 +85,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_guards_that_invalid_categories_cannot_be_assigned()
     {
-        $this->setExpectedException('OpenCFP\Domain\Talk\InvalidTalkSubmissionException', 'category');
+        $this->setExpectedException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class, 'category');
         TalkSubmission::fromNative([
             'title' => 'Invalid Categorized Talk',
             'description' => 'I do not play by the rules.',

--- a/tests/OpenCFP/EnvironmentTest.php
+++ b/tests/OpenCFP/EnvironmentTest.php
@@ -8,7 +8,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_encapsulate_valid_environments()
     {
-        $this->assertInstanceOf('OpenCFP\Environment', Environment::production());
+        $this->assertInstanceOf(\OpenCFP\Environment::class, Environment::production());
 
         $this->assertEquals('production', Environment::production());
         $this->assertEquals('development', Environment::development());

--- a/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
@@ -22,7 +22,7 @@ class ProfileApiControllerTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->speakers = m::mock('OpenCFP\Application\Speakers');
+        $this->speakers = m::mock(\OpenCFP\Application\Speakers::class);
         $this->sut = new ProfileController($this->speakers);
     }
 
@@ -42,7 +42,7 @@ class ProfileApiControllerTest extends PHPUnit_Framework_TestCase
     public function it_responds_unauthorized_when_no_authentication_provided()
     {
         $this->speakers->shouldReceive('findProfile')
-            ->andThrow('OpenCFP\Domain\Services\NotAuthenticatedException');
+            ->andThrow(\OpenCFP\Domain\Services\NotAuthenticatedException::class);
 
         $response = $this->sut->handleShowSpeakerProfile($this->getRequest());
 

--- a/tests/OpenCFP/Http/API/TalkApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/TalkApiControllerTest.php
@@ -22,7 +22,7 @@ class TalkApiControllerTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->speakers = m::mock('OpenCFP\Application\Speakers');
+        $this->speakers = m::mock(\OpenCFP\Application\Speakers::class);
         $this->sut = new TalkController($this->speakers);
     }
 
@@ -39,7 +39,7 @@ class TalkApiControllerTest extends PHPUnit_Framework_TestCase
 
         $this->speakers->shouldReceive('submitTalk')
             ->once()
-            ->with(m::type('OpenCFP\Domain\Talk\TalkSubmission'))
+            ->with(m::type(\OpenCFP\Domain\Talk\TalkSubmission::class))
             ->andReturn($talk);
 
         $response = $this->sut->handleSubmitTalk($request);
@@ -65,7 +65,7 @@ class TalkApiControllerTest extends PHPUnit_Framework_TestCase
         $request = $this->getValidRequest();
 
         $this->speakers->shouldReceive('submitTalk')
-            ->andThrow('OpenCFP\Domain\Services\NotAuthenticatedException');
+            ->andThrow(\OpenCFP\Domain\Services\NotAuthenticatedException::class);
 
         $response = $this->sut->handleSubmitTalk($request);
 
@@ -89,7 +89,7 @@ class TalkApiControllerTest extends PHPUnit_Framework_TestCase
     public function it_responds_unauthorized_when_viewing_single_talk_while_not_authenticated()
     {
         $this->speakers->shouldReceive('getTalk')
-        ->andThrow('OpenCFP\Domain\Services\NotAuthenticatedException');
+        ->andThrow(\OpenCFP\Domain\Services\NotAuthenticatedException::class);
 
         $response = $this->sut->handleViewTalk($this->getValidRequest(), 1);
 
@@ -118,7 +118,7 @@ class TalkApiControllerTest extends PHPUnit_Framework_TestCase
     public function it_should_respond_unauthorized_when_no_authentication_provided()
     {
         $this->speakers->shouldReceive('getTalks')
-            ->andThrow('OpenCFP\Domain\Services\NotAuthenticatedException');
+            ->andThrow(\OpenCFP\Domain\Services\NotAuthenticatedException::class);
 
         $response = $this->sut->handleViewAllTalks($this->getValidRequest());
 

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
@@ -92,7 +92,7 @@ class AdminAccessTraitTest extends \PHPUnit_Framework_TestCase
      */
     private function getApplicationMock(array $items = [])
     {
-        $application = $this->getMockBuilder('OpenCFP\Application')
+        $application = $this->getMockBuilder(\OpenCFP\Application::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;

--- a/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
@@ -17,7 +17,7 @@ class SpeakersControllerTest extends \PHPUnit_Framework_TestCase
         $this->app = new Application(BASE_PATH, Environment::testing());
 
         // Create a test double for our User entity
-        $user = m::mock('OpenCFP\Domain\Entity\User');
+        $user = m::mock(\OpenCFP\Domain\Entity\User::class);
         $user->shouldReceive('hasPermission')->with('admin')->andReturn(true);
         $user->shouldReceive('getId')->andReturn(1);
         $user->shouldReceive('hasAccess')->with('admin')->andReturn(true);
@@ -41,12 +41,12 @@ class SpeakersControllerTest extends \PHPUnit_Framework_TestCase
 
         // Override our mapper with the double
         $spot = m::mock('Spot\Locator');
-        $mapper = m::mock('OpenCFP\Domain\Entity\Mapper\User');
+        $mapper = m::mock(\OpenCFP\Domain\Entity\Mapper\User::class);
         $mapper->shouldReceive('get')
             ->andReturn([]);
 
         $spot->shouldReceive('mapper')
-            ->with('OpenCFP\Domain\Entity\User')
+            ->with(\OpenCFP\Domain\Entity\User::class)
             ->andReturn($mapper);
         $this->app['spot'] = $spot;
 

--- a/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
+++ b/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
@@ -17,7 +17,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $this->app = new Application(BASE_PATH, Environment::testing());
 
         // Create a test double for our User entity
-        $user = m::mock('OpenCFP\Domain\Entity\User');
+        $user = m::mock(\OpenCFP\Domain\Entity\User::class);
         $user->shouldReceive('hasPermission')->with('admin')->andReturn(true);
         $user->shouldReceive('getId')->andReturn(1);
         $user->shouldReceive('hasAccess')->with('admin')->andReturn(true);
@@ -41,7 +41,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $userId = $this->app['user']->getId();
 
         // Create our fake talk
-        $talk = m::mock('OpenCFP\Domain\Entity\Talk');
+        $talk = m::mock(\OpenCFP\Domain\Entity\Talk::class);
         $talk->shouldReceive('save');
         $talk->shouldReceive('set')
             ->with($this->app['user'])
@@ -69,12 +69,12 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
             'favorite' => null,
             'selected' => null,
         ]];
-        $userMapper = m::mock('OpenCFP\Domain\Entity\Mapper\User');
+        $userMapper = m::mock(\OpenCFP\Domain\Entity\Mapper\User::class);
         $userMapper->shouldReceive('migrate');
         $userMapper->shouldReceive('build')->andReturn($this->app['user']);
         $userMapper->shouldReceive('save')->andReturn(true);
 
-        $talkMapper = m::mock('OpenCFP\Domain\Entity\Mapper\Talk');
+        $talkMapper = m::mock(\OpenCFP\Domain\Entity\Mapper\Talk::class);
         $talkMapper->shouldReceive('migrate');
         $talkMapper->shouldReceive('build')->andReturn($talk);
         $talkMapper->shouldReceive('save');
@@ -83,10 +83,10 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         // Overide our DB mappers to return doubles
         $spot = m::mock('Spot\Locator');
         $spot->shouldReceive('mapper')
-            ->with('OpenCFP\Domain\Entity\User')
+            ->with(\OpenCFP\Domain\Entity\User::class)
             ->andReturn($userMapper);
         $spot->shouldReceive('mapper')
-            ->with('OpenCFP\Domain\Entity\Talk')
+            ->with(\OpenCFP\Domain\Entity\Talk::class)
             ->andReturn($talkMapper);
         $this->app['spot'] = $spot;
 
@@ -139,7 +139,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $comment = 'Test Comment';
 
         // Create a TalkComment and mapper, then add the mapper to $app
-        $talkComment = m::mock('OpenCFP\Domain\Entity\TalkComment');
+        $talkComment = m::mock(\OpenCFP\Domain\Entity\TalkComment::class);
         $talkComment->shouldReceive('set')
             ->andSet('talk_id', $talkId);
         $talkComment->shouldReceive('set')
@@ -147,14 +147,14 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $talkComment->shouldReceive('set')
             ->andSet('user_id', uniqid());
 
-        $talkCommentMapper = m::mock('OpenCFP\Domain\Entity\Mapper\TalkComment');
+        $talkCommentMapper = m::mock(\OpenCFP\Domain\Entity\Mapper\TalkComment::class);
         $talkCommentMapper->shouldReceive('get')->andReturn($talkComment);
         $talkCommentMapper->shouldReceive('save');
 
         // Override our mapper with the double
         $spot = m::mock('Spot\Locator');
         $spot->shouldReceive('mapper')
-            ->with('OpenCFP\Domain\Entity\TalkComment')
+            ->with(\OpenCFP\Domain\Entity\TalkComment::class)
             ->andReturn($talkCommentMapper);
         $this->app['spot'] = $spot;
 
@@ -194,7 +194,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         // Override our mapper with the double
         $spot = m::mock('Spot\Locator');
         $spot->shouldReceive('mapper')
-            ->with('OpenCFP\Domain\Entity\Talk')
+            ->with(\OpenCFP\Domain\Entity\Talk::class)
             ->andReturn([]);
         $this->app['spot'] = $spot;
 

--- a/tests/OpenCFP/Http/Controller/FlashableTraitTest.php
+++ b/tests/OpenCFP/Http/Controller/FlashableTraitTest.php
@@ -66,7 +66,7 @@ class FlashableTraitTest extends \PHPUnit_Framework_TestCase
      */
     private function getApplicationMock(array $items = [])
     {
-        $application = $this->getMockBuilder('OpenCFP\Application')
+        $application = $this->getMockBuilder(\OpenCFP\Application::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;

--- a/tests/unit/controllers/SignupControllerTest.php
+++ b/tests/unit/controllers/SignupControllerTest.php
@@ -10,7 +10,7 @@ class SignupControllerTest extends PHPUnit_Framework_TestCase
      */
     public function signupWithValidInfoWorks()
     {
-        $app = m::mock('OpenCFP\Application');
+        $app = m::mock(\OpenCFP\Application::class);
         $app->shouldReceive('redirect');
 
         // Create a session
@@ -47,7 +47,7 @@ class SignupControllerTest extends PHPUnit_Framework_TestCase
 
         // Create a pretend Sentry object that says everything is cool
         $sentry = m::mock('stdClass');
-        $user = m::mock('OpenCFP\Domain\Entity\User');
+        $user = m::mock(\OpenCFP\Domain\Entity\User::class);
         $user->shouldReceive('set');
         $user->shouldReceive('addGroup');
         $user->shouldReceive('relation');

--- a/tests/unit/controllers/TalkControllerTest.php
+++ b/tests/unit/controllers/TalkControllerTest.php
@@ -25,7 +25,7 @@ class TalkControllerTest extends PHPUnit_Framework_TestCase
         $this->app['spot'] = new \Spot\Locator($cfg);
 
         // Initialize the talk table in the sqlite database
-        $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk_mapper->migrate();
 
         // Set things up so Sentry believes we're logged in


### PR DESCRIPTION
This PR

* [x] makes use of the `class` keyword instead of using string literals to reference FQCNs

Follows https://github.com/opencfp/opencfp/pull/270.

:information_desk_person: Makes sense since we've dropped support for PHP5.4, doesn't it?