### PR TITLE
Fix: Visibility should be protected

### DIFF
--- a/tests/OpenCFP/Domain/Services/ResetEmailerTest.php
+++ b/tests/OpenCFP/Domain/Services/ResetEmailerTest.php
@@ -16,7 +16,7 @@ class EmailerTest extends \PHPUnit_Framework_TestCase
     private $reset_code;
     private $reset_mailer;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->swift_mailer = \Mockery::mock('Swift_Mailer')->shouldReceive('send')->once()
             ->with(\Mockery::on($this->validateEmail()))->getMock();
@@ -32,7 +32,7 @@ class EmailerTest extends \PHPUnit_Framework_TestCase
         $this->reset_mailer = new ResetEmailer($this->swift_mailer, $this->template, $this->config_email, $this->config_title);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         \Mockery::close();
     }

--- a/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
@@ -11,7 +11,7 @@ class SpeakersControllerTest extends \PHPUnit_Framework_TestCase
 {
     public $app;
 
-    public function setup()
+    protected function setup()
     {
         // Create our Application object
         $this->app = new Application(BASE_PATH, Environment::testing());

--- a/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
+++ b/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
@@ -11,7 +11,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
 {
     public $app;
 
-    public function setup()
+    protected function setup()
     {
         // Create our Application object
         $this->app = new Application(BASE_PATH, Environment::testing());


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` and `tearDown()` from `public` to `protected`

Related to #307.

:information_desk_person: For reference, see 

* [PHPUnit_Framework_TestCase::setUp()](https://github.com/sebastianbergmann/phpunit/blob/4.8/src/Framework/TestCase.php#L1905-L1911)
* [PHPUnit_Framework_TestCase::tearDown()](https://github.com/sebastianbergmann/phpunit/blob/4.8/src/Framework/TestCase.php#L1937-L1943)

