### PR TITLE
Proper error message on not found speakers or talks

### DIFF
--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -65,7 +65,17 @@ class SpeakersController extends BaseController
 
         // Get info about the speaker
         $user_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\User');
-        $speaker_details = $user_mapper->get($req->get('id'))->toArray();
+        $speaker_details = $user_mapper->get($req->get('id'));
+
+        if (empty($speaker_details)) {
+            $this->app['session']->set('flash', [
+                'type' => 'error',
+                'short' => 'Error',
+                'ext' => "Could not find requested speaker",
+            ]);
+
+            return $this->app->redirect($this->url('admin_speakers'));
+        }
 
         // Get info about the talks
         $talk_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -118,6 +118,20 @@ class TalksController extends BaseController
         $meta_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\TalkMeta');
         $talk_id = $req->get('id');
 
+        $talk = $talk_mapper->where(['id' => $talk_id])
+            ->with(['comments'])
+            ->first();
+
+        if (empty($talk)) {
+            $this->app['session']->set('flash', [
+                'type' => 'error',
+                'short' => 'Error',
+                'ext' => "Could not find requested talk",
+            ]);
+
+            return $this->app->redirect($this->url('admin_talks'));
+        }
+
         // Mark talk as viewed by admin
         $talk_meta = $meta_mapper->where([
                 'admin_user_id' => $this->app['sentry']->getUser()->getId(),
@@ -136,9 +150,6 @@ class TalksController extends BaseController
             $meta_mapper->save($talk_meta);
         }
 
-        $talk = $talk_mapper->where(['id' => $talk_id])
-            ->with(['comments'])
-            ->first();
         $all_talks = $talk_mapper->all()
             ->where(['user_id' => $talk->user_id])
             ->toArray();

--- a/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
@@ -1,0 +1,80 @@
+<?php
+namespace OpenCFP\Tests\Http\Controller\Admin;
+
+use Mockery as m;
+use OpenCFP\Application;
+use OpenCFP\Environment;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+
+class TalksControllerTest extends \PHPUnit_Framework_TestCase
+{
+    public $app;
+
+    public function setup()
+    {
+        // Create our Application object
+        $this->app = new Application(BASE_PATH, Environment::testing());
+
+        // Create a test double for our User entity
+        $user = m::mock('OpenCFP\Domain\Entity\User');
+        $user->shouldReceive('hasPermission')->with('admin')->andReturn(true);
+        $user->shouldReceive('getId')->andReturn(1);
+        $user->shouldReceive('hasAccess')->with('admin')->andReturn(true);
+
+        // Create a test double for our Sentry object
+        $sentry = m::mock('Cartalyst\Sentry\Sentry');
+        $sentry->shouldReceive('check')->andReturn(true);
+        $sentry->shouldReceive('getUser')->andReturn($user);
+        $this->app['sentry'] = $sentry;
+        $this->app['user'] = $user;
+    }
+
+    /**
+     * Verify that not found speaker redirects and sets flash error message
+     *
+     * @test
+     */
+    public function speakerNotFoundHasFlashMessage()
+    {
+        $speakerId = uniqid();
+
+        // Override our mapper with the double
+        $spot = m::mock('Spot\Locator');
+        $mapper = m::mock('OpenCFP\Domain\Entity\Mapper\User');
+        $mapper->shouldReceive('get')
+            ->andReturn([]);
+
+        $spot->shouldReceive('mapper')
+            ->with('OpenCFP\Domain\Entity\User')
+            ->andReturn($mapper);
+        $this->app['spot'] = $spot;
+
+        // Create a session object
+        $this->app['session'] = new Session(new MockFileSessionStorage);
+
+        // Use our pre-configured Application object
+        ob_start();
+        $this->app->run();
+        ob_end_clean();
+
+        // Create our Request object
+        $req = m::mock('Symfony\Component\HttpFoundation\Request');
+        $req->shouldReceive('get')->with('id')->andReturn($speakerId);
+
+        // Execute the controller and capture the output
+        $controller = new \OpenCFP\Http\Controller\Admin\SpeakersController();
+        $controller->setApplication($this->app);
+        $response = $controller->viewAction($req);
+
+        $this->assertInstanceOf(
+            'Symfony\Component\HttpFoundation\RedirectResponse',
+            $response
+        );
+
+        $this->assertContains(
+            'Could not find requested speaker',
+            $this->app['session']->get('flash')
+        );
+    }
+}


### PR DESCRIPTION
This PR applies a fix for these issues: https://github.com/opencfp/opencfp/issues/276 https://github.com/opencfp/opencfp/issues/277

If no record is found, the user is redirected to the index page with a flash error message.