### PR TITLE
Fix: Each class should be in a file of its own

### DIFF
--- a/tests/OpenCFP/Http/API/ApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ApiControllerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use OpenCFP\Http\API\ApiController;
-
 class ApiControllerTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -75,8 +73,4 @@ class ApiControllerTest extends PHPUnit_Framework_TestCase
             ['InternalError', 500, 'Internal server error'],
         ];
     }
-}
-
-class StubApiController extends ApiController
-{
 }

--- a/tests/OpenCFP/Http/API/ApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ApiControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenCFP\Http\API\StubApiController;
+
 class ApiControllerTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/OpenCFP/Http/API/StubApiController.php
+++ b/tests/OpenCFP/Http/API/StubApiController.php
@@ -1,6 +1,6 @@
 <?php
 
-use OpenCFP\Http\API\ApiController;
+namespace OpenCFP\Http\API;
 
 class StubApiController extends ApiController
 {

--- a/tests/OpenCFP/Http/API/StubApiController.php
+++ b/tests/OpenCFP/Http/API/StubApiController.php
@@ -1,0 +1,7 @@
+<?php
+
+use OpenCFP\Http\API\ApiController;
+
+class StubApiController extends ApiController
+{
+}


### PR DESCRIPTION
This PR

* [x] pulls out `StubApiController` into a file of its own
* [x] provides a namespace for `StubApiController` so it can be autoloaded

Follows https://github.com/opencfp/opencfp/pull/306.

Related to #307.