### PR TITLE
Add timezone to .yml config files

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -93,7 +93,7 @@ class Application extends SilexApplication
 
         $this->registerGlobalErrorHandler($this);
 
-        if($timezone = $this->config('application.date_timezone')) {
+        if ($timezone = $this->config('application.date_timezone')) {
             date_default_timezone_set($timezone);
         }
     }

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -92,6 +92,10 @@ class Application extends SilexApplication
         $this->register(new ApplicationServiceProvider);
 
         $this->registerGlobalErrorHandler($this);
+
+        if($timezone = $this->config('application.date_timezone')) {
+            date_default_timezone_set($timezone);
+        }
     }
 
     /**

--- a/config/development.dist.yml
+++ b/config/development.dist.yml
@@ -12,7 +12,7 @@ application:
   secure_ssl: false
   online_conference: false
   date_format: d/m/Y
-
+  date_timezone: "UTC"
 
 api:
   enabled: true

--- a/config/production.dist.yml
+++ b/config/production.dist.yml
@@ -12,7 +12,7 @@ application:
   secure_ssl: true
   online_conference: false
   date_format: d/m/Y
-
+  date_timezone: "UTC"
 
 api:
   enabled: true


### PR DESCRIPTION
Allows users to specify their default timezone via config files. The value is stored in `application.date_timezone` and is set in the application as the last step in `__construct`.

Normally this is set on the server side in `php.ini` files, so no worries if you don't want to merge this. I could see value (especially on shared servers) in having this be configurable app-side so I wanted to suggest & provide a pr for it.

I'm not sure if any tests need to be added to this? I'm happy to add them if needed. Also totally happy to move things around if they would go in better places.