### PR TITLE
Enhancement: Enable unused_use fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -12,6 +12,7 @@ return Symfony\CS\Config\Config::create()
         'multiline_array_trailing_comma',
         'ordered_use',
         'short_array_syntax',
+        'unused_use',
     ])
     ->finder($finder)
 ;

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -3,7 +3,6 @@
 namespace OpenCFP\Http\Controller;
 
 use Cartalyst\Sentry\Users\UserNotFoundException;
-use OpenCFP\Application;
 use OpenCFP\Http\Form\ForgotForm;
 use OpenCFP\Http\Form\ResetForm;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/OpenCFP/ContainerAwareTest.php
+++ b/tests/OpenCFP/ContainerAwareTest.php
@@ -3,7 +3,6 @@
 namespace OpenCFP;
 
 use Mockery as m;
-use OpenCFP\Application;
 
 class ContainerAwareTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
@@ -1,5 +1,4 @@
 <?php
-use Mockery as m;
 use OpenCFP\Application;
 use OpenCFP\Environment;
 

--- a/tests/OpenCFP/Http/Controller/FlashableTraitFake.php
+++ b/tests/OpenCFP/Http/Controller/FlashableTraitFake.php
@@ -2,8 +2,6 @@
 
 namespace OpenCFP\Http\Controller;
 
-use OpenCFP\Application;
-
 class FlashableTraitFake
 {
     use FlashableTrait;

--- a/tests/unit/controllers/SignupControllerTest.php
+++ b/tests/unit/controllers/SignupControllerTest.php
@@ -1,6 +1,5 @@
 <?php
 use Mockery as m;
-use OpenCFP\Application;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 


### PR DESCRIPTION
This PR

* [x] enables the `unused_use` fixer
* [x] runs `make cs`

Follows #242.

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/1.11#usage:

> **unused_use [symfony]**
Unused use statements must be removed.
