### PR TITLE
Handling file upload errors hence preventing 500 ise

### DIFF
--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -80,6 +80,13 @@ class SignupForm extends Form
             return true;
         }
 
+        // Check if the file was uploaded OK, display any error that may have occurred
+        if (!$this->_taintedData['speaker_photo']->isValid()) {
+            $this->_addErrorMessage($this->_taintedData['speaker_photo']->getErrorMessage());
+
+            return false;
+        }
+
         // Check if uploaded file is greater than 5MB
         if ($this->_taintedData['speaker_photo']->getClientSize() > (5 * 1048576)) {
             $this->_addErrorMessage("Speaker photo can not be larger than 5MB");


### PR DESCRIPTION
I ran into the following problem setting up opencfp for Bulgaria PHP:

When registering a new speaker profile or updating the speaker profile picture the following behaviour is observed if the file upload limit in php.ini is lower than the 5MB limit set in the code: Instead of showing a file upload error in the form, the application would throw a '500 Internal Server error' into the index page, where it redirects the user as a side effect of handling a file upload exception.

I added a few lines to classes/Http/Form/SignupForm.php, utilizing the functionality of Symfony\Component\HttpFoundation\File\UploadedFIle for validation and showing upload errors.

'make cs' and phpunit went fine. I have not added any new tests, since I am not really introducing new functionality, just made use of existing one to catch and handle file upload errors more gracefully. Please excuse me if a UI test is expected - this is my first pull request to opencfp and like under tenth one total in github.

Thanks!