### PR TITLE
Fix: Allow builds to finish early

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 sudo: false
 
 matrix:
+  fast_finish: true
   include:
     - php: 7.0
       env: WITH_COVERAGE=true


### PR DESCRIPTION
This PR

* [x] allows builds to finish early

Related to #288.

:information_desk_person: This, of course, only gives us faster feedback if the build has failed.