### PR TITLE
Add comment author full name to comment meta section

### DIFF
--- a/templates/admin/talks/view.twig
+++ b/templates/admin/talks/view.twig
@@ -53,7 +53,9 @@
                     <li>
                         <img src="{{ comment.user.photo_path ? '/uploads/' ~ comment.user.photo_path : '/assets/img/dummyphoto.jpg' }}" class="comment-photo" alt="{{ comment.user.first_name }} {{ comment.user.last_name }}">
                         <p>{{ comment.message }}</p>
-                        <span class="comment-list__meta">{{ comment.created|date("F jS \\a\\t g:ia") }}</span>
+                        <span class="comment-list__meta">
+                            <span class="comment-list__author">{{ comment.user.first_name }} {{ comment.user.last_name }}</span> - {{ comment.created|date("F jS \\a\\t g:ia") }}
+                        </span>
 
                     </li>
                 {% endfor %}

--- a/web/assets/css/site.css
+++ b/web/assets/css/site.css
@@ -280,6 +280,11 @@ a:hover {
   font-size: 75%;
 }
 
+.comment-list__author {
+  color: #999;
+  font-weight: bold;
+}
+
 .comment-photo {
   position: absolute;
   top: 0;


### PR DESCRIPTION
This makes it easier to determine who wrote which comment. Currently, the only identifier of comment author is avatar. This PR addresses: https://github.com/opencfp/opencfp/issues/279