### PR TITLE
Fix: Namespace doesn't match project structure

### DIFF
--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -1,7 +1,11 @@
 <?php
 
+namespace OpenCFP\Test;
+
 use Illuminate\Database\Capsule\Manager as Capsule;
+use PDO;
 use Phinx\Console\Command\Migrate;
+use Phinx\Console\PhinxApplication;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -25,7 +29,7 @@ abstract class DatabaseTestCase extends \PHPUnit_Framework_TestCase
         $input = new ArgvInput(['phinx', 'migrate', '--environment=memory']);
         $output = new NullOutput();
 
-        $phinx = new Phinx\Console\PhinxApplication();
+        $phinx = new PhinxApplication();
         $phinx->setAutoExit(false);
         $phinx->run($input, $output);
 

--- a/tests/Domain/Entity/TalkTest.php
+++ b/tests/Domain/Entity/TalkTest.php
@@ -8,7 +8,7 @@ use OpenCFP\Environment;
 /**
  * @group db
  */
-class TalkEntityTest extends \PHPUnit_Framework_TestCase
+class TalkTest extends \PHPUnit_Framework_TestCase
 {
     private $app;
     private $mapper;

--- a/tests/Domain/Services/ResetEmailerTest.php
+++ b/tests/Domain/Services/ResetEmailerTest.php
@@ -4,7 +4,7 @@ namespace OpenCFP\Test\Domain\Services;
 
 use OpenCFP\Domain\Services\ResetEmailer;
 
-class EmailerTest extends \PHPUnit_Framework_TestCase
+class ResetEmailerTest extends \PHPUnit_Framework_TestCase
 {
     private $swift_mailer;
     private $template;

--- a/tests/Infrastructure/Persistence/IlluminateAirportInformationDatabaseTest.php
+++ b/tests/Infrastructure/Persistence/IlluminateAirportInformationDatabaseTest.php
@@ -3,12 +3,13 @@
 namespace OpenCFP\Test\Infrastructure\Persistence;
 
 use OpenCFP\Infrastructure\Persistence\IlluminateAirportInformationDatabase;
+use OpenCFP\Test\DatabaseTestCase;
 
 /**
  * Tests integration with illuminate/database and airports table to implement
  * an AirportInfromationDatabase
  */
-class IlluminateAirportInformationDatabaseTest extends \DatabaseTestCase
+class IlluminateAirportInformationDatabaseTest extends DatabaseTestCase
 {
     private $airports;
 


### PR DESCRIPTION
This PR

* [x] fixes issues where the namespace used in tests doesn't match the project structure