### PR TITLE
Fix: Use Mockery in ContainerAwareTest

### DIFF
--- a/tests/OpenCFP/ContainerAwareTest.php
+++ b/tests/OpenCFP/ContainerAwareTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP;
 
+use Mockery as m;
 use OpenCFP\Application;
 
 class ContainerAwareTest extends \PHPUnit_Framework_TestCase
@@ -14,10 +15,10 @@ class ContainerAwareTest extends \PHPUnit_Framework_TestCase
         $application = $this->getApplicationMock();
 
         $application
-            ->expects($this->once())
-            ->method('offsetGet')
-            ->with($this->identicalTo($slug))
-            ->willReturn($service)
+            ->shouldReceive('offsetGet')
+            ->once()
+            ->with($slug)
+            ->andReturn($service)
         ;
 
         $containerAware = new ContainerAwareFake();
@@ -28,13 +29,10 @@ class ContainerAwareTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Application
+     * @return m\MockInterface|Application
      */
     private function getApplicationMock()
     {
-        return $this->getMockBuilder('OpenCFP\Application')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
+        return m::mock(Application::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] adjusts `ContainerAwareTest` to make use of `Mockery`

Follows https://github.com/opencfp/opencfp/pull/317#issuecomment-168337163.

:information_desk_person: Consistency always wins!