### PR TITLE
Fix: Simplify test bootstrapping

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/bootstrap.php"
+<phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -9,6 +9,9 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
+    <php>
+        <const name="BASE_PATH" value="."/>
+    </php>
     <filter>
         <whitelist>
             <directory>classes</directory>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-
-require 'vendor/autoload.php';
-
-if (!defined('BASE_PATH')) {
-    define('BASE_PATH', dirname(__DIR__));
-}


### PR DESCRIPTION
This PR

* [x] simplifies test bootstrapping by defining a constant in `phpunit.xml.dist`