### PR TITLE
Fix: Remove unused parameter

### DIFF
--- a/classes/Http/Controller/Admin/AdminAccessTrait.php
+++ b/classes/Http/Controller/Admin/AdminAccessTrait.php
@@ -8,7 +8,7 @@ trait AdminAccessTrait
     {
         if (method_exists($this, $method)) {
             // Check if user is an logged in and an Admin
-            if (! $this->userHasAccess($this->app)) {
+            if (! $this->userHasAccess()) {
                 return $this->redirectTo('dashboard');
             }
 
@@ -16,7 +16,7 @@ trait AdminAccessTrait
         }
     }
 
-    protected function userHasAccess($app)
+    protected function userHasAccess()
     {
         if (!$this->app['sentry']->check()) {
             return false;

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -26,7 +26,7 @@ class ExportsController extends BaseController
 
     public function emailExportAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('login');
         }
 
@@ -48,7 +48,7 @@ class ExportsController extends BaseController
 
     private function talksExportAction($attributed, $where = null)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('login');
         }
 

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -82,7 +82,7 @@ class SpeakersController extends BaseController
     public function viewAction(Request $req)
     {
         // Check if user is an logged in and an Admin
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('dashboard');
         }
 
@@ -139,7 +139,7 @@ class SpeakersController extends BaseController
     public function deleteAction(Request $req)
     {
         // Check if user is an logged in and an Admin
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('dashboard');
         }
 

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -14,7 +14,7 @@ class TalksController extends BaseController
 
     public function indexAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('login');
         }
 
@@ -109,7 +109,7 @@ class TalksController extends BaseController
 
     public function viewAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return $this->redirectTo('login');
         }
 
@@ -180,7 +180,7 @@ class TalksController extends BaseController
 
     public function rateAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return false;
         }
 
@@ -221,7 +221,7 @@ class TalksController extends BaseController
      */
     public function favoriteAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return false;
         }
 
@@ -268,7 +268,7 @@ class TalksController extends BaseController
      */
     public function selectAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return false;
         }
 
@@ -288,7 +288,7 @@ class TalksController extends BaseController
 
     public function commentCreateAction(Request $req)
     {
-        if (!$this->userHasAccess($this->app)) {
+        if (!$this->userHasAccess()) {
             return false;
         }
 

--- a/tests/Http/Controller/Admin/AdminAccessTraitFake.php
+++ b/tests/Http/Controller/Admin/AdminAccessTraitFake.php
@@ -24,6 +24,6 @@ class AdminAccessTraitFake
      */
     public function hasAdminAccess()
     {
-        return $this->userHasAccess($this->app);
+        return $this->userHasAccess();
     }
 }


### PR DESCRIPTION
This PR

* [x] removes a parameter from a method signature that is never used, and stops passing it in