### PR TITLE
Fix: Run php-cs-fixer with --diff on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
 
 script:
   - if [[ "$COLLECT_COVERAGE" == "true" ]]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; else vendor/bin/phpunit; fi
-  - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --verbose; fi
+  - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --verbose --diff; fi
 
 after_success:
   - if [[ "$COLLECT_COVERAGE" == "true" ]]; then vendor/bin/test-reporter --coverage-report build/logs/clover.xml; fi


### PR DESCRIPTION
This PR

* [x] runs `php-cs-fixer` with the `--diff` option on Travis

Related to https://github.com/opencfp/opencfp/pull/357/files#r54354143.

:information_desk_person: We're using that option in [`Makefile`](https://github.com/opencfp/opencfp/blob/master/Makefile#L4), and using it on Travis at least helps to see what the actual problem is when the build fails due to CS issues.