### PR TITLE
Fix: Each class should be in a file of its own

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
         "psr-4": {"OpenCFP\\": "classes/"}
     },
     "autoload-dev": {
+        "classmap": [
+            "tests/unit"
+        ],
         "psr-4": {
             "OpenCFP\\": "tests/OpenCFP/"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "de23e5ca6e180965f8344c17e937c4d6",
+    "hash": "3a05f2418b9953d8af316ca186d956b8",
     "content-hash": "4911e54c51c2c71f3e5053a21f3ead19",
     "packages": [
         {
@@ -1569,9 +1569,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Pimple is a simple Dependency Injection Container for PHP 5.3",
@@ -1588,12 +1586,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "1.0.0"
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "1.0.0",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
                 "shasum": ""
             },
             "type": "library",
@@ -1816,12 +1814,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "v5.0.0"
+                "reference": "e2915242824e32e28be3fc699c453c1d16fd6de1"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/e2915242824e32e28be3fc699c453c1d16fd6de1",
-                "reference": "v5.0.0",
+                "reference": "e2915242824e32e28be3fc699c453c1d16fd6de1",
                 "shasum": ""
             },
             "require": {
@@ -1845,7 +1843,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Chris Corbyn"
@@ -3885,12 +3885,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "v1.2.0"
+                "reference": "4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f",
-                "reference": "v1.2.0",
+                "reference": "4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f",
                 "shasum": ""
             },
             "require": {
@@ -3899,7 +3899,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -3923,7 +3923,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2013-06-09 17:55:57"
+            "time": "2013-06-09 18:05:57"
         },
         {
             "name": "guzzle/guzzle",

--- a/tests/unit/controllers/SessionDouble.php
+++ b/tests/unit/controllers/SessionDouble.php
@@ -1,0 +1,16 @@
+<?php
+
+class SessionDouble extends Symfony\Component\HttpFoundation\Session\Session
+{
+    protected $flash;
+
+    public function get($value, $default = null)
+    {
+        return $this->$value;
+    }
+
+    public function set($name, $value)
+    {
+        $this->$name = $value;
+    }
+}

--- a/tests/unit/controllers/TalkControllerTest.php
+++ b/tests/unit/controllers/TalkControllerTest.php
@@ -112,18 +112,3 @@ class TalkControllerTest extends PHPUnit_Framework_TestCase
         }
     }
 }
-
-class SessionDouble extends Symfony\Component\HttpFoundation\Session\Session
-{
-    protected $flash;
-
-    public function get($value, $default = null)
-    {
-        return $this->$value;
-    }
-
-    public function set($name, $value)
-    {
-        $this->$name = $value;
-    }
-}


### PR DESCRIPTION
This PR

* [x] pulls out `SessionDouble` into a file of its own
* [x] adds classmap autoloading for classes in `tests/unit`

Related to https://github.com/opencfp/opencfp/issues/308.

See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md#3-namespace-and-class-names:

> This means each class is in a file by itself, and is in a namespace of at least one level: a top-level vendor name.

:information_desk_person: This could be part of a series cleaning up the general structure of existing tests.