### PR TITLE
Add titles to talk voting icons

### DIFF
--- a/templates/admin/talks/_table.twig
+++ b/templates/admin/talks/_table.twig
@@ -22,10 +22,10 @@
                 <td><a href="{{ url('admin_speaker_view', { id: talk.user.id }) }}">{{ talk.user.first_name }} {{ talk.user.last_name }}</a></td>
                 {% endif %}
                 <td>
-                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1"><i class="fa fa-thumbs-up admin-icon{% if talk.meta.rating == 1 %} admin-icon--selected{% endif %}"></i></a>
-                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1"><i class="fa fa-thumbs-down admin-icon{% if talk.meta.rating == -1 %} admin-icon--selected{% endif %}"></i></a>
-                    <a href="#" id="talk-favorite-{{ talk.id }}" class="js-talk-favorite" data-id="{{ talk.id }}"><i class="fa fa-star admin-icon{% if talk.favorite == 1 %} admin-icon--selected{% endif %}"></i></a>
-                    <a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}"><i class="fa fa-check-square admin-icon{% if talk.selected == 1 %} admin-icon--selected{% endif %}"></i></a>
+                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up admin-icon{% if talk.meta.rating == 1 %} admin-icon--selected{% endif %}"></i></a>
+                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down admin-icon{% if talk.meta.rating == -1 %} admin-icon--selected{% endif %}"></i></a>
+                    <a href="#" id="talk-favorite-{{ talk.id }}" class="js-talk-favorite" data-id="{{ talk.id }}" title="Favorite!"><i class="fa fa-star admin-icon{% if talk.favorite == 1 %} admin-icon--selected{% endif %}"></i></a>
+                    <a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}" title="Select this talk"><i class="fa fa-check-square admin-icon{% if talk.selected == 1 %} admin-icon--selected{% endif %}"></i></a>
                 </td>
             </tr>
         {% endfor %}

--- a/templates/admin/talks/view.twig
+++ b/templates/admin/talks/view.twig
@@ -3,9 +3,9 @@
     <div class="module">
         <nav class="pull-right">
             <ul class="nav nav-action">
-                <li><a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1"><i class="fa fa-thumbs-up admin-icon{% if talk_meta.rating == 1 %} admin-icon--selected{% endif %}"></i></a></li>
-                <li><a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1"><i class="fa fa-thumbs-down admin-icon{% if talk_meta.rating == -1 %} admin-icon--selected{% endif %}"></i></a></li>
-                <li><a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}"><i class="fa fa-check-square admin-icon{% if talk.selected == 1 %} admin-icon--selected{% endif %}"></i></a></li>
+                <li><a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up admin-icon{% if talk_meta.rating == 1 %} admin-icon--selected{% endif %}"></i></a></li>
+                <li><a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down admin-icon{% if talk_meta.rating == -1 %} admin-icon--selected{% endif %}"></i></a></li>
+                <li><a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}" title="Select this talk"><i class="fa fa-check-square admin-icon{% if talk.selected == 1 %} admin-icon--selected{% endif %}"></i></a></li>
             </ul>
         </nav>
         <div class="module__body">


### PR DESCRIPTION
I'm looking at OpenCFP to help run the CFP at CascadiaFEST 2016 (CascadiaJS). I noticed that the admin talk vote icons didn't have explanations on them so I thought I'd add some simple titles. The copy is open for modifications, but I thought I'd at least start the conversation.
