### PR TITLE
Fix: Set indent size to 2 for YAML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 4
 
 [*.js]
 indent_size = 2
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
This PR

* [x] sets `indent_size` to `2` in `.editorconfig`

Follows #227.

:information_desk_person: Throughout the project, YAML files are indented with 2 spaces. Since we're using `.editorconfig`, it makes sense to adjust it, as not to fight an IDE supporting it.