### PR TITLE
Fix: Use GeneratorTrait

### DIFF
--- a/tests/OpenCFP/Domain/Services/LoginTest.php
+++ b/tests/OpenCFP/Domain/Services/LoginTest.php
@@ -5,12 +5,13 @@ namespace OpenCFP\Domain\Services;
 use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users\UserNotActivatedException;
 use Cartalyst\Sentry\Users\UserNotFoundException;
-use Faker\Factory;
-use Faker\Generator;
 use Mockery as m;
+use OpenCFP\Util\Faker\GeneratorTrait;
 
 class LoginTest extends \PHPUnit_Framework_TestCase
 {
+    use GeneratorTrait;
+
     protected function tearDown()
     {
         unset($_REQUEST);
@@ -236,20 +237,6 @@ class LoginTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertSame($expected, $viewVariables);
-    }
-
-    /**
-     * @return Generator
-     */
-    private function getFaker()
-    {
-        static $faker;
-
-        if ($faker === null) {
-            $faker = Factory::create();
-        }
-
-        return $faker;
     }
 
     /**

--- a/tests/OpenCFP/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/OpenCFP/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -4,16 +4,17 @@ namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users;
-use Faker\Factory;
-use Faker\Generator;
 use Mockery as m;
 use OpenCFP\Domain\Entity;
 use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
 use OpenCFP\Domain\Speaker\SpeakerRepository;
+use OpenCFP\Util\Faker\GeneratorTrait;
 
 class SentryIdentityProviderTest extends \PHPUnit_Framework_TestCase
 {
+    use GeneratorTrait;
+
     public function testImplementsIdentityProvider()
     {
         $sentry = $this->getSentryMock();
@@ -88,20 +89,6 @@ class SentryIdentityProviderTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($user, $provider->getCurrentUser());
-    }
-
-    /**
-     * @return Generator
-     */
-    private function getFaker()
-    {
-        static $faker;
-
-        if ($faker === null) {
-            $faker = Factory::create();
-        }
-
-        return $faker;
     }
 
     /**

--- a/tests/OpenCFP/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
+++ b/tests/OpenCFP/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
@@ -2,16 +2,17 @@
 
 namespace OpenCFP\Infrastructure\Persistence;
 
-use Faker\Factory;
-use Faker\Generator;
 use Mockery as m;
 use OpenCFP\Domain\Entity;
 use OpenCFP\Domain\EntityNotFoundException;
 use OpenCFP\Domain\Speaker\SpeakerRepository;
+use OpenCFP\Util\Faker\GeneratorTrait;
 use Spot\Mapper;
 
 class SpotSpeakerRepositoryTest extends \PHPUnit_Framework_TestCase
 {
+    use GeneratorTrait;
+
     public function testImplementsSpeakerRepository()
     {
         $mapper = $this->getMapperMock();
@@ -74,20 +75,6 @@ class SpotSpeakerRepositoryTest extends \PHPUnit_Framework_TestCase
         $repository = new SpotSpeakerRepository($mapper);
 
         $repository->persist($speaker);
-    }
-
-    /**
-     * @return Generator
-     */
-    private function getFaker()
-    {
-        static $faker;
-
-        if ($faker === null) {
-            $faker = Factory::create();
-        }
-
-        return $faker;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] makes use of the previously extracted `Util\Faker\GeneratorTrait`

Follows #314.