### PR TITLE
Enhancement: Extract GeneratorTrait

### DIFF
--- a/tests/OpenCFP/Util/Faker/GeneratorTest.php
+++ b/tests/OpenCFP/Util/Faker/GeneratorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OpenCFP\Util\Faker;
+
+use Faker\Generator;
+
+class GeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    use GeneratorTrait;
+
+    public function testGetFakerReturnsFaker()
+    {
+        $faker = $this->getFaker();
+
+        $this->assertInstanceOf(Generator::class, $faker);
+    }
+
+    public function testGetFakerReturnsSameInstance()
+    {
+        $faker = $this->getFaker();
+
+        $this->assertSame($faker, $this->getFaker());
+    }
+}

--- a/tests/OpenCFP/Util/Faker/GeneratorTrait.php
+++ b/tests/OpenCFP/Util/Faker/GeneratorTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenCFP\Util\Faker;
+
+use Faker\Factory;
+use Faker\Generator;
+
+trait GeneratorTrait
+{
+    /**
+     * @return Generator
+     */
+    protected function getFaker()
+    {
+        static $faker;
+
+        if ($faker === null) {
+            $faker = Factory::create();
+        }
+
+        return $faker;
+    }
+}

--- a/tests/unit/TalkFormTest.php
+++ b/tests/unit/TalkFormTest.php
@@ -1,11 +1,15 @@
 <?php
 
+use OpenCFP\Util\Faker\GeneratorTrait;
+
 /**
  * Tests for our TalkForm object
  */
 
 class TalkFormTest extends \PHPUnit_Framework_TestCase
 {
+    use GeneratorTrait;
+
     private $purifier;
 
     protected function setUp()
@@ -95,7 +99,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
      */
     public function titleValidatesProvider()
     {
-        $faker = \Faker\Factory::create();
+        $faker = $this->getFaker();
 
         return [
             [substr($faker->text(90), 0, 90), true],
@@ -133,7 +137,7 @@ class TalkFormTest extends \PHPUnit_Framework_TestCase
      */
     public function descriptionValidatesProvider()
     {
-        $faker = \Faker\Factory::create();
+        $faker = $this->getFaker();
 
         return [
             [$faker->text(), true],


### PR DESCRIPTION
This PR

* [x] extracts a `Util\Faker\GeneratorTrait` which returns an instance of `Faker\Generator`
* [x] makes use of the aforementioned trait

Related to #307.

:information_desk_person: While I personally tend to use traits with care, this has proven useful in tests.