### PR TITLE
Fix: Pick a number greater than 0, but not 1

### DIFF
--- a/tests/OpenCFP/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/OpenCFP/Domain/Speaker/SpeakerProfileTest.php
@@ -117,7 +117,12 @@ class SpeakerProfileTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTransportationReturnsFalseIfValueIsNotOne()
     {
-        $transportation = (string) $this->getFaker()->randomNumber(1);
+        $faker = $this->getFaker();
+
+        $transportation = $faker->randomElement([
+            0,
+            $faker->numberBetween(2),
+        ]);
 
         $speaker = new Entity\User();
 


### PR DESCRIPTION
This PR

* [x] picks a non-negative number , but not 1

Follows #326.

:information_desk_person: This fixes the build failing after merging #326, see

* https://travis-ci.org/opencfp/opencfp/jobs/99910488#L527