### PR TITLE
Added conference information from new config settings

### DIFF
--- a/config/development.dist.yml
+++ b/config/development.dist.yml
@@ -3,6 +3,7 @@ application:
   url: http://localhost
   email: contact@openconf.com
   eventurl: http://localhost
+  event_location: Swansea, UK
   enddate: Oct. 14th, 2016
   show_submission_count: false
   airport: MIA
@@ -10,6 +11,8 @@ application:
   departure: 2014-10-31
   secure_ssl: false
   online_conference: false
+  date_format: d/m/Y
+
 
 api:
   enabled: true

--- a/config/production.dist.yml
+++ b/config/production.dist.yml
@@ -3,6 +3,7 @@ application:
   url: http://cfp.dev
   email: contact@openconf.com
   eventurl: http://myenvent.com
+  event_location: Swansea, UK
   enddate: Oct. 14th, 2016
   show_submission_count: false
   airport: MIA
@@ -10,6 +11,8 @@ application:
   departure: 2014-10-31
   secure_ssl: true
   online_conference: false
+  date_format: d/m/Y
+
 
 api:
   enabled: true

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -3,6 +3,7 @@ application:
   url: http://localhost
   email: contact@openconf.com
   eventurl: http://localhost
+  event_location: Miami, FL
   enddate: Oct. 14th, 2016
   show_submission_count: false
   airport: MIA
@@ -10,6 +11,8 @@ application:
   departure: 2014-10-31
   secure_ssl: false
   online_conference: false
+  date_format: m-d-Y
+
 
 api:
   enabled: true

--- a/templates/_header.twig
+++ b/templates/_header.twig
@@ -30,7 +30,13 @@
 <section class="section section--light">
     <div class="container">
         <div class="row">
-            <div class="col-md-8"><h3 class="headline headline--alpha">For More Information About The Conference</h3></div>
+            {% if site.event_location is defined and site.date_format is defined %}
+            <div class="col-md-8"><h3 class="headline headline--alpha">
+                {{ site.title }} is  on {{ site.arrival|date(site.date_format) }} to {{ site.departure|date(site.date_format) }} in {{ site.event_location }}
+            </h3></div>
+            {%  else %}
+                <div class="col-md-8"><h3 class="headline headline--alpha">For More Information About The Conference</h3></div>
+            {% endif %}
             <div class="col-md-4 text-right"><a href="{{ site.eventurl }}" class="btn-opencfp btn-opencfp-medium btn-opencfp--light">Visit Conference Site</a></div>
         </div>
     </div>


### PR DESCRIPTION
One of the first things regular speakers look for on CFP page is the conference date and location. This PR replaces the text "For More Information About The Conference" with the text "GeeHCon is on 26/10/2014 to 31/10/2014 in Swansea, UK".

This only happens if the two new config values that are added are present, and so is backwards compatible.

The new config values are:

event_location - the location of the event in string format
date_format - a Twig `date()` filter compatible string to format the event dates
