### PR TITLE
Fix: Use short array syntax

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,6 +9,7 @@ return Symfony\CS\Config\Config::create()
     ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
     ->fixers([
         '-psr0',
+        'short_array_syntax',
     ])
     ->finder($finder)
 ;

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -42,7 +42,7 @@ class Talk extends Mapper
         $talks = $this->all()
             ->order([$options['order_by'] => $options['sort']])
             ->with(['favorites', 'comments']);
-        $formatted = array();
+        $formatted = [];
 
         foreach ($talks as $talk) {
             $formatted[] = $this->createdFormattedOutput($talk, $admin_user_id);

--- a/classes/Domain/Services/Login.php
+++ b/classes/Domain/Services/Login.php
@@ -25,10 +25,10 @@ class Login
 
         try {
             $this->sentry->authenticate(
-                array(
+                [
                     'email'=>$user,
                     'password'=>$password,
-                ),
+                ],
                 false
             );
         } catch (UserNotFoundException $e) {
@@ -46,7 +46,7 @@ class Login
 
     public function getViewVariables()
     {
-        $variables = array();
+        $variables = [];
         if (isset($_REQUEST['email']) && (isset($_REQUEST['passwd']))) {
             if (!$this->authenticate($_REQUEST['email'], $_REQUEST['passwd'])) {
                 $variables['errorMessage'] = $this->getAuthenticationMessage();

--- a/classes/Domain/Services/ResetEmailer.php
+++ b/classes/Domain/Services/ResetEmailer.php
@@ -32,7 +32,7 @@ class ResetEmailer
 
     private function parameters($userId, $resetCode)
     {
-        return array(
+        return [
             'reset_code' => $resetCode,
             'method' => (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')
                 ? 'https' : 'http',
@@ -40,7 +40,7 @@ class ResetEmailer
             'user_id' => $userId,
             'email' => $this->config_email,
             'title' => $this->config_title
-        );
+        ];
     }
 
     private function preparedMessage($email, $parameters)

--- a/classes/Http/API/ApiController.php
+++ b/classes/Http/API/ApiController.php
@@ -120,7 +120,7 @@ class ApiController
      *
      * @return string the generated URL
      */
-    public function url($route, $parameters = array())
+    public function url($route, $parameters = [])
     {
         return $this->app['url_generator']->generate($route, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
     }

--- a/classes/Http/Controller/Admin/AdminAccessTrait.php
+++ b/classes/Http/Controller/Admin/AdminAccessTrait.php
@@ -12,7 +12,7 @@ trait AdminAccessTrait
                 return $this->redirectTo('dashboard');
             }
 
-            return call_user_func_array(array($this, $method), $arguments);
+            return call_user_func_array([$this, $method], $arguments);
         }
     }
 

--- a/classes/Http/Controller/Admin/AdminsController.php
+++ b/classes/Http/Controller/Admin/AdminsController.php
@@ -33,14 +33,14 @@ class AdminsController extends BaseController
         $pagination = $view->render(
             $pagerfanta,
             $routeGenerator,
-            array('proximity' => 3)
+            ['proximity' => 3]
         );
 
-        $templateData = array(
+        $templateData = [
             'pagination' => $pagination,
             'speakers' => $pagerfanta,
             'page' => $pagerfanta->getCurrentPage()
-        );
+        ];
 
         return $this->render('admin/admins/index.twig', $templateData);
     }
@@ -50,11 +50,11 @@ class AdminsController extends BaseController
         $admin = $this->app['sentry']->getUser();
 
         if ($admin->getId() == $req->get('id')) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => 'Sorry, you cannot remove yourself as Admin.',
-            ));
+            ]);
 
             return $this->redirectTo('admin_admins');
         }
@@ -67,19 +67,19 @@ class AdminsController extends BaseController
         $response = $user->removeGroup($adminGroup);
 
         if ($response == true) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'success',
                 'short' => 'Success',
                 'ext' => 'Successfully removed the Admin!',
-            ));
+            ]);
         }
 
         if ($response == false) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => 'We were unable to remove the Admin. Please try again.',
-            ));
+            ]);
         }
 
         return $this->redirectTo('admin_admins');

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -18,13 +18,13 @@ class DashboardController extends BaseController
         $favorite_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Favorite');
         $recent_talks = $talk_mapper->getRecent($this->app['sentry']->getUser()->getId());
 
-        $templateData = array(
+        $templateData = [
             'speakerTotal' => $speaker_total,
             'talkTotal' => $talk_mapper->all()->count(),
             'favoriteTotal' => $favorite_mapper->all()->count(),
             'selectTotal' => $talk_mapper->all()->where(['selected' => 1])->count(),
             'talks' => $recent_talks
-        );
+        ];
 
         return $this->render('admin/index.twig', $templateData);
     }

--- a/classes/Http/Controller/Admin/ReviewController.php
+++ b/classes/Http/Controller/Admin/ReviewController.php
@@ -45,7 +45,7 @@ class ReviewController extends BaseController
         $pagination = $view->render(
             $pagerfanta,
             $routeGenerator,
-            array('proximity' => 3)
+            ['proximity' => 3]
         );
 
         $template_data = [

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -41,17 +41,17 @@ class SpeakersController extends BaseController
         $pagination = $view->render(
             $pagerfanta,
             $routeGenerator,
-            array('proximity' => 3)
+            ['proximity' => 3]
         );
 
-        $templateData = array(
+        $templateData = [
             'airport' => $this->app->config('application.airport'),
             'arrival' => date('Y-m-d', $this->app->config('application.arrival')),
             'departure' => date('Y-m-d', $this->app->config('application.departure')),
             'pagination' => $pagination,
             'speakers' => $pagerfanta,
             'page' => $pagerfanta->getCurrentPage()
-        );
+        ];
 
         return $this->render('admin/speaker/index.twig', $templateData);
     }
@@ -72,7 +72,7 @@ class SpeakersController extends BaseController
         $talks = $talk_mapper->getByUser($req->get('id'))->toArray();
 
         // Build and render the template
-        $templateData = array(
+        $templateData = [
             'airport' => $this->app->config('application.airport'),
             'arrival' => date('Y-m-d', $this->app->config('application.arrival')),
             'departure' => date('Y-m-d', $this->app->config('application.departure')),
@@ -80,7 +80,7 @@ class SpeakersController extends BaseController
             'talks' => $talks,
             'photo_path' => '/uploads/',
             'page' => $req->get('page'),
-        );
+        ];
 
         return $this->render('admin/speaker/view.twig', $templateData);
     }
@@ -107,11 +107,11 @@ class SpeakersController extends BaseController
         }
 
         // Set flash message
-        $this->app['session']->set('flash', array(
+        $this->app['session']->set('flash', [
             'type' => $type,
             'short' => $short,
             'ext' => $ext
-        ));
+        ]);
 
         return $this->redirectTo('admin_speakers');
     }

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -52,7 +52,7 @@ class TalksController extends BaseController
         $pagination = $view->render(
             $pagerfanta,
             $routeGenerator,
-            array('proximity' => 3)
+            ['proximity' => 3]
         );
 
         $templateData = [
@@ -157,12 +157,12 @@ class TalksController extends BaseController
         });
 
         // Build and render the template
-        $templateData = array(
+        $templateData = [
             'talk' => $talk,
             'talk_meta' => $talk_meta,
             'speaker' => $speaker,
             'otherTalks' => $otherTalks,
-        );
+        ];
 
         return $this->render('admin/talks/view.twig', $templateData);
     }

--- a/classes/Http/Controller/BaseController.php
+++ b/classes/Http/Controller/BaseController.php
@@ -19,7 +19,7 @@ abstract class BaseController
      *
      * @return string the generated URL
      */
-    public function url($route, $parameters = array())
+    public function url($route, $parameters = [])
     {
         return $this->app['url_generator']->generate($route, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
     }

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -16,10 +16,10 @@ class ForgotController extends BaseController
     {
         $form = $this->app['form.factory']->create(new ForgotForm());
 
-        $data = array(
+        $data = [
             'form' => $form->createView(),
             'current_page' => "Forgot Password"
-        );
+        ];
 
         return $this->render('user/forgot_password.twig', $data);
     }
@@ -30,11 +30,11 @@ class ForgotController extends BaseController
         $form->bind($req);
 
         if (!$form->isValid()) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => "Please enter a properly formatted email address"
-            ));
+            ]);
 
             return $this->redirectTo('forgot_password');
         }
@@ -54,11 +54,11 @@ class ForgotController extends BaseController
         $response = $this->app['reset_emailer']->send($user->getId(), $data['email'], $user->getResetPasswordCode());
 
         if ($response == false) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => "We were unable to send your password reset request. Please try again"
-            ));
+            ]);
 
             return $this->redirectTo('forgot_password');
         }
@@ -83,18 +83,18 @@ class ForgotController extends BaseController
         }
 
         if ($error > 0) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => $errorMessage,
-            ));
+            ]);
         }
 
         // Build password form and display it to the user
-        $form_options = array(
+        $form_options = [
             'user_id' => $req->get('user_id'),
             'reset_code' => $req->get('reset_code')
-        );
+        ];
         $form = $this->app['form.factory']->create(new ResetForm(), $form_options);
 
         $data['form'] = $form->createView();
@@ -107,10 +107,10 @@ class ForgotController extends BaseController
     {
         $user_id = $req->get('user_id');
         $reset_code = $req->get('reset_code');
-        $form_options = array(
+        $form_options = [
             'user_id' => $user_id,
             'reset_code' => $reset_code
-        );
+        ];
         $form = $this->app['form.factory']->create(new ResetForm(), $form_options);
 
         if (! $form->isValid()) {
@@ -131,11 +131,11 @@ class ForgotController extends BaseController
         }
 
         if ($error > 0) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => $errorMessage,
-            ));
+            ]);
         }
 
         return $this->redirectTo('forgot_password');
@@ -193,10 +193,10 @@ class ForgotController extends BaseController
 
     protected function successfulSendFlashParameters($email)
     {
-        return array(
+        return [
             'type' => 'success',
             'short' => 'Success',
             'ext' => "If your email was valid, we sent a link to reset your password to $email"
-        );
+        ];
     }
 }

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -19,11 +19,11 @@ class ProfileController extends BaseController
         $user = $this->app['sentry']->getUser();
 
         if ((string) $user->getId() !== $req->get('id')) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => "You cannot edit someone else's profile"
-            ));
+            ]);
 
             return $this->redirectTo('dashboard');
         }
@@ -31,7 +31,7 @@ class ProfileController extends BaseController
         $mapper = $this->app['spot']->mapper('\OpenCFP\Domain\Entity\User');
         $speaker_data = $mapper->get($user->getId())->toArray();
 
-        $form_data = array(
+        $form_data = [
             'email' => $user->getLogin(),
             'first_name' => $speaker_data['first_name'],
             'last_name' => $speaker_data['last_name'],
@@ -47,7 +47,7 @@ class ProfileController extends BaseController
             'id' => $user->getId(),
             'formAction' => $this->url('user_update'),
             'buttonInfo' => 'Update Profile',
-        );
+        ];
 
         return $this->render('user/edit.twig', $form_data) ;
     }
@@ -61,16 +61,16 @@ class ProfileController extends BaseController
         $user = $this->app['sentry']->getUser();
 
         if ((string) $user->getId() !== $req->get('id')) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => "You cannot edit someone else's profile"
-            ));
+            ]);
 
             return $this->redirectTo('dashboard');
         }
 
-        $form_data = array(
+        $form_data = [
             'email' => $req->get('email'),
             'user_id' => $req->get('id'),
             'first_name' => $req->get('first_name'),
@@ -82,7 +82,7 @@ class ProfileController extends BaseController
             'hotel' => $req->get('hotel'),
             'speaker_info' => $req->get('speaker_info') ?: null,
             'speaker_bio' => $req->get('speaker_bio') ?: null,
-        );
+        ];
 
         if ($req->files->get('speaker_photo') != null) {
             // Upload Image
@@ -135,20 +135,20 @@ class ProfileController extends BaseController
             $response = $mapper->save($user);
 
             if ($response >= 0) {
-                $this->app['session']->set('flash', array(
+                $this->app['session']->set('flash', [
                     'type' => 'success',
                     'short' => 'Success',
                     'ext' => "Successfully updated your information!"
-                ));
+                ]);
 
                 return $this->redirectTo('dashboard');
             }
         } else {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => implode('<br>', $form->getErrorMessages())
-            ));
+            ]);
         }
 
         $form_data['formAction'] = $this->url('user_update');
@@ -181,19 +181,19 @@ class ProfileController extends BaseController
          * Okay, the logic is kind of weird but we can use the SignupForm
          * validation code to make sure our password changes are good
          */
-        $formData = array(
+        $formData = [
             'password' => $req->get('password'),
             'password2' => $req->get('password_confirm')
-        );
+        ];
         $form = new SignupForm($formData, $this->app['purifier']);
         $form->sanitize();
 
         if ($form->validatePasswords() === false) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => implode("<br>", $form->getErrorMessages())
-            ));
+            ]);
 
             return $this->redirectTo('password_edit');
         }
@@ -206,20 +206,20 @@ class ProfileController extends BaseController
         $reset_code = $user->getResetPasswordCode();
 
         if (! $user->attemptResetPassword($reset_code, $sanitized_data['password'])) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => "Unable to update your password in the database. Please try again."
-            ));
+            ]);
 
             return $this->redirectTo('password_edit');
         }
 
-        $this->app['session']->set('flash', array(
+        $this->app['session']->set('flash', [
             'type' => 'success',
             'short' => 'Success',
             'ext' => "Changed your password."
-        ));
+        ]);
 
         return $this->redirectTo('password_edit');
     }

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -19,7 +19,7 @@ class SecurityController extends BaseController
 
     public function processAction(Request $req, Application $app)
     {
-        $template_data = array();
+        $template_data = [];
         $code = Response::HTTP_OK;
 
         try {
@@ -37,24 +37,24 @@ class SecurityController extends BaseController
 
             $errorMessage = $page->getAuthenticationMessage();
 
-            $template_data = array(
+            $template_data = [
                 'email' => $req->get('email'),
-            );
+            ];
             $code = Response::HTTP_BAD_REQUEST;
         } catch (Exception $e) {
             $errorMessage = $e->getMessage();
-            $template_data = array(
+            $template_data = [
                 'email' => $req->get('email'),
-            );
+            ];
             $code = Response::HTTP_BAD_REQUEST;
         }
 
         // Set Success Flash Message
-        $this->app['session']->set('flash', array(
+        $this->app['session']->set('flash', [
             'type' => 'error',
             'short' => 'Error',
             'ext' => $errorMessage,
-        ));
+        ]);
 
         $template_data['flash'] = $this->getFlash($app);
 

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -20,11 +20,11 @@ class SignupController extends BaseController
         }
 
         if (strtotime($this->app->config('application.enddate')) < strtotime('now')) {
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => 'Sorry, the call for papers has ended.',
-            ));
+            ]);
 
             return $this->redirectTo('homepage');
         }
@@ -39,7 +39,7 @@ class SignupController extends BaseController
 
     public function processAction(Request $req, Application $app)
     {
-        $form_data = array(
+        $form_data = [
             'formAction' => $this->url('user_create'),
             'first_name' => $req->get('first_name'),
             'last_name' => $req->get('last_name'),
@@ -50,7 +50,7 @@ class SignupController extends BaseController
             'password2' => $req->get('password2'),
             'airport' => $req->get('airport'),
             'buttonInfo' => 'Create my speaker profile'
-        );
+        ];
         $form_data['speaker_info'] = $req->get('speaker_info') ?: null;
         $form_data['speaker_bio'] = $req->get('speaker_bio') ?: null;
         $form_data['transportation'] = $req->get('transportation') ?: null;
@@ -85,7 +85,7 @@ class SignupController extends BaseController
 
             // Create account using Sentry
             try {
-                $user_data = array(
+                $user_data = [
                     'first_name' => $sanitized_data['first_name'],
                     'last_name' => $sanitized_data['last_name'],
                     'company' => $sanitized_data['company'],
@@ -94,7 +94,7 @@ class SignupController extends BaseController
                     'password' => $sanitized_data['password'],
                     'airport' => $sanitized_data['airport'],
                     'activated' => 1
-                );
+                ];
 
                 $user = $app['sentry']->getUserProvider()->create($user_data);
 
@@ -124,29 +124,29 @@ class SignupController extends BaseController
                 }
 
                 // Set Success Flash Message
-                $app['session']->set('flash', array(
+                $app['session']->set('flash', [
                     'type' => 'success',
                     'short' => 'Success',
                     'ext' => "You've successfully created your account!",
-                ));
+                ]);
 
                 return $this->redirectTo('login');
             } catch (UserExistsException $e) {
-                $app['session']->set('flash', array(
+                $app['session']->set('flash', [
                     'type' => 'error',
                     'short' => 'Error',
                     'ext' => 'A user already exists with that email address'
-                ));
+                ]);
             }
         }
 
         if (!$isValid) {
             // Set Error Flash Message
-            $app['session']->set('flash', array(
+            $app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => implode("<br>", $form->getErrorMessages())
-            ));
+            ]);
         }
 
         $form_data['flash'] = $this->getFlash($app);

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -97,7 +97,7 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $data = array(
+        $data = [
             'formAction' => $this->url('talk_update'),
             'id' => $talk_id,
             'title' => html_entity_decode($talk_info['title']),
@@ -110,7 +110,7 @@ class TalkController extends BaseController
             'other' => $talk_info['other'],
             'sponsor' => $talk_info['sponsor'],
             'buttonInfo' => 'Update my talk!',
-        );
+        ];
 
         return $this->render('talk/edit.twig', $data);
     }
@@ -138,7 +138,7 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $data = array(
+        $data = [
             'formAction' => $this->url('talk_create'),
             'title' => $req->get('title'),
             'description' => $req->get('description'),
@@ -150,7 +150,7 @@ class TalkController extends BaseController
             'other' => $req->get('other'),
             'sponsor' => $req->get('sponsor'),
             'buttonInfo' => 'Submit my talk!',
-        );
+        ];
 
         return $this->render('talk/create.twig', $data);
     }
@@ -181,7 +181,7 @@ class TalkController extends BaseController
 
         $user = $this->app['sentry']->getUser();
 
-        $request_data = array(
+        $request_data = [
             'title' => $req->get('title'),
             'description' => $req->get('description'),
             'type' => $req->get('type'),
@@ -192,7 +192,7 @@ class TalkController extends BaseController
             'other' => $req->get('other'),
             'sponsor' => $req->get('sponsor'),
             'user_id' => $req->get('user_id')
-        );
+        ];
 
         $form = new TalkForm($request_data, $this->app['purifier']);
         $form->sanitize();
@@ -200,7 +200,7 @@ class TalkController extends BaseController
 
         if ($isValid) {
             $sanitized_data = $form->getCleanData();
-            $data = array(
+            $data = [
                 'title' => $sanitized_data['title'],
                 'description' => $sanitized_data['description'],
                 'type' => $sanitized_data['type'],
@@ -211,16 +211,16 @@ class TalkController extends BaseController
                 'other' => $sanitized_data['other'],
                 'sponsor' => $sanitized_data['sponsor'],
                 'user_id' => (int) $user->getId(),
-            );
+            ];
 
             $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
             $talk = $talk_mapper->create($data);
 
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'success',
                 'short' => 'Success',
                 'ext' => 'Successfully added talk.',
-            ));
+            ]);
 
             // send email to speaker showing submission
             $this->sendSubmitEmail($this->app, $user->getLogin(), $talk->id);
@@ -229,7 +229,7 @@ class TalkController extends BaseController
         }
 
         if (!$isValid) {
-            $data = array(
+            $data = [
                 'formAction' => $this->url('talk_create'),
                 'title' => $req->get('title'),
                 'description' => $req->get('description'),
@@ -241,13 +241,13 @@ class TalkController extends BaseController
                 'other' => $req->get('other'),
                 'sponsor' => $req->get('sponsor'),
                 'buttonInfo' => 'Submit my talk!',
-            );
+            ];
 
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => implode("<br>", $form->getErrorMessages())
-            ));
+            ]);
         }
 
         $data['flash'] = $this->getFlash($this->app);
@@ -263,7 +263,7 @@ class TalkController extends BaseController
 
         $user = $this->app['sentry']->getUser();
 
-        $request_data = array(
+        $request_data = [
             'id' => $req->get('id'),
             'title' => $req->get('title'),
             'description' => $req->get('description'),
@@ -275,7 +275,7 @@ class TalkController extends BaseController
             'other' => $req->get('other'),
             'sponsor' => $req->get('sponsor'),
             'user_id' => $req->get('user_id')
-        );
+        ];
 
         $form = new TalkForm($request_data, $this->app['purifier']);
         $form->sanitize();
@@ -283,7 +283,7 @@ class TalkController extends BaseController
 
         if ($isValid) {
             $sanitized_data = $form->getCleanData();
-            $data = array(
+            $data = [
                 'id' => (int) $sanitized_data['id'],
                 'title' => $sanitized_data['title'],
                 'description' => $sanitized_data['description'],
@@ -295,7 +295,7 @@ class TalkController extends BaseController
                 'other' => $sanitized_data['other'],
                 'sponsor' => $sanitized_data['sponsor'],
                 'user_id' => (int) $user->getId()
-            );
+            ];
 
             $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
             $talk = $mapper->get($data['id']);
@@ -306,17 +306,17 @@ class TalkController extends BaseController
 
             $mapper->save($talk);
 
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'success',
                 'short' => 'Success',
                 'ext' => 'Successfully updated talk.',
-            ));
+            ]);
 
             return $this->redirectTo('dashboard');
         }
 
         if (! $isValid) {
-            $data = array(
+            $data = [
                 'formAction' => $this->url('talk_update'),
                 'id' => $req->get('id'),
                 'title' => $req->get('title'),
@@ -329,13 +329,13 @@ class TalkController extends BaseController
                 'other' => $req->get('other'),
                 'sponsor' => $req->get('sponsor'),
                 'buttonInfo' => 'Update my talk!',
-            );
+            ];
 
-            $this->app['session']->set('flash', array(
+            $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
                 'ext' => implode("<br>", $form->getErrorMessages())
-            ));
+            ]);
         }
 
         $data['flash'] = $this->getFlash($this->app);
@@ -382,12 +382,12 @@ class TalkController extends BaseController
 
         // Build our email that we will send
         $template = $app['twig']->loadTemplate('emails/talk_submit.twig');
-        $parameters = array(
+        $parameters = [
             'email' => $this->app->config('application.email'),
             'title' => $this->app->config('application.title'),
             'talk' => $talk->title,
             'enddate' => $this->app->config('application.enddate')
-        );
+        ];
 
         try {
             $mailer = $app['mailer'];

--- a/classes/Http/Form/ForgotForm.php
+++ b/classes/Http/Form/ForgotForm.php
@@ -9,12 +9,12 @@ class ForgotForm extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('email', 'text', array(
-            'constraints' => array(
+        $builder->add('email', 'text', [
+            'constraints' => [
                 new Assert\NotBlank(),
                 new Assert\Email()
-            )
-        ));
+            ]
+        ]);
     }
 
     public function getName()

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -8,7 +8,7 @@ abstract class Form
     protected $_cleanData;
     protected $_taintedData;
     protected $_purifier;
-    protected $_fieldList = array();
+    protected $_fieldList = [];
 
     /**
      * Class constructor
@@ -17,13 +17,13 @@ abstract class Form
      * @param \HTMLPurifier $purifier
      * @param $options
      */
-    public function __construct($data, \HTMLPurifier $purifier, array $options = array())
+    public function __construct($data, \HTMLPurifier $purifier, array $options = [])
     {
         $this->_purifier    = $purifier;
         $this->_options     = $options;
-        $this->_messages    = array();
-        $this->_cleanData   = array();
-        $this->_taintedData = array();
+        $this->_messages    = [];
+        $this->_cleanData   = [];
+        $this->_taintedData = [];
 
         $this->populate($data);
     }
@@ -72,13 +72,13 @@ abstract class Form
      * @param  array $keys
      * @return array The cleaned data
      */
-    public function getCleanData(array $keys = array())
+    public function getCleanData(array $keys = [])
     {
         if (empty($keys)) {
             return $this->_cleanData;
         }
 
-        $data = array();
+        $data = [];
         foreach ($keys as $key) {
             if (isset($this->_cleanData[$key])) {
                 $data[$key] = $this->_cleanData[$key];

--- a/classes/Http/Form/ResetForm.php
+++ b/classes/Http/Form/ResetForm.php
@@ -9,16 +9,16 @@ class ResetForm extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('password', 'repeated', array(
-                'constraints' => array(
+        $builder->add('password', 'repeated', [
+                'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(array('min' => 5))),
+                    new Assert\Length(['min' => 5])],
                 'type' => 'password',
-                'first_options' => array('label' => 'Password (minimum 5 characters)'),
-                'second_options' => array('label' => 'Password (confirm)'),
+                'first_options' => ['label' => 'Password (minimum 5 characters)'],
+                'second_options' => ['label' => 'Password (confirm)'],
                 'first_name' => 'password',
                 'second_name' => 'password2',
-                'invalid_message' => 'Passwords did not match'))
+                'invalid_message' => 'Passwords did not match'])
             ->add('user_id', 'hidden')
             ->add('reset_code', 'hidden')
             ->getForm();

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -7,7 +7,7 @@ namespace OpenCFP\Http\Form;
  */
 class SignupForm extends Form
 {
-    protected $_fieldList = array(
+    protected $_fieldList = [
         'email',
         'password',
         'password2',
@@ -20,7 +20,7 @@ class SignupForm extends Form
         'transportation',
         'hotel',
         'speaker_photo'
-    );
+    ];
 
     /**
      * Validate all methods by calling all our validation methods
@@ -69,11 +69,11 @@ class SignupForm extends Form
 
     public function validateSpeakerPhoto()
     {
-        $allowedMimeTypes = array(
+        $allowedMimeTypes = [
             'image/jpeg',
             'image/jpg',
             'image/png',
-        );
+        ];
 
         // Speaker Photo is not required, only validate if it exists
         if (!isset($this->_taintedData['speaker_photo'])) {
@@ -169,7 +169,7 @@ class SignupForm extends Form
         $first_name = filter_var(
             $this->_cleanData['first_name'],
             FILTER_SANITIZE_STRING,
-            array('flags' => FILTER_FLAG_STRIP_HIGH | FILTER_FLAG_STRIP_LOW)
+            ['flags' => FILTER_FLAG_STRIP_HIGH | FILTER_FLAG_STRIP_LOW]
         );
         $validation_response = true;
 

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -8,7 +8,7 @@ namespace OpenCFP\Http\Form;
  */
 class TalkForm extends Form
 {
-    protected $_fieldList = array(
+    protected $_fieldList = [
         'title',
         'description',
         'type',
@@ -19,7 +19,7 @@ class TalkForm extends Form
         'other',
         'sponsor',
         'user_id'
-    );
+    ];
 
     /**
      * Santize all our fields that were submitted
@@ -101,10 +101,10 @@ class TalkForm extends Form
      */
     public function validateType()
     {
-        $validTalkTypes = array(
+        $validTalkTypes = [
             'regular',
             'tutorial'
-        );
+        ];
 
         if (empty($this->_cleanData['type']) || !isset($this->_cleanData['type'])) {
             $this->_addErrorMessage("You must choose what type of talk you are submitting");
@@ -123,11 +123,11 @@ class TalkForm extends Form
 
     public function validateLevel()
     {
-        $validLevels = array(
+        $validLevels = [
             'entry',
             'mid',
             'advanced'
-        );
+        ];
 
         if (empty($this->_cleanData['level']) || !isset($this->_cleanData['level'])) {
             $this->_addErrorMessage("You must choose what level of talk you are submitting");
@@ -146,7 +146,7 @@ class TalkForm extends Form
 
     public function validateCategory()
     {
-        $validCategories = array(
+        $validCategories = [
             'development',
             'framework',
             'database',
@@ -159,7 +159,7 @@ class TalkForm extends Form
             'other',
             'continuousdelivery',
             'ibmi'
-        );
+        ];
 
         if (empty($this->_cleanData['category']) || !isset($this->_cleanData['category'])) {
             $this->_addErrorMessage("You must choose what category of talk you are submitting");

--- a/classes/Provider/ControllerResolver.php
+++ b/classes/Provider/ControllerResolver.php
@@ -35,6 +35,6 @@ class ControllerResolver extends \Silex\ControllerResolver
             throw new \InvalidArgumentException(sprintf('Service "%s" does not exist.', $controller));
         }
 
-        return array($this->app[$service], $method);
+        return [$this->app[$service], $method];
     }
 }

--- a/classes/Provider/Gateways/ApiGatewayProvider.php
+++ b/classes/Provider/Gateways/ApiGatewayProvider.php
@@ -33,7 +33,7 @@ class ApiGatewayProvider implements ServiceProviderInterface
 
             if (0 === strpos($request->headers->get('Content-Type'), 'application/json')) {
                 $data = json_decode($request->getContent(), true);
-                $request->request->replace(is_array($data) ? $data : array());
+                $request->request->replace(is_array($data) ? $data : []);
             }
         });
 

--- a/classes/Provider/Gateways/OAuthGatewayProvider.php
+++ b/classes/Provider/Gateways/OAuthGatewayProvider.php
@@ -57,7 +57,7 @@ class OAuthGatewayProvider implements ServiceProviderInterface
 
             if (0 === strpos($request->headers->get('Content-Type'), 'application/json')) {
                 $data = json_decode($request->getContent(), true);
-                $request->request->replace(is_array($data) ? $data : array());
+                $request->request->replace(is_array($data) ? $data : []);
             }
         });
 

--- a/classes/Provider/SentryServiceProvider.php
+++ b/classes/Provider/SentryServiceProvider.php
@@ -15,7 +15,7 @@ class SentryServiceProvider implements ServiceProviderInterface
         // Create a new Database connection
         $database = new Capsule;
 
-        $database->addConnection(array(
+        $database->addConnection([
             'driver'    => 'mysql',
             'host'      => $app->config('database.host'),
             'database'  => $app->config('database.database'),
@@ -23,7 +23,7 @@ class SentryServiceProvider implements ServiceProviderInterface
             'password'  => $app->config('database.password'),
             'charset'   => 'utf8',
             'collation' => 'utf8_unicode_ci'
-        ));
+        ]);
 
         // Makes the new "capsule" the global static instance.
         $database->setAsGlobal();
@@ -37,7 +37,7 @@ class SentryServiceProvider implements ServiceProviderInterface
             $groupProvider = new \Cartalyst\Sentry\Groups\Eloquent\Provider;
             $throttleProvider = new \Cartalyst\Sentry\Throttling\Eloquent\Provider($userProvider);
             $session = new SymfonySentrySession($app['session']);
-            $cookie = new \Cartalyst\Sentry\Cookies\NativeCookie(array());
+            $cookie = new \Cartalyst\Sentry\Cookies\NativeCookie([]);
 
             $sentry = new \Cartalyst\Sentry\Sentry(
                 $userProvider,

--- a/classes/Provider/YamlConfigDriver.php
+++ b/classes/Provider/YamlConfigDriver.php
@@ -13,6 +13,6 @@ class YamlConfigDriver extends IgorYamlConfigDriver
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
         $config = Yaml::parse(file_get_contents($filename));
-        return $config ?: array();
+        return $config ?: [];
     }
 }

--- a/tests/OpenCFP/Domain/Entity/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/TalkTest.php
@@ -31,11 +31,11 @@ class TalkEntityTest extends \PHPUnit_Framework_TestCase
     public function utf8CharactersCorrectlyEncoded()
     {
         $title = "Battle: Feature Branches VS Feature Switching (╯°□°)╯︵ ┻━┻ ︵ ╯(°□° ╯)";
-        $data = array(
+        $data = [
             'title' => $title,
             'description' => 'Talk with UTF-8 characters in the title',
             'user_id' => 1
-        );
+        ];
         $talk = $this->mapper->create($data);
 
         $this->assertEquals(

--- a/tests/OpenCFP/Domain/Services/ResetEmailerTest.php
+++ b/tests/OpenCFP/Domain/Services/ResetEmailerTest.php
@@ -46,7 +46,7 @@ class EmailerTest extends \PHPUnit_Framework_TestCase
     private function validateEmail()
     {
         return function ($message) {
-            return $message->getTo() === array($this->user_email => null);
+            return $message->getTo() === [$this->user_email => null];
         };
     }
 }

--- a/tests/unit/LoginTest.php
+++ b/tests/unit/LoginTest.php
@@ -11,10 +11,10 @@ class LoginTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->credentials = array(
+        $this->credentials = [
             'email'    => 'foo@bar.com',
             'password' => 'baz_bat',
-        );
+        ];
     }
 
     public function testAuthenticateInvalid()

--- a/tests/unit/SignupFormTest.php
+++ b/tests/unit/SignupFormTest.php
@@ -17,10 +17,10 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function formRejectsValidationOnMissingFields()
     {
-        $data = array(
+        $data = [
             'email' => 'test@domain.com',
             'notrequired' => 'test'
-        );
+        ];
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $response = $form->hasRequiredFields();
         $this->assertFalse($response);
@@ -36,7 +36,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function emailsAreBeingValidatedCorrectly($email, $expectedResponse)
     {
-        $data = array('email' => $email);
+        $data = ['email' => $email];
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $this->assertEquals(
             $form->validateEmail(),
@@ -53,7 +53,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function emailValidationShouldFailWithoutEmail()
     {
-        $data = array();
+        $data = [];
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $this->assertFalse(
             $form->validateEmail(),
@@ -68,13 +68,13 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function emailProvider()
     {
-        return array(
-            array('test', false),
-            array('test@domain.com', true),
-            array('', false),
-            array('test@domain', false),
-            array('test+tricky@domain.com', true)
-        );
+        return [
+            ['test', false],
+            ['test@domain.com', true],
+            ['', false],
+            ['test@domain', false],
+            ['test+tricky@domain.com', true]
+        ];
     }
 
     /**
@@ -84,12 +84,12 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function properPasswordValidator()
     {
-        return array(
-            array('acceptable'),
-            array('testing123'),
-            array('{^secur3'),
-            array('invalidChars&*$')
-        );
+        return [
+            ['acceptable'],
+            ['testing123'],
+            ['{^secur3'],
+            ['invalidChars&*$']
+        ];
     }
 
     /**
@@ -102,10 +102,10 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function properPasswordsPassValidationAndSanitization($passwd)
     {
-        $data = array(
+        $data = [
             'password' => $passwd,
             'password2' => $passwd
-        );
+        ];
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
 
@@ -127,10 +127,10 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function badPasswordsAreBeingCorrectlyDetected($passwd, $passwd2, $expectedMessage, $expectedResponse)
     {
-        $data = array(
+        $data = [
             'password' => $passwd,
             'password2' => $passwd2
-        );
+        ];
 
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
@@ -151,12 +151,12 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function badPasswordProvider()
     {
-        return array(
-            array('foo', 'foo', "The submitted password must be at least 5 characters long", false),
-            array('bar', 'foo', "The submitted passwords do not match", false),
-            array(null, null, "Missing passwords", false),
-            array('password with spaces', 'password with spaces', "The submitted password contains invalid characters", false),
-        );
+        return [
+            ['foo', 'foo', "The submitted password must be at least 5 characters long", false],
+            ['bar', 'foo', "The submitted passwords do not match", false],
+            [null, null, "Missing passwords", false],
+            ['password with spaces', 'password with spaces', "The submitted password contains invalid characters", false],
+        ];
     }
 
     /**
@@ -193,13 +193,13 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             $longName .= 'X';
         }
 
-        return array(
-            array('Chris', true),
-            array(null, false),
-            array('', false),
-            array(false, false),
-            array($longName, false),
-        );
+        return [
+            ['Chris', true],
+            [null, false],
+            ['', false],
+            [false, false],
+            [$longName, false],
+        ];
     }
 
     /**
@@ -236,13 +236,13 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             $longName .= 'X';
         }
 
-        return array(
-            array('Chris', true),
-            array(null, false),
-            array('', false),
-            array(false, false),
-            array($longName, false),
-        );
+        return [
+            ['Chris', true],
+            [null, false],
+            ['', false],
+            [false, false],
+            [$longName, false],
+        ];
     }
 
     /**
@@ -271,20 +271,20 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function validateAllProvider()
     {
-        $baseData = array(
+        $baseData = [
             'email' => 'test@domain.com',
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => 'McTesterton'
-        );
+        ];
         $baseDataWithSpeakerInfo = $baseData;
         $baseDataWithSpeakerInfo['speaker_info'] = "Testing speaker info data";
 
-        return array(
-            array($baseData, true),
-            array($baseDataWithSpeakerInfo, true),
-        );
+        return [
+            [$baseData, true],
+            [$baseDataWithSpeakerInfo, true],
+        ];
     }
 
     /**
@@ -335,10 +335,10 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
       */
     public function speakerTextProvider()
     {
-        return array(
-            array('Speaker text that can go in multiple places', true),
-            array(null, false),
-        );
+        return [
+            ['Speaker text that can go in multiple places', true],
+            [null, false],
+        ];
     }
 
     /**
@@ -368,66 +368,66 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
      */
     public function sanitizationProvider()
     {
-        $badDataIn = array(
+        $badDataIn = [
             'email' => 'test@domain.com',
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => "<script>alert('XSS')</script>"
-        );
+        ];
 
-        $badDataOut = array(
+        $badDataOut = [
             'email' => 'test@domain.com',
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => ""
-        );
+        ];
 
-        $goodDataIn = array(
+        $goodDataIn = [
             'email' => 'test@domain.com',
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => "McTesterton"
-        );
+        ];
 
         $goodDataOut = $goodDataIn;
 
-        $badSpeakerInfoIn = array(
+        $badSpeakerInfoIn = [
             'email' => 'test@domain.com',
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => "McTesterton",
             'speaker_info' => "<a href=\"http://lolcoin.com/redeem\">Speaker bio</a>"
-        );
+        ];
 
-        $badSpeakerInfoOut = array(
+        $badSpeakerInfoOut = [
             'email' => 'test@domain.com',
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => "McTesterton",
             'speaker_info' => "<a href=\"http://lolcoin.com/redeem\">Speaker bio</a>"
-        );
+        ];
 
-        $goodSpeakerInfoIn = array(
+        $goodSpeakerInfoIn = [
             'email' => 'test@domain.com',
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => "McTesterton",
             'speaker_info' => "Find my bio at http://littlehart.net"
-        );
+        ];
 
         $goodSpeakerInfoOut = $goodSpeakerInfoIn;
 
-        return array(
-            array($badDataIn, $badDataOut),
-            array($goodDataIn, $goodDataOut),
-            array($badSpeakerInfoIn, $badSpeakerInfoOut),
-            array($goodSpeakerInfoIn, $goodSpeakerInfoOut)
-        );
+        return [
+            [$badDataIn, $badDataOut],
+            [$goodDataIn, $goodDataOut],
+            [$badSpeakerInfoIn, $badSpeakerInfoOut],
+            [$goodSpeakerInfoIn, $goodSpeakerInfoOut]
+        ];
     }
 }

--- a/tests/unit/TalkFormTest.php
+++ b/tests/unit/TalkFormTest.php
@@ -41,11 +41,11 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
      */
     public function hasRequiredProvider()
     {
-        $badData = array(
+        $badData = [
             'title' => 'Bad Data',
             'description' => 'Hey, why are we missing fields!'
-        );
-        $goodData = array(
+        ];
+        $goodData = [
             'title' => 'Talk Title',
             'description' => 'Description of our talk',
             'type' => 'session',
@@ -56,15 +56,15 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
             'desired' => 1,
             'sponsor' => 1,
             'user_id' => 1
-        );
+        ];
         $extendedData = $goodData;
         $extendedData['extra'] = "Extra data in \$_POST but we ignore it";
 
-        return array(
-            array(serialize($badData), false),
-            array(serialize($goodData), true),
-            array(serialize($extendedData), true)
-        );
+        return [
+            [serialize($badData), false],
+            [serialize($goodData), true],
+            [serialize($extendedData), true]
+        ];
     }
 
     /**
@@ -77,7 +77,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
      */
     public function titleValidatesCorrectly($title, $expectedResponse)
     {
-        $data = array('title' => $title);
+        $data = ['title' => $title];
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
         $form->sanitize();
 
@@ -97,12 +97,12 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
     {
         $faker = \Faker\Factory::create();
 
-        return array(
-            array(substr($faker->text(90), 0, 90), true),
-            array(null, false),
-            array("This is a string that could be more than 100 characters long but will we really know for sure until I check it out?", false),
-            array("A little bit of this & that", true)
-        );
+        return [
+            [substr($faker->text(90), 0, 90), true],
+            [null, false],
+            ["This is a string that could be more than 100 characters long but will we really know for sure until I check it out?", false],
+            ["A little bit of this & that", true]
+        ];
     }
 
     /**
@@ -115,7 +115,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
      */
     public function descriptionValidatesCorrectly($description, $expectedResponse)
     {
-        $data = array('description' => $description);
+        $data = ['description' => $description];
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
         $form->sanitize();
 
@@ -135,11 +135,11 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
     {
         $faker = \Faker\Factory::create();
 
-        return array(
-            array($faker->text(), true),
-            array(null, false),
-            array('<script>alert("XSS");</script>', false),
-        );
+        return [
+            [$faker->text(), true],
+            [null, false],
+            ['<script>alert("XSS");</script>', false],
+        ];
     }
 
     /**
@@ -152,7 +152,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
      */
     public function typeValidatesCorrectly($type, $expectedResponse)
     {
-        $data = array('type' => $type);
+        $data = ['type' => $type];
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
         $form->sanitize();
 
@@ -170,15 +170,15 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
      */
     public function typeProvider()
     {
-        return array(
-            array('regular', true),
-            array('tutorial', true),
-            array('foo', false),
-            array(null, false),
-            array(false, false),
-            array(1, false),
-            array(true, false)
-        );
+        return [
+            ['regular', true],
+            ['tutorial', true],
+            ['foo', false],
+            [null, false],
+            [false, false],
+            [1, false],
+            [true, false]
+        ];
     }
 
     /**
@@ -188,18 +188,18 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
      */
     public function speakerIdProvider()
     {
-        $validSpeakerInfo = array(
+        $validSpeakerInfo = [
             'user_id' => 1,
             'info' => 'Special speaker info'
-        );
+        ];
 
-        return array(
-            array(1, $validSpeakerInfo, true),
-            array(0, false, false),
-            array(null, false, false),
-            array(true, false, false),
-            array(false, false, false),
-            array('user', false, false)
-        );
+        return [
+            [1, $validSpeakerInfo, true],
+            [0, false, false],
+            [null, false, false],
+            [true, false, false],
+            [false, false, false],
+            ['user', false, false]
+        ];
     }
 }


### PR DESCRIPTION
This PR

* [x] enables the `short_array_syntax` fixer
* [x] runs `make cs`

Follows #242.

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/1.11#usage:

> **short_array_syntax [contrib]**
PHP arrays should use the PHP 5.4 short-syntax.
