### PR TITLE
Remove poor-man's debug statement

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -281,7 +281,6 @@ class Application extends SilexApplication
         $app->error(function (\Exception $e, $code) use ($app) {
             /** @var Request $request */
             $request = $app['request'];
-            die($e->getMessage());
 
             if (in_array('application/json', $request->getAcceptableContentTypes())) {
                 $headers = [];


### PR DESCRIPTION
Yeahhhh... this is my bad so boo to me on this one.

In applying some fix-up changes to #333, I needed to get the exception message before error handler munched it. Rather than actually improving things (as I should have), I just dumped the message as a temporary measure. This got committed.

Because this was committed, the following happened afterwards...

![image](https://cloud.githubusercontent.com/assets/2453394/12279968/94590e06-b958-11e5-9beb-3fd7c6d2a781.png)

That's right... the unit test suite is actually bailing in the middle of execution from a `die` statement in the error handler and then returning zero! 

Anywho, this PR is against the tip of `upstream/master` and demonstrates a passing (for real) test suite. Kicking myself over this. I should have caught it. My bad!

/cc @chartjes Can you review and merge this when ready?
