### PR TITLE
Apply Consistency Fixups to tests/OpenCFP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/opencfp
 
 - **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to run `make cs`, which will apply all code-style fixes necessary.
 
-- **Add tests!** - Your patch probably won't be accepted if it doesn't have tests. Any new tests must be placed in the `tests/OpenCFP` directory and properly namespaced at `OpenCFP\Tests`. There will be an ongoing effort to move remaining tests from `tests/unit` into that namespace.
+- **Add tests!** - Your patch probably won't be accepted if it doesn't have tests. Any new tests must be placed in the `tests/OpenCFP` directory and properly namespaced at `OpenCFP\Test`. There will be an ongoing effort to move remaining tests from `tests/unit` into that namespace.
 
 - **Tests must be clear in meaning** - We value clarity in meaning / purposes behind tests. If there is excessive setup required for a test, it should be hidden behind an intention-revealing (and possibly re-usable) method.
 

--- a/composer.json
+++ b/composer.json
@@ -38,14 +38,16 @@
         "monolog/monolog": "^1.17"
     },
     "autoload": {
-        "psr-4": {"OpenCFP\\": "classes/"}
+        "psr-4": {
+            "OpenCFP\\": "classes/"
+        }
     },
     "autoload-dev": {
         "classmap": [
             "tests/unit"
         ],
         "psr-4": {
-            "OpenCFP\\": "tests/OpenCFP/"
+            "OpenCFP\\Test\\": "tests/OpenCFP/"
         }
     },
     "require-dev": {

--- a/tests/OpenCFP/Application/SpeakersTest.php
+++ b/tests/OpenCFP/Application/SpeakersTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace OpenCFP\Application;
+namespace OpenCFP\Test\Application;
 
 use Mockery as m;
 use Mockery\MockInterface;
+use OpenCFP\Application\Speakers;
 use OpenCFP\Domain\CallForProposal;
 use OpenCFP\Domain\Entity\Talk;
 use OpenCFP\Domain\Entity\User;

--- a/tests/OpenCFP/ApplicationTest.php
+++ b/tests/OpenCFP/ApplicationTest.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace OpenCFP;
+namespace OpenCFP\Test;
 
+use OpenCFP\Application;
+use OpenCFP\Environment;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 

--- a/tests/OpenCFP/ApplicationTest.php
+++ b/tests/OpenCFP/ApplicationTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 class ApplicationTest extends \PHPUnit_Framework_TestCase
 {
     /** @var Application */
-    protected $sut;
+    private $sut;
 
     /**
      * @test

--- a/tests/OpenCFP/ContainerAwareFake.php
+++ b/tests/OpenCFP/ContainerAwareFake.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace OpenCFP;
+namespace OpenCFP\Test;
+
+use OpenCFP\ContainerAware;
 
 class ContainerAwareFake
 {

--- a/tests/OpenCFP/ContainerAwareTest.php
+++ b/tests/OpenCFP/ContainerAwareTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace OpenCFP;
+namespace OpenCFP\Test;
 
 use Mockery as m;
+use OpenCFP\Application;
 
 class ContainerAwareTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/OpenCFP/ContainerAwareTest.php
+++ b/tests/OpenCFP/ContainerAwareTest.php
@@ -28,6 +28,10 @@ class ContainerAwareTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($service, $containerAware->getService($slug));
     }
 
+    //
+    // Factory Method
+    //
+
     /**
      * @return m\MockInterface|Application
      */

--- a/tests/OpenCFP/Domain/CallForProposalTest.php
+++ b/tests/OpenCFP/Domain/CallForProposalTest.php
@@ -1,8 +1,11 @@
 <?php
 
+namespace OpenCFP\Test\Domain;
+
+use DateTime;
 use OpenCFP\Domain\CallForProposal;
 
-class CallForProposalTest extends PHPUnit_Framework_TestCase
+class CallForProposalTest extends \PHPUnit_Framework_TestCase
 {
     /** @test */
     public function it_should_tell_whether_or_not_the_cfp_is_open()

--- a/tests/OpenCFP/Domain/Entity/FavoriteTest.php
+++ b/tests/OpenCFP/Domain/Entity/FavoriteTest.php
@@ -5,11 +5,14 @@ namespace OpenCFP\Test\Domain\Entity;
 use OpenCFP\Application;
 use OpenCFP\Environment;
 
-class FavoriteEntityTest extends \PHPUnit_Framework_TestCase
+/**
+ * @group db
+ */
+class FavoriteTest extends \PHPUnit_Framework_TestCase
 {
-    public $app;
-    public $mapper;
-    public $talk;
+    private $app;
+    private $mapper;
+    private $talk;
 
     protected function setUp()
     {

--- a/tests/OpenCFP/Domain/Entity/FavoriteTest.php
+++ b/tests/OpenCFP/Domain/Entity/FavoriteTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace OpenCFP\Test\Domain\Entity;
+
 use OpenCFP\Application;
 use OpenCFP\Environment;
 

--- a/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace OpenCFP\Test\Domain\Entity\Mapper;
+
 use OpenCFP\Application;
 use OpenCFP\Environment;
 

--- a/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
@@ -8,7 +8,7 @@ use OpenCFP\Environment;
 /**
  * @group db
  */
-class TalkMapperTest extends \PHPUnit_Framework_TestCase
+class TalkTest extends \PHPUnit_Framework_TestCase
 {
     private $app;
     private $mapper;

--- a/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/Mapper/TalkTest.php
@@ -2,10 +2,13 @@
 use OpenCFP\Application;
 use OpenCFP\Environment;
 
+/**
+ * @group db
+ */
 class TalkMapperTest extends \PHPUnit_Framework_TestCase
 {
-    public $app;
-    public $mapper;
+    private $app;
+    private $mapper;
     private $entities = ['Talk', 'TalkMeta', 'User', 'Favorite'];
 
     protected function setUp()
@@ -55,6 +58,10 @@ class TalkMapperTest extends \PHPUnit_Framework_TestCase
             "Did not get expected list of admin-favorited talks"
         );
     }
+
+    //
+    // Factory Methods
+    //
 
     private function createViewedTalks($talk_data, $total)
     {

--- a/tests/OpenCFP/Domain/Entity/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/TalkTest.php
@@ -2,10 +2,13 @@
 use OpenCFP\Application;
 use OpenCFP\Environment;
 
+/**
+ * @group db
+ */
 class TalkEntityTest extends \PHPUnit_Framework_TestCase
 {
-    public $app;
-    public $mapper;
+    private $app;
+    private $mapper;
     private $entities = ['Talk', 'TalkMeta', 'User', 'Favorite'];
 
     protected function setUp()
@@ -67,6 +70,10 @@ class TalkEntityTest extends \PHPUnit_Framework_TestCase
             "Talk::getRecent() did not grab 10 talks out of 11"
         );
     }
+
+    //
+    // Factory Methods
+    //
 
     private function bulkCreateTalks($numTalks)
     {

--- a/tests/OpenCFP/Domain/Entity/TalkTest.php
+++ b/tests/OpenCFP/Domain/Entity/TalkTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace OpenCFP\Test\Domain\Entity;
+
 use OpenCFP\Application;
 use OpenCFP\Environment;
 

--- a/tests/OpenCFP/Domain/Services/LoginTest.php
+++ b/tests/OpenCFP/Domain/Services/LoginTest.php
@@ -240,6 +240,10 @@ class LoginTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $viewVariables);
     }
 
+    //
+    // Factory Methods
+    //
+
     /**
      * @return m\MockInterface|Sentry
      */

--- a/tests/OpenCFP/Domain/Services/LoginTest.php
+++ b/tests/OpenCFP/Domain/Services/LoginTest.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace OpenCFP\Domain\Services;
+namespace OpenCFP\Test\Domain\Services;
 
 use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users\UserNotActivatedException;
 use Cartalyst\Sentry\Users\UserNotFoundException;
 use Mockery as m;
-use OpenCFP\Util\Faker\GeneratorTrait;
+use OpenCFP\Domain\Services\Login;
+use OpenCFP\Test\Util\Faker\GeneratorTrait;
 
 class LoginTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/OpenCFP/Domain/Services/ResetEmailerTest.php
+++ b/tests/OpenCFP/Domain/Services/ResetEmailerTest.php
@@ -43,6 +43,10 @@ class EmailerTest extends \PHPUnit_Framework_TestCase
         $this->reset_mailer->send($this->user_id, $this->user_email, $this->reset_code);
     }
 
+    //
+    // Helpers
+    //
+
     private function validateEmail()
     {
         return function ($message) {

--- a/tests/OpenCFP/Domain/Services/ResetEmailerTest.php
+++ b/tests/OpenCFP/Domain/Services/ResetEmailerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Tests\Domain\Services;
+namespace OpenCFP\Test\Domain\Services;
 
 use OpenCFP\Domain\Services\ResetEmailer;
 

--- a/tests/OpenCFP/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/OpenCFP/Domain/Speaker/SpeakerProfileTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace OpenCFP\Domain\Speaker;
+namespace OpenCFP\Test\Domain\Speaker;
 
 use OpenCFP\Domain\Entity;
-use OpenCFP\Util\Faker\GeneratorTrait;
+use OpenCFP\Domain\Speaker\SpeakerProfile;
+use OpenCFP\Test\Util\Faker\GeneratorTrait;
 
 class SpeakerProfileTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/OpenCFP/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/OpenCFP/Domain/Talk/TalkSubmissionTest.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace OpenCFP\Test\Domain\Talk;
+
 use OpenCFP\Domain\Talk\TalkSubmission;
 
-class TalkSubmissionTest extends PHPUnit_Framework_TestCase
+class TalkSubmissionTest extends \PHPUnit_Framework_TestCase
 {
     /** @test */
     public function it_should_be_created_from_native_format()

--- a/tests/OpenCFP/EnvironmentTest.php
+++ b/tests/OpenCFP/EnvironmentTest.php
@@ -1,4 +1,8 @@
-<?php namespace OpenCFP;
+<?php
+
+namespace OpenCFP\Test;
+
+use OpenCFP\Environment;
 
 /**
  * @covers OpenCFP\Environment
@@ -8,7 +12,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_encapsulate_valid_environments()
     {
-        $this->assertInstanceOf(\OpenCFP\Environment::class, Environment::production());
+        $this->assertInstanceOf(Environment::class, Environment::production());
 
         $this->assertEquals('production', Environment::production());
         $this->assertEquals('development', Environment::development());

--- a/tests/OpenCFP/Http/API/ApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ApiControllerTest.php
@@ -1,8 +1,10 @@
 <?php
 
-use OpenCFP\Http\API\StubApiController;
+namespace OpenCFP\Test\Http\API;
 
-class ApiControllerTest extends PHPUnit_Framework_TestCase
+use OpenCFP\Test\Http\API\StubApiController;
+
+class ApiControllerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var StubApiController

--- a/tests/OpenCFP/Http/API/ApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ApiControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace OpenCFP\Test\Http\API;
 
-use OpenCFP\Test\Http\API\StubApiController;
-
 class ApiControllerTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
@@ -65,6 +65,10 @@ class ProfileApiControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Zomgz it blew up somehow', $response->getContent());
     }
 
+    //
+    // Factory Methods
+    //
+
     private function getRequest(array $data = [])
     {
         $request = Request::create('');

--- a/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/ProfileApiControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace OpenCFP\Test\Http\API;
+
+use Exception;
 use Mockery as m;
 use Mockery\MockInterface;
 use OpenCFP\Application\Speakers;
@@ -8,7 +11,7 @@ use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Http\API\ProfileController;
 use Symfony\Component\HttpFoundation\Request;
 
-class ProfileApiControllerTest extends PHPUnit_Framework_TestCase
+class ProfileApiControllerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var ProfileController

--- a/tests/OpenCFP/Http/API/StubApiController.php
+++ b/tests/OpenCFP/Http/API/StubApiController.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace OpenCFP\Http\API;
+namespace OpenCFP\Test\Http\API;
+
+use OpenCFP\Http\API\ApiController;
 
 class StubApiController extends ApiController
 {

--- a/tests/OpenCFP/Http/API/TalkApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/TalkApiControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace OpenCFP\Test\Http\API;
+
 use Mockery as m;
 use Mockery\MockInterface;
 use OpenCFP\Application\Speakers;
@@ -8,7 +10,7 @@ use OpenCFP\Domain\Talk\TalkSubmission;
 use OpenCFP\Http\API\TalkController;
 use Symfony\Component\HttpFoundation\Request;
 
-class TalkApiControllerTest extends PHPUnit_Framework_TestCase
+class TalkApiControllerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var TalkController

--- a/tests/OpenCFP/Http/API/TalkApiControllerTest.php
+++ b/tests/OpenCFP/Http/API/TalkApiControllerTest.php
@@ -128,6 +128,10 @@ class TalkApiControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Unauthorized', $response->getContent());
     }
 
+    //
+    // Factory Methods
+    //
+
     private function getRequest(array $data = [])
     {
         $request = Request::create('');
@@ -139,11 +143,11 @@ class TalkApiControllerTest extends \PHPUnit_Framework_TestCase
     private function getValidRequest()
     {
         return $this->getRequest([
-        'title' => 'Happy Path Submission',
-        'description' => 'I play by the rules.',
-        'type' => 'regular',
-        'level' => 'entry',
-        'category' => 'api',
+            'title' => 'Happy Path Submission',
+            'description' => 'I play by the rules.',
+            'type' => 'regular',
+            'level' => 'entry',
+            'category' => 'api',
         ]);
     }
 }

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitFake.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace OpenCFP\Http\Controller\Admin;
+namespace OpenCFP\Test\Http\Controller\Admin;
 
 use OpenCFP\Application;
+use OpenCFP\Http\Controller\Admin\AdminAccessTrait;
 
 class AdminAccessTraitFake
 {

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Http\Controller\Admin;
+namespace OpenCFP\Test\Http\Controller\Admin;
 
 use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users\UserInterface;

--- a/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/AdminAccessTraitTest.php
@@ -86,6 +86,10 @@ class AdminAccessTraitTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($adminAccess->hasAdminAccess());
     }
 
+    //
+    // Factory Methods
+    //
+
     /**
      * @param array $items
      * @return Application|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
@@ -1,5 +1,6 @@
 <?php
-namespace OpenCFP\Tests\Http\Controller\Admin;
+
+namespace OpenCFP\Test\Http\Controller\Admin;
 
 use Mockery as m;
 use OpenCFP\Application;

--- a/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/OpenCFP/Http/Controller/Admin/SpeakersControllerTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 
 class SpeakersControllerTest extends \PHPUnit_Framework_TestCase
 {
-    public $app;
+    private $app;
 
     protected function setUp()
     {

--- a/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
+++ b/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
@@ -1,5 +1,6 @@
 <?php
-namespace OpenCFP\Tests\Http\Controller\Admin;
+
+namespace OpenCFP\Test\Http\Controller\Admin;
 
 use Mockery as m;
 use OpenCFP\Application;

--- a/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
+++ b/tests/OpenCFP/Http/Controller/Admin/TalksControllerTests.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 
 class TalksControllerTest extends \PHPUnit_Framework_TestCase
 {
-    public $app;
+    private $app;
 
     protected function setUp()
     {

--- a/tests/OpenCFP/Http/Controller/FlashableTraitFake.php
+++ b/tests/OpenCFP/Http/Controller/FlashableTraitFake.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace OpenCFP\Http\Controller;
+namespace OpenCFP\Test\Http\Controller;
+
+use OpenCFP\Http\Controller\FlashableTrait;
 
 class FlashableTraitFake
 {

--- a/tests/OpenCFP/Http/Controller/FlashableTraitTest.php
+++ b/tests/OpenCFP/Http/Controller/FlashableTraitTest.php
@@ -60,6 +60,10 @@ class FlashableTraitTest extends \PHPUnit_Framework_TestCase
         $flashable->clearFlash($application);
     }
 
+    //
+    // Factory Methods
+    //
+
     /**
      * @param array $items
      * @return Application|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/OpenCFP/Http/Controller/FlashableTraitTest.php
+++ b/tests/OpenCFP/Http/Controller/FlashableTraitTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Http\Controller;
+namespace OpenCFP\Test\Http\Controller;
 
 use OpenCFP\Application;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;

--- a/tests/OpenCFP/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/OpenCFP/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -92,6 +92,10 @@ class SentryIdentityProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($user, $provider->getCurrentUser());
     }
 
+    //
+    // Factory Methods
+    //
+
     /**
      * @return m\MockInterface|Sentry
      */

--- a/tests/OpenCFP/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/OpenCFP/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Infrastructure\Auth;
+namespace OpenCFP\Test\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users;
@@ -9,7 +9,8 @@ use OpenCFP\Domain\Entity;
 use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
 use OpenCFP\Domain\Speaker\SpeakerRepository;
-use OpenCFP\Util\Faker\GeneratorTrait;
+use OpenCFP\Infrastructure\Auth\SentryIdentityProvider;
+use OpenCFP\Test\Util\Faker\GeneratorTrait;
 
 class SentryIdentityProviderTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/OpenCFP/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -1,9 +1,11 @@
 <?php
 
+namespace OpenCFP\Test\Infrastructure\Crypto;
+
 use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
 use RandomLib\Factory;
 
-class PseudoRandomStringGeneratorTest extends PHPUnit_Framework_TestCase
+class PseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var PseudoRandomStringGenerator

--- a/tests/OpenCFP/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
+++ b/tests/OpenCFP/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace OpenCFP\Infrastructure\Persistence;
+namespace OpenCFP\Test\Infrastructure\Persistence;
 
 use Mockery as m;
 use OpenCFP\Domain\Entity;
 use OpenCFP\Domain\EntityNotFoundException;
 use OpenCFP\Domain\Speaker\SpeakerRepository;
-use OpenCFP\Util\Faker\GeneratorTrait;
+use OpenCFP\Infrastructure\Persistence\SpotSpeakerRepository;
+use OpenCFP\Test\Util\Faker\GeneratorTrait;
 use Spot\Mapper;
 
 class SpotSpeakerRepositoryTest extends \PHPUnit_Framework_TestCase

--- a/tests/OpenCFP/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
+++ b/tests/OpenCFP/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
@@ -78,6 +78,10 @@ class SpotSpeakerRepositoryTest extends \PHPUnit_Framework_TestCase
         $repository->persist($speaker);
     }
 
+    //
+    // Factory Methods
+    //
+
     /**
      * @return m\MockInterface|Mapper
      */

--- a/tests/OpenCFP/Infrastructure/Persistence/SpotTalkRepositoryTest.php
+++ b/tests/OpenCFP/Infrastructure/Persistence/SpotTalkRepositoryTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace OpenCFP\Infrastructure\Persistence;
+namespace OpenCFP\Test\Infrastructure\Persistence;
 
 use Mockery as m;
 use OpenCFP\Domain\Entity;
 use OpenCFP\Domain\Talk\TalkRepository;
+use OpenCFP\Infrastructure\Persistence\SpotTalkRepository;
 use Spot\Mapper;
 
 class SpotTalkRepositoryTest extends \PHPUnit_Framework_TestCase

--- a/tests/OpenCFP/Infrastructure/Persistence/SpotTalkRepositoryTest.php
+++ b/tests/OpenCFP/Infrastructure/Persistence/SpotTalkRepositoryTest.php
@@ -36,6 +36,10 @@ class SpotTalkRepositoryTest extends \PHPUnit_Framework_TestCase
         $repository->persist($talk);
     }
 
+    //
+    // Factory Methods
+    //
+
     /**
      * @return m\MockInterface|Mapper
      */

--- a/tests/OpenCFP/Provider/SymfonySentrySessionTest.php
+++ b/tests/OpenCFP/Provider/SymfonySentrySessionTest.php
@@ -92,6 +92,10 @@ class SymfonySentrySessionTest extends \PHPUnit_Framework_TestCase
         $sentrySession->forget();
     }
 
+    //
+    // Factory Methods
+    //
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|SessionInterface
      */

--- a/tests/OpenCFP/Provider/SymfonySentrySessionTest.php
+++ b/tests/OpenCFP/Provider/SymfonySentrySessionTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace OpenCFP\Provider;
+namespace OpenCFP\Test\Provider;
 
+use OpenCFP\Provider\SymfonySentrySession;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class SymfonySentrySessionTest extends \PHPUnit_Framework_TestCase

--- a/tests/OpenCFP/Util/Faker/GeneratorTest.php
+++ b/tests/OpenCFP/Util/Faker/GeneratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Util\Faker;
+namespace OpenCFP\Test\Util\Faker;
 
 use Faker\Generator;
 

--- a/tests/OpenCFP/Util/Faker/GeneratorTrait.php
+++ b/tests/OpenCFP/Util/Faker/GeneratorTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Util\Faker;
+namespace OpenCFP\Test\Util\Faker;
 
 use Faker\Factory;
 use Faker\Generator;

--- a/tests/unit/TalkFormTest.php
+++ b/tests/unit/TalkFormTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use OpenCFP\Util\Faker\GeneratorTrait;
+use OpenCFP\Test\Util\Faker\GeneratorTrait;
 
 /**
  * Tests for our TalkForm object

--- a/tests/unit/controllers/DashboardControllerTest.php
+++ b/tests/unit/controllers/DashboardControllerTest.php
@@ -1,16 +1,18 @@
 <?php
+
 use Cartalyst\Sentry\Sentry;
 use Mockery as m;
 use OpenCFP\Application;
 use OpenCFP\Domain\Entity\User;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Environment;
+use OpenCFP\Test\Util\Faker\GeneratorTrait;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 
 class DashboardControllerTest extends PHPUnit_Framework_TestCase
 {
-    use OpenCFP\Util\Faker\GeneratorTrait;
+    use GeneratorTrait;
 
     /**
      * Test that the index page returns a list of talks associated


### PR DESCRIPTION
Related: #307 

This PR applies a number of consistency fixes to all test cases under `tests/OpenCFP`, the intended migration location of all unit tests for the system. Here is a summary of things I looked for and changed.

* If a test talked to the database (sqlite) it has been marked as part of `group db`. This is so we can target these for improvement, isolation of real business logic. Thinking forward, these might actually be more clear if broken out as easier to maintain end-to-end tests.
* If a test class name differed from file name, corrections were made to have the test match the production system under test with `Test` appended to class name.
* Every test case under `tests/OpenCFP` is now namespaced under `OpenCFP\Test`. This caused a lot of package import breakage, which was also resolved. 
* Property visibility for systems under tests are `private`, down from `protected` or `public`.
* Visibility and casing of PHPUnit `setUp` and `tearDown` methods was set to `protected` to match parent, and camel-cased instead of lowercase.
* A comment was placed between test methods and factory methods / helpers as a search target for future refactoring of these common methods into either a **well thought out** trait or an abstract test case.

This PR purposefully does not make changes to any tests under `tests/unit` as there will be on-going effort to merge those tests under this namespace. It was just easier to get the destination cleaned up before doing so. Many tests under `tests/unit` overlap with cases already under `tests/OpenCFP`, so care must be taken to cull any double-coverage as well as characterize the tests for future work. Many of those tests are far-reaching, non-intention-revealing, hard to read. This would be improved as part of the ongoing improvements to the test suite.