### PR TITLE
Enhancement: Enable multiline_array_trailing_comma fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,6 +9,7 @@ return Symfony\CS\Config\Config::create()
     ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
     ->fixers([
         '-psr0',
+        'multiline_array_trailing_comma',
         'ordered_use',
         'short_array_syntax',
     ])

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -288,7 +288,7 @@ class Application extends SilexApplication
                 }
 
                 return new JsonResponse([
-                    'error' => $e->getMessage()
+                    'error' => $e->getMessage(),
                 ], $code, $headers);
             }
 

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -32,7 +32,7 @@ class Application extends ConsoleApplication
             new ListCommand,
             new AdminPromoteCommand,
             new AdminDemoteCommand,
-            new ClearCacheCommand
+            new ClearCacheCommand,
         ];
     }
 

--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -21,7 +21,7 @@ class AdminDemoteCommand extends BaseCommand
         $this
             ->setName('admin:demote')
             ->setDefinition([
-                new InputArgument('email', InputArgument::REQUIRED, 'Email address of user to demote')
+                new InputArgument('email', InputArgument::REQUIRED, 'Email address of user to demote'),
             ])
             ->setDescription('Demote an existing user from being an admin')
             ->setHelp(<<<EOF

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -21,7 +21,7 @@ class AdminPromoteCommand extends BaseCommand
         $this
             ->setName('admin:promote')
             ->setDefinition([
-                new InputArgument('email', InputArgument::REQUIRED, 'Email address of user to promote to admin')
+                new InputArgument('email', InputArgument::REQUIRED, 'Email address of user to promote to admin'),
             ])
             ->setDescription('Promote an existing user to be an admin')
             ->setHelp(<<<EOF

--- a/classes/Domain/Entity/Favorite.php
+++ b/classes/Domain/Entity/Favorite.php
@@ -14,14 +14,14 @@ class Favorite extends Entity
             'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
             'admin_user_id' => ['type' => 'integer', 'required' => true],
             'talk_id' => ['type' => 'integer', 'required' => true],
-            'created' => ['type' => 'datetime', 'value' => new \DateTime()]
+            'created' => ['type' => 'datetime', 'value' => new \DateTime()],
         ];
     }
 
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'talk' => $mapper->belongsTo($entity, 'OpenCFP\Domain\Entity\Talk', 'talk_id')
+            'talk' => $mapper->belongsTo($entity, 'OpenCFP\Domain\Entity\Talk', 'talk_id'),
         ];
     }
 }

--- a/classes/Domain/Entity/Group.php
+++ b/classes/Domain/Entity/Group.php
@@ -15,7 +15,7 @@ class Group extends Entity
             'name' => ['type' => 'string', 'length' => 255, 'required' => true],
             'permissions' => ['type' => 'text'],
             'created_at' => ['type' => 'datetime', 'value' => new \DateTime()],
-            'updated_at' => ['type' => 'datetime', 'value' => new \DateTime()]
+            'updated_at' => ['type' => 'datetime', 'value' => new \DateTime()],
         ];
     }
 

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -408,7 +408,7 @@ class Talk extends Mapper
             $output['user'] = [
                 'id' => $talk->speaker->id,
                 'first_name' => $talk->speaker->first_name,
-                'last_name' => $talk->speaker->last_name
+                'last_name' => $talk->speaker->last_name,
             ];
         }
 

--- a/classes/Domain/Entity/Phinxlog.php
+++ b/classes/Domain/Entity/Phinxlog.php
@@ -13,7 +13,7 @@ class Phinxlog extends Entity
         return [
             'version' => ['type' => 'bigint', 'required' => true],
             'start_time' => ['type' => 'time', 'value' => time()],
-            'end_time' => ['type' => 'time', 'value' => null]
+            'end_time' => ['type' => 'time', 'value' => null],
         ];
     }
 }

--- a/classes/Domain/Entity/Talk.php
+++ b/classes/Domain/Entity/Talk.php
@@ -25,7 +25,7 @@ class Talk extends Entity
             'sponsor' => ['type' => 'smallint', 'value' => 0],
             'selected' => ['type' => 'smallint', 'value' => 0],
             'created_at' => ['type' => 'datetime', 'value' => new \DateTime()],
-            'updated_at' => ['type' => 'datetime', 'value' => new \DateTime()]
+            'updated_at' => ['type' => 'datetime', 'value' => new \DateTime()],
         ];
     }
 

--- a/classes/Domain/Entity/TalkMeta.php
+++ b/classes/Domain/Entity/TalkMeta.php
@@ -14,14 +14,14 @@ class TalkMeta extends \Spot\Entity
             'talk_id' => ['type' => 'integer', 'required' => true],
             'rating' => ['type' => 'smallint', 'default' => 0],
             'viewed' => ['type' => 'boolean', 'default' => false],
-            'created' => ['type' => 'datetime', 'value' => new \DateTime()]
+            'created' => ['type' => 'datetime', 'value' => new \DateTime()],
         ];
     }
 
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'talk' => $mapper->belongsTo($entity, 'OpenCFP\Domain\Entity\Talk', 'talk_id')
+            'talk' => $mapper->belongsTo($entity, 'OpenCFP\Domain\Entity\Talk', 'talk_id'),
         ];
     }
 }

--- a/classes/Domain/Entity/Throttle.php
+++ b/classes/Domain/Entity/Throttle.php
@@ -19,7 +19,7 @@ class Throttle extends Entity
             'banned' => ['type' => 'smallint', 'value' => 0],
             'last_attempt_at' => ['type' => 'time', 'value' => null],
             'suspended_at' => ['type' => 'time', 'value' => null],
-            'banned_at' => ['type' => 'time', 'value' => null]
+            'banned_at' => ['type' => 'time', 'value' => null],
         ];
     }
 }

--- a/classes/Domain/Entity/User.php
+++ b/classes/Domain/Entity/User.php
@@ -33,7 +33,7 @@ class User extends Entity
             'transportation' => ['type' => 'smallint', 'value' => 0],
             'info' => ['type' => 'text'],
             'bio' => ['type' => 'text'],
-            'photo_path' => ['type' => 'string', 'length' => 255]
+            'photo_path' => ['type' => 'string', 'length' => 255],
         ];
     }
 

--- a/classes/Domain/Entity/UserGroup.php
+++ b/classes/Domain/Entity/UserGroup.php
@@ -13,7 +13,7 @@ class UserGroup extends Entity
         return [
             'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
             'user_id' => ['type' => 'integer'],
-            'group_id' => ['type' => 'integer']
+            'group_id' => ['type' => 'integer'],
         ];
     }
 }

--- a/classes/Domain/OAuth/Client.php
+++ b/classes/Domain/OAuth/Client.php
@@ -22,7 +22,7 @@ class Client extends Entity
     public static function relations(MapperInterface $mapper, EntityInterface $entity)
     {
         return [
-            'endpoints' => $mapper->hasMany($entity, 'OpenCFP\Domain\OAuth\Endpoint', 'client_id')
+            'endpoints' => $mapper->hasMany($entity, 'OpenCFP\Domain\OAuth\Endpoint', 'client_id'),
         ];
     }
 
@@ -38,7 +38,7 @@ class Client extends Entity
             'id' => $this->id,
             'secret' => $this->secret,
             'name' => $this->name,
-            'redirect_uris' => $redirectUris
+            'redirect_uris' => $redirectUris,
         ];
     }
 }

--- a/classes/Domain/Services/ResetEmailer.php
+++ b/classes/Domain/Services/ResetEmailer.php
@@ -39,7 +39,7 @@ class ResetEmailer
             'host' => !empty($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost',
             'user_id' => $userId,
             'email' => $this->config_email,
-            'title' => $this->config_title
+            'title' => $this->config_title,
         ];
     }
 

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -94,7 +94,7 @@ class SpeakerProfile
             'name' => $this->getName(),
             'email' => $this->getEmail(),
             'twitter' => $this->getTwitter(),
-            'bio' => $this->getBio()
+            'bio' => $this->getBio(),
         ];
     }
 }

--- a/classes/Domain/Talk/TalkSubmission.php
+++ b/classes/Domain/Talk/TalkSubmission.php
@@ -35,7 +35,7 @@ class TalkSubmission
             'slides' => '',
             'other' => '',
             'sponsor' => '',
-            'user_id' => ''
+            'user_id' => '',
         ], $this->data);
 
         return new Talk($data);
@@ -127,7 +127,7 @@ class TalkSubmission
             'uiux',
             'other',
             'continuousdelivery',
-            'ibmi'
+            'ibmi',
         ]);
     }
 }

--- a/classes/Http/Controller/Admin/AdminsController.php
+++ b/classes/Http/Controller/Admin/AdminsController.php
@@ -39,7 +39,7 @@ class AdminsController extends BaseController
         $templateData = [
             'pagination' => $pagination,
             'speakers' => $pagerfanta,
-            'page' => $pagerfanta->getCurrentPage()
+            'page' => $pagerfanta->getCurrentPage(),
         ];
 
         return $this->render('admin/admins/index.twig', $templateData);

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -23,7 +23,7 @@ class DashboardController extends BaseController
             'talkTotal' => $talk_mapper->all()->count(),
             'favoriteTotal' => $favorite_mapper->all()->count(),
             'selectTotal' => $talk_mapper->all()->where(['selected' => 1])->count(),
-            'talks' => $recent_talks
+            'talks' => $recent_talks,
         ];
 
         return $this->render('admin/index.twig', $templateData);

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -50,7 +50,7 @@ class SpeakersController extends BaseController
             'departure' => date('Y-m-d', $this->app->config('application.departure')),
             'pagination' => $pagination,
             'speakers' => $pagerfanta,
-            'page' => $pagerfanta->getCurrentPage()
+            'page' => $pagerfanta->getCurrentPage(),
         ];
 
         return $this->render('admin/speaker/index.twig', $templateData);
@@ -110,7 +110,7 @@ class SpeakersController extends BaseController
         $this->app['session']->set('flash', [
             'type' => $type,
             'short' => $short,
-            'ext' => $ext
+            'ext' => $ext,
         ]);
 
         return $this->redirectTo('admin_speakers');

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -186,7 +186,7 @@ class TalksController extends BaseController
 
         $talk_meta = $mapper->where([
                 'admin_user_id' => $admin_user_id,
-                'talk_id' => (int)$req->get('id')
+                'talk_id' => (int)$req->get('id'),
             ])
             ->first();
 
@@ -227,7 +227,7 @@ class TalksController extends BaseController
             // Delete the record that matches
             $favorite = $mapper->first([
                 'admin_user_id' => $admin_user_id,
-                'talk_id' => (int) $req->get('id')
+                'talk_id' => (int) $req->get('id'),
             ]);
 
             return $mapper->delete($favorite);
@@ -235,7 +235,7 @@ class TalksController extends BaseController
 
         $previous_favorite = $mapper->where([
             'admin_user_id' => $admin_user_id,
-            'talk_id' => (int) $req->get('id')
+            'talk_id' => (int) $req->get('id'),
         ]);
 
         if ($previous_favorite->count() == 0) {
@@ -296,7 +296,7 @@ class TalksController extends BaseController
         $this->app['session']->set('flash', [
                 'type' => 'success',
                 'short' => 'Success',
-                'ext' => "Comment Added!"
+                'ext' => "Comment Added!",
             ]);
 
         return $this->app->redirect($this->url('admin_talk_view', ['id' => $talk_id]));

--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -26,7 +26,7 @@ class DashboardController extends BaseController
 
             return $this->render('dashboard.twig', [
                 'profile' => $profile,
-                'cfp_open' => $this->isCfpOpen()
+                'cfp_open' => $this->isCfpOpen(),
             ]);
         } catch (NotAuthenticatedException $e) {
             return $this->redirectTo('login');

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -18,7 +18,7 @@ class ForgotController extends BaseController
 
         $data = [
             'form' => $form->createView(),
-            'current_page' => "Forgot Password"
+            'current_page' => "Forgot Password",
         ];
 
         return $this->render('user/forgot_password.twig', $data);
@@ -33,7 +33,7 @@ class ForgotController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "Please enter a properly formatted email address"
+                'ext' => "Please enter a properly formatted email address",
             ]);
 
             return $this->redirectTo('forgot_password');
@@ -57,7 +57,7 @@ class ForgotController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "We were unable to send your password reset request. Please try again"
+                'ext' => "We were unable to send your password reset request. Please try again",
             ]);
 
             return $this->redirectTo('forgot_password');
@@ -93,7 +93,7 @@ class ForgotController extends BaseController
         // Build password form and display it to the user
         $form_options = [
             'user_id' => $req->get('user_id'),
-            'reset_code' => $req->get('reset_code')
+            'reset_code' => $req->get('reset_code'),
         ];
         $form = $this->app['form.factory']->create(new ResetForm(), $form_options);
 
@@ -109,7 +109,7 @@ class ForgotController extends BaseController
         $reset_code = $req->get('reset_code');
         $form_options = [
             'user_id' => $user_id,
-            'reset_code' => $reset_code
+            'reset_code' => $reset_code,
         ];
         $form = $this->app['form.factory']->create(new ResetForm(), $form_options);
 
@@ -196,7 +196,7 @@ class ForgotController extends BaseController
         return [
             'type' => 'success',
             'short' => 'Success',
-            'ext' => "If your email was valid, we sent a link to reset your password to $email"
+            'ext' => "If your email was valid, we sent a link to reset your password to $email",
         ];
     }
 }

--- a/classes/Http/Controller/PagesController.php
+++ b/classes/Http/Controller/PagesController.php
@@ -24,7 +24,7 @@ class PagesController extends BaseController
         $numberOfTalks = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk')->all()->count();
 
         return [
-            'number_of_talks' => $numberOfTalks
+            'number_of_talks' => $numberOfTalks,
         ];
     }
 }

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -22,7 +22,7 @@ class ProfileController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "You cannot edit someone else's profile"
+                'ext' => "You cannot edit someone else's profile",
             ]);
 
             return $this->redirectTo('dashboard');
@@ -64,7 +64,7 @@ class ProfileController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "You cannot edit someone else's profile"
+                'ext' => "You cannot edit someone else's profile",
             ]);
 
             return $this->redirectTo('dashboard');
@@ -138,7 +138,7 @@ class ProfileController extends BaseController
                 $this->app['session']->set('flash', [
                     'type' => 'success',
                     'short' => 'Success',
-                    'ext' => "Successfully updated your information!"
+                    'ext' => "Successfully updated your information!",
                 ]);
 
                 return $this->redirectTo('dashboard');
@@ -147,7 +147,7 @@ class ProfileController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => implode('<br>', $form->getErrorMessages())
+                'ext' => implode('<br>', $form->getErrorMessages()),
             ]);
         }
 
@@ -183,7 +183,7 @@ class ProfileController extends BaseController
          */
         $formData = [
             'password' => $req->get('password'),
-            'password2' => $req->get('password_confirm')
+            'password2' => $req->get('password_confirm'),
         ];
         $form = new SignupForm($formData, $this->app['purifier']);
         $form->sanitize();
@@ -192,7 +192,7 @@ class ProfileController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => implode("<br>", $form->getErrorMessages())
+                'ext' => implode("<br>", $form->getErrorMessages()),
             ]);
 
             return $this->redirectTo('password_edit');
@@ -209,7 +209,7 @@ class ProfileController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "Unable to update your password in the database. Please try again."
+                'ext' => "Unable to update your password in the database. Please try again.",
             ]);
 
             return $this->redirectTo('password_edit');
@@ -218,7 +218,7 @@ class ProfileController extends BaseController
         $this->app['session']->set('flash', [
             'type' => 'success',
             'short' => 'Success',
-            'ext' => "Changed your password."
+            'ext' => "Changed your password.",
         ]);
 
         return $this->redirectTo('password_edit');

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -33,7 +33,7 @@ class SignupController extends BaseController
             'transportation' => 0,
             'hotel' => 0,
             'formAction' => $this->url('user_create'),
-            'buttonInfo' => 'Create my speaker profile'
+            'buttonInfo' => 'Create my speaker profile',
         ]);
     }
 
@@ -49,7 +49,7 @@ class SignupController extends BaseController
             'password' => $req->get('password'),
             'password2' => $req->get('password2'),
             'airport' => $req->get('airport'),
-            'buttonInfo' => 'Create my speaker profile'
+            'buttonInfo' => 'Create my speaker profile',
         ];
         $form_data['speaker_info'] = $req->get('speaker_info') ?: null;
         $form_data['speaker_bio'] = $req->get('speaker_bio') ?: null;
@@ -93,7 +93,7 @@ class SignupController extends BaseController
                     'email' => $sanitized_data['email'],
                     'password' => $sanitized_data['password'],
                     'airport' => $sanitized_data['airport'],
-                    'activated' => 1
+                    'activated' => 1,
                 ];
 
                 $user = $app['sentry']->getUserProvider()->create($user_data);
@@ -135,7 +135,7 @@ class SignupController extends BaseController
                 $app['session']->set('flash', [
                     'type' => 'error',
                     'short' => 'Error',
-                    'ext' => 'A user already exists with that email address'
+                    'ext' => 'A user already exists with that email address',
                 ]);
             }
         }
@@ -145,7 +145,7 @@ class SignupController extends BaseController
             $app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => implode("<br>", $form->getErrorMessages())
+                'ext' => implode("<br>", $form->getErrorMessages()),
             ]);
         }
 

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -78,7 +78,7 @@ class TalkController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Read Only',
-                'ext' => 'You cannot edit talks once the call for papers has ended']
+                'ext' => 'You cannot edit talks once the call for papers has ended', ]
             );
 
             return $this->app->redirect($this->url('talk_view', ['id' => $talk_id]));
@@ -132,7 +132,7 @@ class TalkController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => 'You cannot create talks once the call for papers has ended']
+                'ext' => 'You cannot create talks once the call for papers has ended', ]
             );
 
             return $this->redirectTo('dashboard');
@@ -173,7 +173,7 @@ class TalkController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => 'You cannot create talks once the call for papers has ended']
+                'ext' => 'You cannot create talks once the call for papers has ended', ]
             );
 
             return $this->redirectTo('dashboard');
@@ -191,7 +191,7 @@ class TalkController extends BaseController
             'slides' => $req->get('slides'),
             'other' => $req->get('other'),
             'sponsor' => $req->get('sponsor'),
-            'user_id' => $req->get('user_id')
+            'user_id' => $req->get('user_id'),
         ];
 
         $form = new TalkForm($request_data, $this->app['purifier']);
@@ -246,7 +246,7 @@ class TalkController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => implode("<br>", $form->getErrorMessages())
+                'ext' => implode("<br>", $form->getErrorMessages()),
             ]);
         }
 
@@ -274,7 +274,7 @@ class TalkController extends BaseController
             'slides' => $req->get('slides'),
             'other' => $req->get('other'),
             'sponsor' => $req->get('sponsor'),
-            'user_id' => $req->get('user_id')
+            'user_id' => $req->get('user_id'),
         ];
 
         $form = new TalkForm($request_data, $this->app['purifier']);
@@ -294,7 +294,7 @@ class TalkController extends BaseController
                 'slides' => $sanitized_data['slides'],
                 'other' => $sanitized_data['other'],
                 'sponsor' => $sanitized_data['sponsor'],
-                'user_id' => (int) $user->getId()
+                'user_id' => (int) $user->getId(),
             ];
 
             $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
@@ -334,7 +334,7 @@ class TalkController extends BaseController
             $this->app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => implode("<br>", $form->getErrorMessages())
+                'ext' => implode("<br>", $form->getErrorMessages()),
             ]);
         }
 
@@ -386,7 +386,7 @@ class TalkController extends BaseController
             'email' => $this->app->config('application.email'),
             'title' => $this->app->config('application.title'),
             'talk' => $talk->title,
-            'enddate' => $this->app->config('application.enddate')
+            'enddate' => $this->app->config('application.enddate'),
         ];
 
         try {

--- a/classes/Http/Form/ForgotForm.php
+++ b/classes/Http/Form/ForgotForm.php
@@ -12,8 +12,8 @@ class ForgotForm extends AbstractType
         $builder->add('email', 'text', [
             'constraints' => [
                 new Assert\NotBlank(),
-                new Assert\Email()
-            ]
+                new Assert\Email(),
+            ],
         ]);
     }
 

--- a/classes/Http/Form/ResetForm.php
+++ b/classes/Http/Form/ResetForm.php
@@ -12,13 +12,13 @@ class ResetForm extends AbstractType
         $builder->add('password', 'repeated', [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['min' => 5])],
+                    new Assert\Length(['min' => 5]), ],
                 'type' => 'password',
                 'first_options' => ['label' => 'Password (minimum 5 characters)'],
                 'second_options' => ['label' => 'Password (confirm)'],
                 'first_name' => 'password',
                 'second_name' => 'password2',
-                'invalid_message' => 'Passwords did not match'])
+                'invalid_message' => 'Passwords did not match', ])
             ->add('user_id', 'hidden')
             ->add('reset_code', 'hidden')
             ->getForm();

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -19,7 +19,7 @@ class SignupForm extends Form
         'speaker_bio',
         'transportation',
         'hotel',
-        'speaker_photo'
+        'speaker_photo',
     ];
 
     /**

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -18,7 +18,7 @@ class TalkForm extends Form
         'slides',
         'other',
         'sponsor',
-        'user_id'
+        'user_id',
     ];
 
     /**
@@ -103,7 +103,7 @@ class TalkForm extends Form
     {
         $validTalkTypes = [
             'regular',
-            'tutorial'
+            'tutorial',
         ];
 
         if (empty($this->_cleanData['type']) || !isset($this->_cleanData['type'])) {
@@ -126,7 +126,7 @@ class TalkForm extends Form
         $validLevels = [
             'entry',
             'mid',
-            'advanced'
+            'advanced',
         ];
 
         if (empty($this->_cleanData['level']) || !isset($this->_cleanData['level'])) {
@@ -158,7 +158,7 @@ class TalkForm extends Form
             'uiux',
             'other',
             'continuousdelivery',
-            'ibmi'
+            'ibmi',
         ];
 
         if (empty($this->_cleanData['category']) || !isset($this->_cleanData['category'])) {

--- a/classes/Http/OAuth/AuthorizationController.php
+++ b/classes/Http/OAuth/AuthorizationController.php
@@ -63,7 +63,7 @@ class AuthorizationController extends ApiController
         } catch (OAuthException $e) {
             return $this->setStatusCode($e->httpStatusCode)->respond([
                 'error' => $e->errorType,
-                'message' => $e->getMessage()
+                'message' => $e->getMessage(),
             ], $e->getHttpHeaders());
         }
     }
@@ -87,7 +87,7 @@ class AuthorizationController extends ApiController
 
             $redirectUri = RedirectUri::make($authParams['redirect_uri'], [
                 'error' => $error->errorType,
-                'message' => $error->getMessage()
+                'message' => $error->getMessage(),
             ]);
 
             return $this->setStatusCode(Response::HTTP_FOUND)->respond('', ['Location' => $redirectUri]);
@@ -110,7 +110,7 @@ class AuthorizationController extends ApiController
         } catch (\Exception $e) {
             return $this->setStatusCode($e->httpStatusCode)->respond([
                 'error' => $e->errorType,
-                'message' => $e->getMessage()
+                'message' => $e->getMessage(),
             ], $e->getHttpHeaders());
         }
     }

--- a/classes/Http/OAuth/ClientRegistrationController.php
+++ b/classes/Http/OAuth/ClientRegistrationController.php
@@ -43,13 +43,13 @@ class ClientRegistrationController extends ApiController
             $client = $this->clients->create([
                 'id' => $clientIdentifier,
                 'secret' => $clientSecret,
-                'name' => $request->get('name')
+                'name' => $request->get('name'),
             ]);
 
             foreach ($request->get('redirect_uris') as $uri) {
                 $this->endpoints->create([
                     'client_id' => $clientIdentifier,
-                    'redirect_uri' => $uri
+                    'redirect_uri' => $uri,
                 ]);
             }
 

--- a/classes/Infrastructure/OAuth/ClientStorage.php
+++ b/classes/Infrastructure/OAuth/ClientStorage.php
@@ -36,7 +36,7 @@ class ClientStorage extends AbstractStorage implements ClientInterface
 
             $clientData = [
                 'id'    =>  $result[0]['id'],
-                'name'  =>  $result[0]['name']
+                'name'  =>  $result[0]['name'],
             ];
 
             if ($redirectUri) {

--- a/classes/Provider/SentryServiceProvider.php
+++ b/classes/Provider/SentryServiceProvider.php
@@ -22,7 +22,7 @@ class SentryServiceProvider implements ServiceProviderInterface
             'username'  => $app->config('database.user'),
             'password'  => $app->config('database.password'),
             'charset'   => 'utf8',
-            'collation' => 'utf8_unicode_ci'
+            'collation' => 'utf8_unicode_ci',
         ]);
 
         // Makes the new "capsule" the global static instance.

--- a/classes/Provider/SpotServiceProvider.php
+++ b/classes/Provider/SpotServiceProvider.php
@@ -21,7 +21,7 @@ class SpotServiceProvider implements ServiceProviderInterface
                 'user' => $app->config('database.user'),
                 'password' => $app->config('database.password'),
                 'host' => $app->config('database.host'),
-                'driver' => 'pdo_mysql'
+                'driver' => 'pdo_mysql',
             ];
 
             if ($app->config('database.port') !== null) {

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -21,8 +21,8 @@ class TwigServiceProvider implements ServiceProviderInterface
             'twig.path' => $app->templatesPath(),
             'twig.options' => [
                 'debug' => !$app->isProduction(),
-                'cache' => $app->config('cache.enabled') ? $app->cacheTwigPath() : false
-            ]
+                'cache' => $app->config('cache.enabled') ? $app->cacheTwigPath() : false,
+            ],
         ]);
 
         if (!$app->isProduction()) {

--- a/tests/OpenCFP/Application/SpeakersTest.php
+++ b/tests/OpenCFP/Application/SpeakersTest.php
@@ -152,7 +152,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
             'description' => 'Some example talk for our submission',
             'type' => 'regular',
             'category' => 'api',
-            'level' => 'mid'
+            'level' => 'mid',
         ]);
 
         /**
@@ -177,7 +177,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
             'description' => 'Some example talk for our submission',
             'type' => 'regular',
             'category' => 'api',
-            'level' => 'mid'
+            'level' => 'mid',
         ]);
 
         $this->sut->submitTalk($submission);
@@ -206,7 +206,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
             'id' => self::SPEAKER_ID,
             'email' => 'speaker@opencfp.org',
             'first_name' => 'Fake',
-            'last_name' => 'Speaker'
+            'last_name' => 'Speaker',
         ]);
     }
 
@@ -234,7 +234,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
             new Talk([
                 'id' => 1,
                 'title' => 'Testy Talk',
-                'user_id' => self::SPEAKER_ID + 1 // Not the speaker!
+                'user_id' => self::SPEAKER_ID + 1, // Not the speaker!
             ])
         );
 
@@ -253,7 +253,7 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
             new Talk([
                 'id' => 1,
                 'title' => 'Testy Talk',
-                'user_id' => self::SPEAKER_ID
+                'user_id' => self::SPEAKER_ID,
             ])
         );
 
@@ -272,18 +272,18 @@ class SpeakersTest extends \PHPUnit_Framework_TestCase
             new Talk([
                 'id' => 1,
                 'title' => 'Testy Talk',
-                'user_id' => self::SPEAKER_ID
+                'user_id' => self::SPEAKER_ID,
             ]),
             new Talk([
                 'id' => 2,
                 'title' => 'Another Talk',
-                'user_id' => self::SPEAKER_ID
+                'user_id' => self::SPEAKER_ID,
             ]),
             new Talk([
                 'id' => 3,
                 'title' => 'Yet Another Talk',
-                'user_id' => self::SPEAKER_ID
-            ])
+                'user_id' => self::SPEAKER_ID,
+            ]),
         ]);
 
         return $stub;

--- a/tests/OpenCFP/Domain/Entity/FavoriteTest.php
+++ b/tests/OpenCFP/Domain/Entity/FavoriteTest.php
@@ -15,7 +15,7 @@ class FavoriteEntityTest extends \PHPUnit_Framework_TestCase
         $cfg = new \Spot\Config;
         $cfg->addConnection('sqlite', [
             'dbname' => 'sqlite::memory',
-            'driver' => 'pdo_sqlite'
+            'driver' => 'pdo_sqlite',
         ]);
         $this->app['spot'] = new \Spot\Locator($cfg);
         $this->mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Favorite');
@@ -26,7 +26,7 @@ class FavoriteEntityTest extends \PHPUnit_Framework_TestCase
         $data = [
             'title' => 'Favorite Entity Test',
             'description' => 'This is a stubbed talk for a Favorite Entity Test',
-            'user_id' => 1
+            'user_id' => 1,
         ];
         $talk_mapper->migrate();
         $this->talk = $talk_mapper->create($data);
@@ -42,7 +42,7 @@ class FavoriteEntityTest extends \PHPUnit_Framework_TestCase
             'id' => 1,
             'admin_user_id' => 1,
             'talk_id' => $this->talk->id,
-            'created' => $created
+            'created' => $created,
         ];
         $favorite = $this->mapper->create($data);
 

--- a/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
@@ -90,7 +90,7 @@ class TalkMapperTest extends \PHPUnit_Framework_TestCase
             $random_admin_id = rand();
             $favorite_data = [
                 'admin_user_id' => $random_admin_id,
-                'talk_id' => $talk->id
+                'talk_id' => $talk->id,
             ];
             $favorite = $favorite_mapper->create($favorite_data);
         }

--- a/tests/OpenCFP/Domain/Entity/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/TalkTest.php
@@ -14,7 +14,7 @@ class TalkEntityTest extends \PHPUnit_Framework_TestCase
         $cfg = new \Spot\Config;
         $cfg->addConnection('sqlite', [
             'dbname' => 'sqlite::memory',
-            'driver' => 'pdo_sqlite'
+            'driver' => 'pdo_sqlite',
         ]);
         $this->app['spot'] = new \Spot\Locator($cfg);
 
@@ -34,7 +34,7 @@ class TalkEntityTest extends \PHPUnit_Framework_TestCase
         $data = [
             'title' => $title,
             'description' => 'Talk with UTF-8 characters in the title',
-            'user_id' => 1
+            'user_id' => 1,
         ];
         $talk = $this->mapper->create($data);
 
@@ -75,7 +75,7 @@ class TalkEntityTest extends \PHPUnit_Framework_TestCase
             $data = [
                 'title' => $title,
                 'description' => "Description for $title",
-                'user_id' => 1
+                'user_id' => 1,
             ];
             $this->mapper->create($data);
         }

--- a/tests/OpenCFP/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/OpenCFP/Domain/Talk/TalkSubmissionTest.php
@@ -16,7 +16,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
             'description' => 'I play by the rules.',
             'type' => 'regular',
             'level' => 'entry',
-            'category' => 'api'
+            'category' => 'api',
         ]);
 
         // Factory method for talk out of submission.
@@ -45,7 +45,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
     {
         return [
             [''],
-            ['String over one-hundred characters long: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel placerat nulla. Nunc orci aliquam.']
+            ['String over one-hundred characters long: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel placerat nulla. Nunc orci aliquam.'],
         ];
     }
 
@@ -55,7 +55,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('OpenCFP\Domain\Talk\InvalidTalkSubmissionException', 'description');
         TalkSubmission::fromNative([
             'title' => 'Talk With No Description',
-            'description' => ''
+            'description' => '',
         ]);
     }
 
@@ -66,7 +66,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
         TalkSubmission::fromNative([
             'title' => 'Some off-the-wall Talk Type',
             'description' => 'I do not play by the rules.',
-            'type' => 'hamburger'
+            'type' => 'hamburger',
         ]);
     }
 
@@ -78,7 +78,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
             'title' => 'Invalid Skill Level Talk',
             'description' => 'I do not play by the rules.',
             'type' => 'regular',
-            'level' => 'over 9000'
+            'level' => 'over 9000',
         ]);
     }
 
@@ -91,7 +91,7 @@ class TalkSubmissionTest extends PHPUnit_Framework_TestCase
             'description' => 'I do not play by the rules.',
             'type' => 'regular',
             'level' => 'entry',
-            'category' => 'skylanders'
+            'category' => 'skylanders',
         ]);
     }
 }

--- a/tests/OpenCFP/Http/API/TalkApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/TalkApiControllerTest.php
@@ -103,7 +103,7 @@ class TalkApiControllerTest extends PHPUnit_Framework_TestCase
         $this->speakers->shouldReceive('getTalks')->once()->andReturn([
             new Talk(['title' => 'Testy Talk']),
             new Talk(['title' => 'Another Talk']),
-            new Talk(['title' => 'Yet Another Talk'])
+            new Talk(['title' => 'Yet Another Talk']),
         ]);
 
         $response = $this->sut->handleViewAllTalks($this->getValidRequest());
@@ -141,7 +141,7 @@ class TalkApiControllerTest extends PHPUnit_Framework_TestCase
         'description' => 'I play by the rules.',
         'type' => 'regular',
         'level' => 'entry',
-        'category' => 'api'
+        'category' => 'api',
         ]);
     }
 }

--- a/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
+++ b/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
@@ -49,7 +49,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $userDetails = [
             'id' => $userId,
             'first_name' => 'Test',
-            'last_name' => 'User'
+            'last_name' => 'User',
         ];
 
         $talkData = [0 => [
@@ -67,7 +67,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
             'created_at' => date('Y-m-d'),
             'user' => $userDetails,
             'favorite' => null,
-            'selected' => null
+            'selected' => null,
         ]];
         $userMapper = m::mock('OpenCFP\Domain\Entity\Mapper\User');
         $userMapper->shouldReceive('migrate');

--- a/tests/unit/SignupFormTest.php
+++ b/tests/unit/SignupFormTest.php
@@ -19,7 +19,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
     {
         $data = [
             'email' => 'test@domain.com',
-            'notrequired' => 'test'
+            'notrequired' => 'test',
         ];
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $response = $form->hasRequiredFields();
@@ -73,7 +73,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             ['test@domain.com', true],
             ['', false],
             ['test@domain', false],
-            ['test+tricky@domain.com', true]
+            ['test+tricky@domain.com', true],
         ];
     }
 
@@ -88,7 +88,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             ['acceptable'],
             ['testing123'],
             ['{^secur3'],
-            ['invalidChars&*$']
+            ['invalidChars&*$'],
         ];
     }
 
@@ -104,7 +104,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
     {
         $data = [
             'password' => $passwd,
-            'password2' => $passwd
+            'password2' => $passwd,
         ];
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
@@ -129,7 +129,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
     {
         $data = [
             'password' => $passwd,
-            'password2' => $passwd2
+            'password2' => $passwd2,
         ];
 
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
@@ -276,7 +276,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => 'McTesterton'
+            'last_name' => 'McTesterton',
         ];
         $baseDataWithSpeakerInfo = $baseData;
         $baseDataWithSpeakerInfo['speaker_info'] = "Testing speaker info data";
@@ -373,7 +373,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => "<script>alert('XSS')</script>"
+            'last_name' => "<script>alert('XSS')</script>",
         ];
 
         $badDataOut = [
@@ -381,7 +381,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => ""
+            'last_name' => "",
         ];
 
         $goodDataIn = [
@@ -389,7 +389,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => "McTesterton"
+            'last_name' => "McTesterton",
         ];
 
         $goodDataOut = $goodDataIn;
@@ -400,7 +400,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => "McTesterton",
-            'speaker_info' => "<a href=\"http://lolcoin.com/redeem\">Speaker bio</a>"
+            'speaker_info' => "<a href=\"http://lolcoin.com/redeem\">Speaker bio</a>",
         ];
 
         $badSpeakerInfoOut = [
@@ -409,7 +409,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => "McTesterton",
-            'speaker_info' => "<a href=\"http://lolcoin.com/redeem\">Speaker bio</a>"
+            'speaker_info' => "<a href=\"http://lolcoin.com/redeem\">Speaker bio</a>",
         ];
 
         $goodSpeakerInfoIn = [
@@ -418,7 +418,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
             'last_name' => "McTesterton",
-            'speaker_info' => "Find my bio at http://littlehart.net"
+            'speaker_info' => "Find my bio at http://littlehart.net",
         ];
 
         $goodSpeakerInfoOut = $goodSpeakerInfoIn;
@@ -427,7 +427,7 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
             [$badDataIn, $badDataOut],
             [$goodDataIn, $goodDataOut],
             [$badSpeakerInfoIn, $badSpeakerInfoOut],
-            [$goodSpeakerInfoIn, $goodSpeakerInfoOut]
+            [$goodSpeakerInfoIn, $goodSpeakerInfoOut],
         ];
     }
 }

--- a/tests/unit/TalkFormTest.php
+++ b/tests/unit/TalkFormTest.php
@@ -43,7 +43,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
     {
         $badData = [
             'title' => 'Bad Data',
-            'description' => 'Hey, why are we missing fields!'
+            'description' => 'Hey, why are we missing fields!',
         ];
         $goodData = [
             'title' => 'Talk Title',
@@ -55,7 +55,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
             'other' => 'Misc comments',
             'desired' => 1,
             'sponsor' => 1,
-            'user_id' => 1
+            'user_id' => 1,
         ];
         $extendedData = $goodData;
         $extendedData['extra'] = "Extra data in \$_POST but we ignore it";
@@ -63,7 +63,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
         return [
             [serialize($badData), false],
             [serialize($goodData), true],
-            [serialize($extendedData), true]
+            [serialize($extendedData), true],
         ];
     }
 
@@ -101,7 +101,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
             [substr($faker->text(90), 0, 90), true],
             [null, false],
             ["This is a string that could be more than 100 characters long but will we really know for sure until I check it out?", false],
-            ["A little bit of this & that", true]
+            ["A little bit of this & that", true],
         ];
     }
 
@@ -177,7 +177,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
             [null, false],
             [false, false],
             [1, false],
-            [true, false]
+            [true, false],
         ];
     }
 
@@ -190,7 +190,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
     {
         $validSpeakerInfo = [
             'user_id' => 1,
-            'info' => 'Special speaker info'
+            'info' => 'Special speaker info',
         ];
 
         return [
@@ -199,7 +199,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
             [null, false, false],
             [true, false, false],
             [false, false, false],
-            ['user', false, false]
+            ['user', false, false],
         ];
     }
 }

--- a/tests/unit/controllers/SignupControllerTest.php
+++ b/tests/unit/controllers/SignupControllerTest.php
@@ -38,7 +38,7 @@ class SignupControllerTest extends PHPUnit_Framework_TestCase
             'speaker_bio' => null,
             'transportation' => null,
             'hotel' => null,
-            'buttonInfo' => 'Create my speaker profile'
+            'buttonInfo' => 'Create my speaker profile',
         ];
 
         // Set our HTMLPurifier we use for validation

--- a/tests/unit/controllers/TalkControllerTest.php
+++ b/tests/unit/controllers/TalkControllerTest.php
@@ -20,7 +20,7 @@ class TalkControllerTest extends PHPUnit_Framework_TestCase
         $cfg = new \Spot\Config;
         $cfg->addConnection('sqlite', [
             'dbname' => 'sqlite::memory',
-            'driver' => 'pdo_sqlite'
+            'driver' => 'pdo_sqlite',
         ]);
         $this->app['spot'] = new \Spot\Locator($cfg);
 
@@ -73,7 +73,7 @@ class TalkControllerTest extends PHPUnit_Framework_TestCase
             'slides' => '',
             'other' => '',
             'sponsor' => '',
-            'user_id' => $this->app['sentry']->getUser()->getId()
+            'user_id' => $this->app['sentry']->getUser()->getId(),
         ];
 
         $this->setPost($talk_data);


### PR DESCRIPTION
This PR

* [x] enables the `multiline_array_trailing_comma` fixer
* [x] runs `make cs`

Follows #242.

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/1.11#usage:

> **multiline_array_trailing_comma [symfony]**
PHP multi-line arrays should have a trailing comma.
