### PR TITLE
Fix: Update fzaninotto/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "require-dev": {
         "codeclimate/php-test-reporter": "0.2.0",
         "fabpot/php-cs-fixer": "^1.10",
-        "fzaninotto/faker": "1.2.*",
+        "fzaninotto/faker": "^1.5.0",
         "johnkary/phpunit-speedtrap": "~1.0@dev",
         "mockery/mockery": "1.0.*@dev",
         "phpunit/dbunit": "1.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3a05f2418b9953d8af316ca186d956b8",
-    "content-hash": "4911e54c51c2c71f3e5053a21f3ead19",
+    "hash": "68d4f0d5bf4bcca7812e0772b741a458",
+    "content-hash": "026cf3fcba691677e3952f10967706f3",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -3881,31 +3881,37 @@
         },
         {
             "name": "fzaninotto/faker",
-            "version": "v1.2.0",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f"
+                "reference": "d0190b156bcca848d401fb80f31f504f37141c8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f",
-                "reference": "4ad4bc4b5c8d3c0f3cf55d2fedc2f65b313ec62f",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d0190b156bcca848d401fb80f31f504f37141c8d",
+                "reference": "d0190b156bcca848d401fb80f31f504f37141c8d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "suggest": {
+                "ext-intl": "*"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.5.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Faker": "src/",
-                    "Faker\\PHPUnit": "test/"
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3914,7 +3920,7 @@
             ],
             "authors": [
                 {
-                    "name": "François Zaninotto"
+                    "name": "Francois Zaninotto"
                 }
             ],
             "description": "Faker is a PHP library that generates fake data for you.",
@@ -3923,7 +3929,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2013-06-09 18:05:57"
+            "time": "2015-05-29 06:29:14"
         },
         {
             "name": "guzzle/guzzle",


### PR DESCRIPTION
This PR

* [x] updates `fzaninotto/faker`

Related to #307.

:information_desk_person: Because why not? [`fzaninotto/faker:1.2.0`](https://packagist.org/packages/fzaninotto/faker#v1.2.0) was released more than two years ago.