### PR TITLE
Fix: Increase visibility of actions

### DIFF
--- a/classes/Http/Controller/Admin/AdminsController.php
+++ b/classes/Http/Controller/Admin/AdminsController.php
@@ -10,7 +10,7 @@ class AdminsController extends BaseController
 {
     use AdminAccessTrait;
 
-    private function indexAction(Request $req)
+    public function indexAction(Request $req)
     {
         $adminGroup = $this->app['sentry']->getGroupProvider()->findByName('Admin');
         $adminUsers = $this->app['sentry']->findAllUsersInGroup($adminGroup);
@@ -45,7 +45,7 @@ class AdminsController extends BaseController
         return $this->render('admin/admins/index.twig', $templateData);
     }
 
-    private function removeAction(Request $req)
+    public function removeAction(Request $req)
     {
         $admin = $this->app['sentry']->getUser();
 

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -9,7 +9,7 @@ class DashboardController extends BaseController
 {
     use AdminAccessTrait;
 
-    private function indexAction(Request $req)
+    public function indexAction(Request $req)
     {
         $user_mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\User');
         $speaker_total = $user_mapper->all()->count();

--- a/classes/Http/Controller/Admin/ReviewController.php
+++ b/classes/Http/Controller/Admin/ReviewController.php
@@ -10,7 +10,7 @@ class ReviewController extends BaseController
 {
     use AdminAccessTrait;
 
-    private function indexAction(Request $req)
+    public function indexAction(Request $req)
     {
         $user = $this->app['sentry']->getUser();
 

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -15,7 +15,7 @@ class SpeakersController extends BaseController
     use AdminAccessTrait;
     use FlashableTrait;
 
-    private function indexAction(Request $req)
+    public function indexAction(Request $req)
     {
         $rawSpeakers = $this->app['spot']
             ->mapper('OpenCFP\Domain\Entity\User')
@@ -56,7 +56,7 @@ class SpeakersController extends BaseController
         return $this->render('admin/speaker/index.twig', $templateData);
     }
 
-    private function viewAction(Request $req)
+    public function viewAction(Request $req)
     {
         // Check if user is an logged in and an Admin
         if (!$this->userHasAccess($this->app)) {
@@ -95,7 +95,7 @@ class SpeakersController extends BaseController
         return $this->render('admin/speaker/view.twig', $templateData);
     }
 
-    private function deleteAction(Request $req)
+    public function deleteAction(Request $req)
     {
         // Check if user is an logged in and an Admin
         if (!$this->userHasAccess($this->app)) {

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -178,7 +178,7 @@ class TalksController extends BaseController
         return $this->render('admin/talks/view.twig', $templateData);
     }
 
-    private function rateAction(Request $req)
+    public function rateAction(Request $req)
     {
         if (!$this->userHasAccess($this->app)) {
             return false;
@@ -219,7 +219,7 @@ class TalksController extends BaseController
      * @param  Request $req Request Object
      * @return bool
      */
-    private function favoriteAction(Request $req)
+    public function favoriteAction(Request $req)
     {
         if (!$this->userHasAccess($this->app)) {
             return false;
@@ -266,7 +266,7 @@ class TalksController extends BaseController
      * @param  Request $req Request Object
      * @return bool
      */
-    private function selectAction(Request $req)
+    public function selectAction(Request $req)
     {
         if (!$this->userHasAccess($this->app)) {
             return false;
@@ -286,7 +286,7 @@ class TalksController extends BaseController
         return true;
     }
 
-    private function commentCreateAction(Request $req)
+    public function commentCreateAction(Request $req)
     {
         if (!$this->userHasAccess($this->app)) {
             return false;


### PR DESCRIPTION
This PR

* [x] raises the visibilities of actions from `private` to `public`

:information_desk_person: Not sure how the routing and dispatching works, but I don't think that the actions dispatched to should be `private` or `protected`.