### PR TITLE
Enhancement: Streamline testing process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-    - TRAVIS_DB=cfp_travis
+    - TRAVIS_DB=cfp_test
     - CODECLIMATE_REPO_TOKEN=9deb249b01a414d979959cfd05a4c351b19a5959858653b20276454d4189edc3
 
 # cache composer downloads so installing is quicker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,33 @@ We accept contributions via Pull Requests on [Github](https://github.com/opencfp
 
 ## Running Tests
 
-Having installed all dependencies via `composer install`:
+Run
 
-``` bash
-$ ./vendor/bin/phpunit
 ```
+$ make test
+```
+
+to run all the tests.
+
+## Fixing Code Style issues
+
+Run
+
+```
+$ make cs
+```
+
+to detect and automatically fix code style issues.
+
+## Extra lazy?
+
+Run
+
+```
+$ make
+```
+
+to run both all the tests and to automatically fix code style issues. 
 
 ## Credit
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,19 @@
-.PHONY: cs
+.PHONY: composer cs database it test
 
-cs:
+it: cs test
+
+composer:
+	composer install --prefer-dist
+
+cs: composer
 	vendor/bin/php-cs-fixer fix --verbose --diff
+
+database: composer
+	mysql -uroot -e "DROP DATABASE IF EXISTS cfp_test"
+	mysql -uroot -e "CREATE DATABASE cfp_test"
+	cp phinx.yml.dist phinx.yml
+	vendor/bin/phinx migrate -e testing
+
+test: composer database
+	vendor/bin/phpunit
+

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -22,8 +22,8 @@ cache:
 
 database:
   host: 127.0.0.1
-  database: cfp_travis
-  dsn: mysql:dbname=cfp_travis;host=127.0.0.1
+  database: cfp_test
+  dsn: mysql:dbname=cfp_test;host=127.0.0.1
   user: root
   password:
 

--- a/phinx.yml.dist
+++ b/phinx.yml.dist
@@ -21,7 +21,7 @@ environments:
     testing:
         adapter: mysql
         host: localhost
-        name: cfp_travis
+        name: cfp_test
         user: root
         pass: ''
 


### PR DESCRIPTION
This PR

* [x] uses `cfp_test` as database name for testing instead of `cfp_travis`
* [x] adds `it`, `composer`, `database`, and `test` targets to `Makefile`

:information_desk_person: Run

```
$ make
```

to run all the things!
