### PR TITLE
Fix: Remove non-existent test suites

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,12 +20,6 @@
 
     <testsuites>
         <testsuite name="all">
-            <directory>tests</directory>
-        </testsuite>
-        <testsuite name="unit">
-            <directory>tests/unit</directory>
-        </testsuite>
-        <testsuite name="framework">
             <directory>tests/OpenCFP</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
This PR

* [x] removes non-existent test suites from `phpunit.xml.dist`

Follows #344.