### PR TITLE
Add unit tests to work started in #352

### DIFF
--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -80,6 +80,13 @@ class SignupForm extends Form
             return true;
         }
 
+        // Check if the file was uploaded OK, display any error that may have occurred
+        if (!$this->_taintedData['speaker_photo']->isValid()) {
+            $this->_addErrorMessage($this->_taintedData['speaker_photo']->getErrorMessage());
+
+            return false;
+        }
+
         // Check if uploaded file is greater than 5MB
         if ($this->_taintedData['speaker_photo']->getClientSize() > (5 * 1048576)) {
             $this->_addErrorMessage("Speaker photo can not be larger than 5MB");

--- a/tests/Http/Form/SignupFormTest.php
+++ b/tests/Http/Form/SignupFormTest.php
@@ -2,6 +2,9 @@
 
 namespace OpenCFP\Test\Http\Form;
 
+use Mockery as m;
+use OpenCFP\Http\Form\SignupForm;
+
 class SignupFormTest extends \PHPUnit_Framework_TestCase
 {
     private $purifier;
@@ -9,6 +12,24 @@ class SignupFormTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->purifier = new \HTMLPurifier();
+    }
+
+    /**
+     * @test
+     */
+    public function formRejectsValidationOnInvalidSpeakerPhoto()
+    {
+        // Mock speaker photo.
+        $photo = m::mock('stdClass');
+        $photo->shouldReceive('isValid')->andReturn(false);
+        $photo->shouldReceive('getErrorMessage')->andReturn('stubbed error message');
+
+        $form = new SignupForm(['speaker_photo' => $photo], $this->purifier);
+
+        $form->validateSpeakerPhoto();
+
+        $this->assertTrue($form->hasErrors());
+        $this->assertContains('stubbed error message', $form->getErrorMessages()[0]);
     }
 
     /**

--- a/tests/Infrastructure/Persistence/IlluminateAirportInformationDatabaseTest.php
+++ b/tests/Infrastructure/Persistence/IlluminateAirportInformationDatabaseTest.php
@@ -7,8 +7,6 @@ use OpenCFP\Infrastructure\Persistence\IlluminateAirportInformationDatabase;
 /**
  * Tests integration with illuminate/database and airports table to implement
  * an AirportInfromationDatabase
- *
- * @group wip
  */
 class IlluminateAirportInformationDatabaseTest extends \DatabaseTestCase
 {


### PR DESCRIPTION
Related: #352 

@madasha added a validation check to ensure speaker photo upload was valid but was not comfortable adding tests for this feature. I've got that covered in this PR.

Original PR:

```
madasha commented 3 days ago
I ran into the following problem setting up opencfp for Bulgaria PHP:

When registering a new speaker profile or updating the speaker profile picture the following behaviour is observed if the file upload limit in php.ini is lower than the 5MB limit set in the code: Instead of showing a file upload error in the form, the application would throw a '500 Internal Server error' into the index page, where it redirects the user as a side effect of handling a file upload exception.

I added a few lines to classes/Http/Form/SignupForm.php, utilizing the functionality of Symfony\Component\HttpFoundation\File\UploadedFIle for validation and showing upload errors.

'make cs' and phpunit went fine. I have not added any new tests, since I am not really introducing new functionality, just made use of existing one to catch and handle file upload errors more gracefully. Please excuse me if a UI test is expected - this is my first pull request to opencfp and like under tenth one total in github.

Thanks!
```