### PR TITLE
Fix: Invalid default values for DATETIME columns

### DIFF
--- a/migrations/20141201172522_alter_user_column_defaults.php
+++ b/migrations/20141201172522_alter_user_column_defaults.php
@@ -19,8 +19,8 @@ class AlterUserColumnDefaults extends AbstractMigration
             ->changeColumn('reset_password_code', 'string', ['null' => true])
             ->changeColumn('first_name', 'string', ['null' => true])
             ->changeColumn('last_name', 'string', ['null' => true])
-            ->changeColumn('created_at', 'datetime', ['default' => '0000-00-00 00:00:00'])
-            ->changeColumn('updated_at', 'datetime', ['default' => '0000-00-00 00:00:00'])
+            ->changeColumn('created_at', 'datetime', ['default' => '1000-01-01 00:00:00'])
+            ->changeColumn('updated_at', 'datetime', ['default' => '1000-01-01 00:00:00'])
             ->save();
     }
 

--- a/migrations/20141203111136_alter_talk_column_defaults.php
+++ b/migrations/20141203111136_alter_talk_column_defaults.php
@@ -14,8 +14,8 @@ class AlterTalkColumnDefaults extends AbstractMigration
             ->changeColumn('favorite', 'boolean', ['default' => 0])
             ->changeColumn('sponsor', 'boolean', ['default' => 0])
             ->changeColumn('selected', 'boolean', ['default' => 0])
-            ->changeColumn('created_at', 'datetime', ['default' => '0000-00-00 00:00:00'])
-            ->changeColumn('updated_at', 'datetime', ['default' => '0000-00-00 00:00:00'])
+            ->changeColumn('created_at', 'datetime', ['default' => '1000-01-01 00:00:00'])
+            ->changeColumn('updated_at', 'datetime', ['default' => '1000-01-01 00:00:00'])
             ->save();
     }
 

--- a/migrations/20150702132854_fix_defaults_for_users_table.php
+++ b/migrations/20150702132854_fix_defaults_for_users_table.php
@@ -21,14 +21,14 @@ class FixDefaultsForUsersTable extends AbstractMigration
         $users->changeColumn('permissions', 'text', ['null' => true]);
         $users->changeColumn('activated', 'boolean', ['default' => 0]);
         $users->changeColumn('activation_code', 'string', ['null' => true]);
-        $users->changeColumn('activated_at', 'datetime', ['null' => true, 'default' => '0000-00-00 00:00:00']);
-        $users->changeColumn('last_login', 'datetime', ['null' => true, 'default' => '0000-00-00 00:00:00']);
+        $users->changeColumn('activated_at', 'datetime', ['null' => true, 'default' => '1000-01-01 00:00:00']);
+        $users->changeColumn('last_login', 'datetime', ['null' => true, 'default' => '1000-01-01 00:00:00']);
         $users->changeColumn('persist_code', 'string', ['null' => true]);
         $users->changeColumn('reset_password_code', 'string', ['null' => true]);
         $users->changeColumn('first_name', 'string', ['null' => true]);
         $users->changeColumn('last_name', 'string', ['null' => true]);
-        $users->changeColumn('created_at', 'datetime', ['default' => '0000-00-00 00:00:00']);
-        $users->changeColumn('updated_at', 'datetime', ['default' => '0000-00-00 00:00:00']);
+        $users->changeColumn('created_at', 'datetime', ['default' => '1000-01-01 00:00:00']);
+        $users->changeColumn('updated_at', 'datetime', ['default' => '1000-01-01 00:00:00']);
 
         // Custom fields
         $users->changeColumn('company', 'string', ['null' => true]);

--- a/migrations/20160103163540_allow_date_time_fields_to_be_null.php
+++ b/migrations/20160103163540_allow_date_time_fields_to_be_null.php
@@ -1,0 +1,71 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AllowDateTimeFieldsToBeNull extends AbstractMigration
+{
+    public function up()
+    {
+        $options = [
+            'null' => true,
+            'default' => null,
+        ];
+
+        $talks = $this->table('talks');
+
+        $talks->changeColumn('created_at', 'datetime', $options);
+        $talks->changeColumn('updated_at', 'datetime', $options);
+
+        $talks->save();
+
+        $users = $this->table('users');
+
+        $users->changeColumn('activated_at', 'datetime', $options);
+        $users->changeColumn('created_at', 'datetime', $options);
+        $users->changeColumn('updated_at', 'datetime', $options);
+        $users->changeColumn('last_login', 'datetime', $options);
+
+        $users->save();
+    }
+
+    public function down()
+    {
+        $talks = $this->table('talks');
+
+        $talks->changeColumn('created_at', 'datetime', [
+            'null' => false,
+            'default' => '1000-01-01 00:00:00',
+        ]);
+
+        $talks->changeColumn('updated_at', 'datetime', [
+            'null' => false,
+            'default' => '1000-01-01 00:00:00',
+        ]);
+
+        $talks->save();
+
+        $users = $this->table('users');
+
+        $users->changeColumn('activated_at', 'datetime', [
+            'null' => true,
+            'default' => '1000-01-01 00:00:00',
+        ]);
+
+        $users->changeColumn('created_at', 'datetime', [
+            'null' => false,
+            'default' => '1000-01-01 00:00:00',
+        ]);
+
+        $users->changeColumn('updated_at', 'datetime', [
+            'null' => false,
+            'default' => '1000-01-01 00:00:00',
+        ]);
+
+        $users->changeColumn('last_login', 'datetime', [
+            'null' => true,
+            'default' => '1000-01-01 00:00:00',
+        ]);
+
+        $users->save();
+    }
+}

--- a/migrations/20160103164746_set_date_time_fields_with_previous_default_to_null.php
+++ b/migrations/20160103164746_set_date_time_fields_with_previous_default_to_null.php
@@ -1,0 +1,46 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class SetDateTimeFieldsWithPreviousDefaultToNull extends AbstractMigration
+{
+    /**
+     * @var array
+     */
+    private $tables = [
+        'talks' => [
+            'created_at',
+            'updated_at',
+        ],
+        'users' => [
+            'activated_at',
+            'created_at',
+            'updated_at',
+            'last_login',
+        ],
+    ];
+
+    public function up()
+    {
+        $this->run('UPDATE `%s` SET `%s` = NULL WHERE `%s` = "1000-01-01 00:00:00"');
+    }
+
+    public function down()
+    {
+        $this->run('UPDATE `%s` SET `%s` = "1000-01-01 00:00:00" WHERE `%s` IS NULL');
+    }
+
+    private function run($sql)
+    {
+        array_walk($this->tables, function ($columnNames, $tableName) use ($sql) {
+            array_walk($columnNames, function ($columnName) use ($tableName, $sql) {
+                $this->execute(sprintf(
+                    $sql,
+                    $tableName,
+                    $columnName,
+                    $columnName
+                ));
+            });
+        });
+    }
+}


### PR DESCRIPTION
This PR

* [x] modifies existing migrations to set `DATETIME` field defaults to values within accepted range
* [x] adds a migration which allows `DATETIME` fields to be nullable and changes their default to `NULL`
* [x] adds a migration which updates `DATETIME` fields with previous defaults to `NULL`

Somewhat related to #307.

:person_with_pouting_face: An attempt to run the migrations on a system where MySQL 5.7 is installed results in this:

```
$ vendor/bin/phinx migrate --configuration phinx.yml.dist

Phinx by Rob Morgan - https://phinx.org. version 0.5.0

using config file ./phinx.yml.dist
using config parser yaml
using migration path /Users/am/Sites/opencfp/opencfp/migrations
warning no environment specified, defaulting to: development
using adapter mysql
using database cfp

 == 20141201172522 AlterUserColumnDefaults: migrating

  [PDOException]
  SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'created_at'
```

## Server SQL Modes

As suggested by @mdwheele, this is apparently related to different default MySQL modes:

### MySQL 5.5 (as seen on Travis)

See http://dev.mysql.com/doc/refman/5.5/en/sql-mode.html#sql-mode-setting:

> The default SQL mode is empty (no modes set).

```
$ mysql -e "SHOW VARIABLES LIKE '%version%'" -uroot

+-------------------------+-----------------------------+
| Variable_name           | Value                       |
+-------------------------+-----------------------------+
| innodb_version          | 5.5.41                      |
| protocol_version        | 10                          |
| slave_type_conversions  |                             |
| version                 | 5.5.41-0ubuntu0.12.04.1-log |
| version_comment         | (Ubuntu)                    |
| version_compile_machine | x86_64                      |
| version_compile_os      | debian-linux-gnu            |
+-------------------------+-----------------------------+

$ mysql -e "SELECT @@GLOBAL.sql_mode;" -uroot

+-------------------+
| @@GLOBAL.sql_mode |
+-------------------+
|                   |
+-------------------+

$ mysql -e "SELECT @@SESSION.sql_mode;" -uroot

+--------------------+
| @@SESSION.sql_mode |
+--------------------+
|                    |
+--------------------+
```

For reference, see 

* https://travis-ci.org/opencfp/opencfp/jobs/100003130#L459-L470
* https://travis-ci.org/opencfp/opencfp/jobs/100003130#L471-L476
* https://travis-ci.org/opencfp/opencfp/jobs/100003130#L477-L482

### MySQL 5.7

See http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-setting:

> The default SQL mode in MySQL 5.7 includes these modes: [`ONLY_FULL_GROUP_BY`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by), [`STRICT_TRANS_TABLES`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_strict_trans_tables), [`NO_ZERO_IN_DATE`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_in_date), [`NO_ZERO_DATE`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_date), [`ERROR_FOR_DIVISION_BY_ZERO`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_error_for_division_by_zero), [`NO_AUTO_CREATE_USER`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_auto_create_user), and [`NO_ENGINE_SUBSTITUTION`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_engine_substitution).

> The [`ONLY_FULL_GROUP_BY`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by) and [`STRICT_TRANS_TABLES`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_strict_trans_tables) modes were added in MySQL 5.7.5. The [`NO_AUTO_CREATE_USER`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_auto_create_user) mode was added in MySQL 5.7.7. The [`ERROR_FOR_DIVISION_BY_ZERO`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_error_for_division_by_zero), [`NO_ZERO_DATE`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_date), and [`NO_ZERO_IN_DATE`](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_in_date) modes were added in MySQL 5.7.8. For additional discussion regarding these changes to the default SQL mode value, see [SQL Mode Changes in MySQL 5.7](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-changes).

```
$ mysql -e "SHOW VARIABLES LIKE '%version%'" -uroot 

+-------------------------+----------+
| Variable_name           | Value    |
+-------------------------+----------+
| innodb_version          | 5.7.9    |
| protocol_version        | 10       |
| slave_type_conversions  |          |
| version                 | 5.7.9    |
| version_comment         | Homebrew |
| version_compile_machine | x86_64   |
| version_compile_os      | osx10.11 |
+-------------------------+----------+

$ mysql -e "SELECT @@GLOBAL.sql_mode;" -uroot 

+-------------------------------------------------------------------------------------------------------------------------------------------+
| @@GLOBAL.sql_mode                                                                                                                         |
+-------------------------------------------------------------------------------------------------------------------------------------------+
| ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION |
+-------------------------------------------------------------------------------------------------------------------------------------------+

$ mysql -e "SELECT @@SESSION.sql_mode;" -uroot 

+-------------------------------------------------------------------------------------------------------------------------------------------+
| @@SESSION.sql_mode                                                                                                                        |
+-------------------------------------------------------------------------------------------------------------------------------------------+
| ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION |
+-------------------------------------------------------------------------------------------------------------------------------------------+
```

#### `NO_ZERO_DATE`

See http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_date:

>The `NO_ZERO_DATE` mode affects whether the server permits `0000-00-00` as a valid date. Its effect also depends on whether strict SQL mode is enabled.
>
>* If this mode is not enabled, `0000-00-00` is permitted and inserts produce no warning.
>
* If this mode is enabled, `0000-00-00` is permitted and inserts produce a warning.
>
>If this mode and strict mode are enabled, `0000-00-00` is not permitted and inserts produce an error, unless `IGNORE` is given as well. For `INSERT IGNORE` and `UPDATE IGNORE`, `0000-00-00` is permitted and inserts produce a warning.
