### PR TITLE
Fix: Allow to indent Makefile with tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 2
 
 [*.yml]
 indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This PR

* [x] adjusts `.editorconfig` to allow indentation of `Makefile`s with tabs

Follows #227.