### PR TITLE
Fix: Case-insensitive method names

### DIFF
--- a/tests/OpenCFP/Domain/Entity/FavoriteTest.php
+++ b/tests/OpenCFP/Domain/Entity/FavoriteTest.php
@@ -8,7 +8,7 @@ class FavoriteEntityTest extends \PHPUnit_Framework_TestCase
     public $mapper;
     public $talk;
 
-    protected function setup()
+    protected function setUp()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
         // Create an in-memory database

--- a/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
@@ -9,7 +9,7 @@ class TalkMapperTest extends \PHPUnit_Framework_TestCase
     public $mapper;
     private $entities = ['Talk', 'TalkMeta', 'User', 'Favorite'];
 
-    protected function setup()
+    protected function setUp()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
         $cfg = new \Spot\Config;

--- a/tests/OpenCFP/Domain/Entity/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/TalkTest.php
@@ -8,7 +8,7 @@ class TalkEntityTest extends \PHPUnit_Framework_TestCase
     public $mapper;
     private $entities = ['Talk', 'TalkMeta', 'User', 'Favorite'];
 
-    protected function setup()
+    protected function setUp()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
         $cfg = new \Spot\Config;

--- a/tests/OpenCFP/Http/API/ApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ApiControllerTest.php
@@ -9,7 +9,7 @@ class ApiControllerTest extends PHPUnit_Framework_TestCase
      */
     private $sut;
 
-    protected function setup()
+    protected function setUp()
     {
         $this->sut = new StubApiController();
     }

--- a/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
@@ -20,7 +20,7 @@ class ProfileApiControllerTest extends PHPUnit_Framework_TestCase
      */
     private $speakers;
 
-    protected function setup()
+    protected function setUp()
     {
         $this->speakers = m::mock('OpenCFP\Application\Speakers');
         $this->sut = new ProfileController($this->speakers);

--- a/tests/OpenCFP/Http/API/TalkApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/TalkApiControllerTest.php
@@ -20,7 +20,7 @@ class TalkApiControllerTest extends PHPUnit_Framework_TestCase
      */
     private $speakers;
 
-    protected function setup()
+    protected function setUp()
     {
         $this->speakers = m::mock('OpenCFP\Application\Speakers');
         $this->sut = new TalkController($this->speakers);

--- a/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
@@ -11,7 +11,7 @@ class SpeakersControllerTest extends \PHPUnit_Framework_TestCase
 {
     public $app;
 
-    protected function setup()
+    protected function setUp()
     {
         // Create our Application object
         $this->app = new Application(BASE_PATH, Environment::testing());

--- a/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
+++ b/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
@@ -11,7 +11,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
 {
     public $app;
 
-    protected function setup()
+    protected function setUp()
     {
         // Create our Application object
         $this->app = new Application(BASE_PATH, Environment::testing());

--- a/tests/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -10,7 +10,7 @@ class PseudoRandomStringGeneratorTest extends PHPUnit_Framework_TestCase
      */
     private $sut;
 
-    protected function setup()
+    protected function setUp()
     {
         $this->sut = new PseudoRandomStringGenerator(new Factory());
     }

--- a/tests/unit/controllers/TalkControllerTest.php
+++ b/tests/unit/controllers/TalkControllerTest.php
@@ -9,7 +9,7 @@ class TalkControllerTest extends PHPUnit_Framework_TestCase
     protected $app;
     protected $req;
 
-    protected function setup()
+    protected function setUp()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
         ob_start();


### PR DESCRIPTION
This PR

* [x] renames `setup()` to `setUp()`

Related to #307.
Follows #312.