### PR TITLE
Fix: Remove unused import

### DIFF
--- a/tests/OpenCFP/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/OpenCFP/Domain/Speaker/SpeakerProfileTest.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Domain\Speaker;
 
-use Mockery as m;
 use OpenCFP\Domain\Entity;
 use OpenCFP\Util\Faker\GeneratorTrait;
 


### PR DESCRIPTION
This PR

* [x] removes an unused import

Follows #326.
Follows #243.

:information_desk_person: This PR fixes the build failing after merging #326, see

* https://travis-ci.org/opencfp/opencfp/jobs/99910489#L531