### PR TITLE
Fix: Disable xdebug when we don't need it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
+  - if [[ "$WITH_COVERAGE" != "true" ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - composer validate --no-check-publish
 


### PR DESCRIPTION
This PR

* [x] disables xdebug when we don't need it

Related to #288.

:information_desk_person: We only need it when we want to collect coverage, right?