### PR TITLE
Fix: Seed Faker

### DIFF
--- a/tests/OpenCFP/Util/Faker/GeneratorTrait.php
+++ b/tests/OpenCFP/Util/Faker/GeneratorTrait.php
@@ -16,6 +16,7 @@ trait GeneratorTrait
 
         if ($faker === null) {
             $faker = Factory::create();
+            $faker->seed(9000);
         }
 
         return $faker;


### PR DESCRIPTION
This PR

* [x] seeds the faker, resulting in the same randomness, if you will

:information_desk_person: This produces the same results, sort of.

For reference, see https://github.com/fzaninotto/Faker#seeding-the-generator.