### PR TITLE
Fix: Remove unused local variables

### DIFF
--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -39,9 +39,6 @@ class Talk extends Mapper
             ]
         );
 
-        $talks = $this->all()
-            ->order([$options['order_by'] => $options['sort']])
-            ->with(['favorites', 'comments']);
         $formatted = [];
 
         if ($where) {

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -19,9 +19,6 @@ class SecurityController extends BaseController
 
     public function processAction(Request $req, Application $app)
     {
-        $template_data = [];
-        $code = Response::HTTP_OK;
-
         try {
             $page = new Login($app['sentry']);
 

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -44,7 +44,6 @@ class TalkController extends BaseController
             return $this->redirectTo('login');
         }
 
-        $user = $this->app['sentry']->getUser();
         /////////
 
         try {

--- a/tests/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/Domain/Entity/Mapper/TalkTest.php
@@ -51,7 +51,7 @@ class TalkTest extends \PHPUnit_Framework_TestCase
         $talk = $mapper->create($talk_data);
 
         $this->createAdminFavoredTalks($admin_user_id, $admin_majority, $talk);
-        $expected_admin_favorite = $mapper->createdFormattedOutput($talk, $admin_user_id);
+        $mapper->createdFormattedOutput($talk, $admin_user_id);
         $admin_favorite_collection = $mapper->getFavoritesByUserId($admin_user_id);
         $admin_favorite = $admin_favorite_collection[0];
 
@@ -101,7 +101,7 @@ class TalkTest extends \PHPUnit_Framework_TestCase
                 'admin_user_id' => $random_admin_id,
                 'talk_id' => $talk->id,
             ];
-            $favorite = $favorite_mapper->create($favorite_data);
+            $favorite_mapper->create($favorite_data);
         }
     }
 }

--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -42,7 +42,7 @@ class SignupControllerTest extends \PHPUnit_Framework_TestCase
         $controller->setApplication($app);
 
         $req = m::mock('Symfony\Component\HttpFoundation\Request');
-        $response = $controller->indexAction($req, $currentTimeString);
+        $controller->indexAction($req, $currentTimeString);
 
         $expectedMessage = "Sorry, the call for papers has ended.";
         $session_details = $app['session']->get('flash');
@@ -182,7 +182,7 @@ class SignupControllerTest extends \PHPUnit_Framework_TestCase
         $files->shouldReceive('get')->with('speaker_photo')->andReturn(null);
         $req->files = $files;
 
-        $response = $controller->processAction($req, $app);
+        $controller->processAction($req, $app);
         $expectedMessage = "You've successfully created your account!";
         $session_details = $app['session']->get('flash');
 

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -86,7 +86,7 @@ class TalkControllerTest extends \PHPUnit_Framework_TestCase
          * If the talk was successfully created, a success value is placed
          * into the session flash area for display
          */
-        $create_response = $controller->processCreateAction($this->req);
+        $controller->processCreateAction($this->req);
 
         $create_flash = $this->app['session']->get('flash');
         $this->assertEquals($create_flash['type'], 'success');
@@ -97,7 +97,7 @@ class TalkControllerTest extends \PHPUnit_Framework_TestCase
         $talk_data['title'] = "Test Title With Ampersand & More Things";
         $this->setPost($talk_data);
 
-        $update_response = $controller->updateAction($this->req, $this->app);
+        $controller->updateAction($this->req, $this->app);
         $update_flash = $this->app['session']->get('flash');
         $this->assertEquals($update_flash['type'], 'success');
     }


### PR DESCRIPTION
This PR

* [x] removes unused local variables