### PR TITLE
Fix: Introduce explaining variable when fetching Twig_Environment from container

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -33,6 +33,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Twig_Environment;
 
 class Application extends SilexApplication
 {
@@ -304,18 +305,21 @@ class Application extends SilexApplication
                 ], $code, $headers);
             }
 
+            /* @var Twig_Environment $twig */
+            $twig = $app['twig'];
+
             switch ($code) {
                 case Response::HTTP_UNAUTHORIZED:
-                    $message = $app['twig']->render('error/401.twig');
+                    $message = $twig->render('error/401.twig');
                     break;
                 case Response::HTTP_FORBIDDEN:
-                    $message = $app['twig']->render('error/403.twig');
+                    $message = $twig->render('error/403.twig');
                     break;
                 case Response::HTTP_NOT_FOUND:
-                    $message = $app['twig']->render('error/404.twig');
+                    $message = $twig->render('error/404.twig');
                     break;
                 default:
-                    $message = $app['twig']->render('error/500.twig');
+                    $message = $twig->render('error/500.twig');
             }
 
             return new Response($message, $code);

--- a/classes/Http/Controller/BaseController.php
+++ b/classes/Http/Controller/BaseController.php
@@ -6,6 +6,7 @@ use OpenCFP\ContainerAware;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig_Environment;
 
 abstract class BaseController
 {
@@ -35,7 +36,10 @@ abstract class BaseController
      */
     public function render($name, array $context = [], $status = Response::HTTP_OK)
     {
-        return new Response($this->app['twig']->render($name, $context), $status);
+        /* @var Twig_Environment $twig */
+        $twig = $this->app['twig'];
+
+        return new Response($twig->render($name, $context), $status);
     }
 
     /**

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -8,6 +8,7 @@ use OpenCFP\Http\Form\TalkForm;
 use Silex\Application;
 use Swift_Message;
 use Symfony\Component\HttpFoundation\Request;
+use Twig_Environment;
 
 class TalkController extends BaseController
 {
@@ -379,8 +380,11 @@ class TalkController extends BaseController
         $mapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk = $mapper->get($talk_id);
 
+        /* @var Twig_Environment $twig */
+        $twig = $app['twig'];
+
         // Build our email that we will send
-        $template = $app['twig']->loadTemplate('emails/talk_submit.twig');
+        $template = $twig->loadTemplate('emails/talk_submit.twig');
         $parameters = [
             'email' => $this->app->config('application.email'),
             'title' => $this->app->config('application.title'),

--- a/classes/Http/OAuth/AuthorizationController.php
+++ b/classes/Http/OAuth/AuthorizationController.php
@@ -12,6 +12,7 @@ use OpenCFP\Http\API\ApiController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Twig_Environment;
 
 class AuthorizationController extends ApiController
 {
@@ -53,8 +54,11 @@ class AuthorizationController extends ApiController
             // Grab currently authenticated user, if authenticated.
             $this->identityProvider->getCurrentUser();
 
+            /* @var Twig_Environment $twig */
+            $twig = $this->service('twig');
+
             // Show authorization interface
-            return $this->service('twig')->render('oauth/authorize.twig', ['authParams' => $authParams]);
+            return $twig->render('oauth/authorize.twig', ['authParams' => $authParams]);
         } catch (NotAuthenticatedException $e) {
             // Authenticate user and come back here.
             $this->service('session')->set('redirectTo', $request->getUri());

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -6,6 +6,7 @@ use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Twig_Environment;
 
 class WebGatewayProvider implements ServiceProviderInterface
 {
@@ -20,16 +21,19 @@ class WebGatewayProvider implements ServiceProviderInterface
 
         $web->before(new RequestCleaner($app['purifier']));
         $web->before(function (Request $request, Application $app) {
-            $app['twig']->addGlobal('current_page', $request->getRequestUri());
-            $app['twig']->addGlobal('cfp_open', strtotime('now') < strtotime($app->config('application.enddate') . ' 11:59 PM'));
+            /* @var Twig_Environment $twig */
+            $twig = $app['twig'];
+
+            $twig->addGlobal('current_page', $request->getRequestUri());
+            $twig->addGlobal('cfp_open', strtotime('now') < strtotime($app->config('application.enddate') . ' 11:59 PM'));
 
             if ($app['sentry']->check()) {
-                $app['twig']->addGlobal('user', $app['sentry']->getUser());
-                $app['twig']->addGlobal('user_is_admin', $app['sentry']->getUser()->hasAccess('admin'));
+                $twig->addGlobal('user', $app['sentry']->getUser());
+                $twig->addGlobal('user_is_admin', $app['sentry']->getUser()->hasAccess('admin'));
             }
 
             if ($app['session']->has('flash')) {
-                $app['twig']->addGlobal('flash', $app['session']->get('flash'));
+                $twig->addGlobal('flash', $app['session']->get('flash'));
                 $app['session']->set('flash', null);
             }
         });

--- a/classes/Provider/ResetEmailerServiceProvider.php
+++ b/classes/Provider/ResetEmailerServiceProvider.php
@@ -5,6 +5,7 @@ namespace OpenCFP\Provider;
 use OpenCFP\Domain\Services\ResetEmailer;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
+use Twig_Environment;
 
 class ResetEmailerServiceProvider implements ServiceProviderInterface
 {
@@ -14,9 +15,12 @@ class ResetEmailerServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['reset_emailer'] = $app->share(function ($app) {
+            /* @var Twig_Environment $twig */
+            $twig = $app['twig'];
+
             return new ResetEmailer(
                 $app['mailer'],
-                $app['twig']->loadTemplate('emails/reset_password.twig'),
+                $twig->loadTemplate('emails/reset_password.twig'),
                 $app->config('application.email'),
                 $app->config('application.title')
             );

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -7,6 +7,7 @@ use Ciconia\Extension\Gfm\WhiteSpaceExtension;
 use Silex\Application;
 use Silex\Provider\TwigServiceProvider as SilexTwigServiceProvider;
 use Silex\ServiceProviderInterface;
+use Twig_Environment;
 use Twig_Extension_Debug;
 use Twig_SimpleFunction;
 
@@ -25,19 +26,22 @@ class TwigServiceProvider implements ServiceProviderInterface
             ],
         ]);
 
+        /* @var Twig_Environment $twig */
+        $twig = $app['twig'];
+
         if (!$app->isProduction()) {
-            $app['twig']->addExtension(new Twig_Extension_Debug);
+            $twig->addExtension(new Twig_Extension_Debug);
         }
 
-        $app['twig']->addFunction(new Twig_SimpleFunction('uploads', function ($path) {
+        $twig->addFunction(new Twig_SimpleFunction('uploads', function ($path) {
             return '/uploads/' . $path;
         }));
 
-        $app['twig']->addFunction(new Twig_SimpleFunction('assets', function ($path) {
+        $twig->addFunction(new Twig_SimpleFunction('assets', function ($path) {
             return '/assets/' . $path;
         }));
 
-        $app['twig']->addGlobal('site', $app->config('application'));
+        $twig->addGlobal('site', $app->config('application'));
 
         // Twig Markdown Extension
         $markdown = new Ciconia();
@@ -45,7 +49,7 @@ class TwigServiceProvider implements ServiceProviderInterface
         $markdown->addExtension(new WhiteSpaceExtension);
         $engine = new CiconiaEngine($markdown);
 
-        $app['twig']->addExtension(new MarkdownExtension($engine));
+        $twig->addExtension(new MarkdownExtension($engine));
     }
 
     /**

--- a/tests/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Http/Controller/Admin/TalksControllerTest.php
@@ -9,6 +9,7 @@ use OpenCFP\Environment;
 use Spot\Query;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+use Twig_Environment;
 
 class TalksControllerTest extends \PHPUnit_Framework_TestCase
 {
@@ -116,11 +117,13 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $req->query = $paramBag;
         $req->shouldReceive('getRequestUri')->andReturn('foo');
 
-        $this->app['twig']
-            ->addGlobal(
-                'user_is_admin',
-                $this->app['sentry']->getUser()->hasAccess('admin')
-            );
+        /* @var Twig_Environment $twig */
+        $twig = $this->app['twig'];
+
+        $twig->addGlobal(
+            'user_is_admin',
+            $this->app['sentry']->getUser()->hasAccess('admin')
+        );
 
         ob_start();
         $this->app->run();

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -9,6 +9,7 @@ use OpenCFP\Environment;
 use OpenCFP\Test\Util\Faker\GeneratorTrait;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+use Twig_Environment;
 
 class DashboardControllerTest extends \PHPUnit_Framework_TestCase
 {
@@ -81,7 +82,11 @@ class DashboardControllerTest extends \PHPUnit_Framework_TestCase
         // TODO services like configuration and template rending is painful.
         $config = $app['config']['application'];
         $config['online_conference'] = true;
-        $app['twig']->addGlobal('site', $config);
+
+        /* @var Twig_Environment $twig */
+        $twig = $app['twig'];
+
+        $twig->addGlobal('site', $config);
 
         // There's some global before filters that call Sentry directly.
         // We have to stub that behaviour here to have it think we are not admin.


### PR DESCRIPTION
This PR

* [x] introduces an explaining variable `$twig` when fetching `Twig_Enviroment` from the container

:information_desk_person: This allows to provide an inline docblock, which is helpful with 

* auto-completion
* reducing errors related to undefined methods when running inspections
* finding usages

and it also micro-optimizes the application, yay!

:person_with_pouting_face: In related news, I'm happy to sort out a few more of these issues. Also, noted that there are a bunch of different ways of fetching services from the container

* sometimes using the `ContainerAware` trait in controllers, services are fetched from the field `$app`
* sometimes using the `ContainerAware` trait in controllers, services are fetched using the method `service()`
* sometimes the container is passed into a controller action

What do you think, would it be worth to streamline this?