### PR TITLE
Fix: Use more appropriate formatter

### DIFF
--- a/tests/OpenCFP/Domain/Services/LoginTest.php
+++ b/tests/OpenCFP/Domain/Services/LoginTest.php
@@ -85,7 +85,7 @@ class LoginTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $email = $faker->email;
-        $password = $faker->word;
+        $password = $faker->password;
 
         $sentry = $this->getSentryMock();
 
@@ -114,7 +114,7 @@ class LoginTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $email = $faker->email;
-        $password = $faker->word;
+        $password = $faker->password;
 
         $sentry = $this->getSentryMock();
 
@@ -143,7 +143,7 @@ class LoginTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $email = $faker->email;
-        $password = $faker->word;
+        $password = $faker->password;
 
         $sentry = $this->getSentryMock();
 
@@ -171,7 +171,7 @@ class LoginTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $email = $faker->email;
-        $password = $faker->word;
+        $password = $faker->password;
 
         $sentry = $this->getSentryMock();
 
@@ -206,7 +206,7 @@ class LoginTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $email = $faker->email;
-        $password = $faker->word;
+        $password = $faker->password;
 
         $sentry = $this->getSentryMock();
 


### PR DESCRIPTION
This PR

* [x] uses a more appropriate formatter when generating fake passwords

Follows #313.