### PR TITLE
Changing value passed to google flights URL to match airport code

### DIFF
--- a/templates/admin/speaker/index.twig
+++ b/templates/admin/speaker/index.twig
@@ -20,7 +20,7 @@
                         <td>{{ speaker.company }}</td>
                         <td>{{ speaker.twitter }}</td>
                         <td><a href="mailto:{{ speaker.email }}">{{ speaker.email }}</a></td>
-                        <td>{% if speaker.airport.code %}<a href="https://www.google.com/flights/#search;f={{ speaker.airport.name|upper }};t={{ airport|upper }};d={{ arrival }};r={{ departure }}" target="_blank">Flight Cost</a> from {{ speaker.airport.code }}<br/><span style="font-size: 14px; color: #888">{{ speaker.airport.name }}, {{ speaker.airport.country }}</span>{% else %}Not Provided{% endif %}</td>
+                        <td>{% if speaker.airport.code %}<a href="https://www.google.com/flights/#search;f={{ speaker.airport.code|upper }};t={{ airport|upper }};d={{ arrival }};r={{ departure }}" target="_blank">Flight Cost</a> from {{ speaker.airport.code }}<br/><span style="font-size: 14px; color: #888">{{ speaker.airport.name }}, {{ speaker.airport.country }}</span>{% else %}Not Provided{% endif %}</td>
                         <td>{{ speaker.created_at|date("F jS \\a\\t g:ia T") }}</td>
                         <td><a href="{{ url('admin_speaker_delete', { id: speaker.id }) }}" onClick="return confirm('Are you sure you want to delete this user');">Delete</a></td>
                     </tr>

--- a/templates/admin/speaker/view.twig
+++ b/templates/admin/speaker/view.twig
@@ -12,7 +12,7 @@
             <div class="col-md-8">
                 <blockquote>
                     <h2>{{ speaker.first_name }} {{ speaker.last_name }}</h2>
-                    {% if speaker.airport.code %}<p><a href="https://www.google.com/flights/#search;f={{ speaker.airport.name|upper }};t={{ airport|upper }};d={{ arrival }};r={{ departure }}" target="_blank">{{ speaker.airport.code }} </a><i class="fa fa-plane"></i></p>{% endif %}
+                    {% if speaker.airport.code %}<p><a href="https://www.google.com/flights/#search;f={{ speaker.airport.code|upper }};t={{ airport|upper }};d={{ arrival }};r={{ departure }}" target="_blank">{{ speaker.airport.code }} </a><i class="fa fa-plane"></i></p>{% endif %}
                 </blockquote>
                 <p>
                   <i class="fa fa-envelope"></i> <a href="mailto:{{ speaker.email }}">{{ speaker.email }}</a><br>


### PR DESCRIPTION
While using the software I found this great functionality to check airfare cost for speakers flying in from somewhere through google flights. There was only a minor problem - the value passed to the 'f' param in the URL is supposed to be the code of the airport, instead of the full name to make it work. Like this:
https://www.google.com/flights/#search;f=BRU;t=SOF;d=2016-10-07;r=2016-10-09

Made a minor change in two templates in the admin area to reflect this in the composed URL.