### PR TITLE
Add Sqlite3 memory environment to Phinx and fix previous migration

### DIFF
--- a/migrations/20150519122926_reset_photo_paths.php
+++ b/migrations/20150519122926_reset_photo_paths.php
@@ -63,6 +63,10 @@ class ResetPhotoPaths extends AbstractMigration
     private function getSpeakers()
     {
         // Return structure that is collection of [id, photo_path]
+        if ($this->isSqlite()) {
+            return $this->fetchAll("SELECT id, photo_path, first_name || ' ' || last_name as name FROM users WHERE photo_path <> ''");
+        }
+
         return $this->fetchAll("SELECT id, photo_path, CONCAT(first_name, ' ', last_name) as name FROM users WHERE photo_path <> ''");
     }
 
@@ -102,5 +106,10 @@ class ResetPhotoPaths extends AbstractMigration
     private function fileExists($photoPath)
     {
         return file_exists(__DIR__ . '/../web/uploads/' . $photoPath);
+    }
+
+    private function isSqlite()
+    {
+        return $this->getAdapter()->getAdapterType() === 'sqlite';
     }
 }

--- a/phinx.yml.dist
+++ b/phinx.yml.dist
@@ -24,3 +24,7 @@ environments:
         name: cfp_travis
         user: root
         pass: ''
+
+    memory:
+        adapter: sqlite
+        memory: true


### PR DESCRIPTION
The ANSI standard for SQL concatenation is the pipe operator `||`. Sqlite3 supports this without additional configuration and does not support use of `CONCAT()` function. MySQL supports `||` operator, but only with changes to the SQL mode.

I am writing a PHPUnit TestCase for a class that will not be using Spot2 to implement entity retrieval from database. I will be using PDO through `illuminate\database`. I want to use a Sqlite in-memory database for this.

Phinx can migrate into a `sqlite` database in-memory. Phinx fails to run our current migrations on Sqlite3 because we use `CONCAT()` in the affected migration. In order to patch, I have added a run-time check for use of the `sqlite` adapter. If used, I run an alternate query that uses the pipe-operator for concatenation instead of `CONCAT()`. 

I believe modification of a previous migration is reasonable as it is unlikely that anyone is using this software on Sqlite. Even if so, it is currently broken as they cannot run the migrations! :smile: 

I'm going to go ahead and base my further work on this and if rejected, I can find time to write an alternate persistence adapter.