### PR TITLE
Fix: Introduce explaining variable when fetching Sentry from container

### DIFF
--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -42,8 +42,9 @@ EOF
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var Sentry $sentry */
+        /* @var Sentry $sentry */
         $sentry = $this->app['sentry'];
+
         $email = $input->getArgument('email');
 
         $output->writeln(sprintf('Retrieving account from <info>%s</info>...', $email));

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -42,8 +42,9 @@ EOF
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var Sentry $sentry */
+        /* @var Sentry $sentry */
         $sentry = $this->app['sentry'];
+
         $email = $input->getArgument('email');
 
         $output->writeln(sprintf('Retrieving account from <info>%s</info>...', $email));

--- a/classes/Http/Controller/Admin/AdminAccessTrait.php
+++ b/classes/Http/Controller/Admin/AdminAccessTrait.php
@@ -2,6 +2,8 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use Cartalyst\Sentry\Sentry;
+
 trait AdminAccessTrait
 {
     public function __call($method, $arguments)
@@ -18,11 +20,14 @@ trait AdminAccessTrait
 
     protected function userHasAccess()
     {
-        if (!$this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+        
+        if (!$sentry->check()) {
             return false;
         }
 
-        $user = $this->app['sentry']->getUser();
+        $user = $sentry->getUser();
 
         if (!$user->hasPermission('admin')) {
             return false;

--- a/classes/Http/Controller/Admin/AdminsController.php
+++ b/classes/Http/Controller/Admin/AdminsController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use Cartalyst\Sentry\Sentry;
 use OpenCFP\Http\Controller\BaseController;
 use Pagerfanta\View\TwitterBootstrap3View;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,8 +13,11 @@ class AdminsController extends BaseController
 
     public function indexAction(Request $req)
     {
-        $adminGroup = $this->app['sentry']->getGroupProvider()->findByName('Admin');
-        $adminUsers = $this->app['sentry']->findAllUsersInGroup($adminGroup);
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+        
+        $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
+        $adminUsers = $sentry->findAllUsersInGroup($adminGroup);
 
         // Set up our page stuff
         $adapter = new \Pagerfanta\Adapter\ArrayAdapter($adminUsers->toArray());
@@ -47,7 +51,10 @@ class AdminsController extends BaseController
 
     public function removeAction(Request $req)
     {
-        $admin = $this->app['sentry']->getUser();
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+        
+        $admin = $sentry->getUser();
 
         if ($admin->getId() == $req->get('id')) {
             $this->app['session']->set('flash', [
@@ -61,9 +68,9 @@ class AdminsController extends BaseController
 
         $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
         $user_data = $mapper->get($req->get('id'))->toArray();
-        $user = $this->app['sentry']->getUserProvider()->findByLogin($user_data['email']);
+        $user = $sentry->getUserProvider()->findByLogin($user_data['email']);
 
-        $adminGroup = $this->app['sentry']->getGroupProvider()->findByName('Admin');
+        $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
         $response = $user->removeGroup($adminGroup);
 
         if ($response == true) {

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use Cartalyst\Sentry\Sentry;
 use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -16,7 +17,11 @@ class DashboardController extends BaseController
 
         $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $favorite_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
-        $recent_talks = $talk_mapper->getRecent($this->app['sentry']->getUser()->getId());
+
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+        
+        $recent_talks = $talk_mapper->getRecent($sentry->getUser()->getId());
 
         $templateData = [
             'speakerTotal' => $speaker_total,

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use Cartalyst\Sentry\Sentry;
 use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -53,7 +54,11 @@ class ExportsController extends BaseController
         }
 
         $sort = [ "created_at" => "DESC" ];
-        $admin_user_id = $this->app['sentry']->getUser()->getId();
+
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        $admin_user_id = $sentry->getUser()->getId();
         $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
         $talks = $mapper->getAllPagerFormatted($admin_user_id, $sort, $attributed, $where);
 

--- a/classes/Http/Controller/Admin/ReviewController.php
+++ b/classes/Http/Controller/Admin/ReviewController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use Cartalyst\Sentry\Sentry;
 use OpenCFP\Http\Controller\BaseController;
 use Pagerfanta\View\TwitterBootstrap3View;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,7 +13,10 @@ class ReviewController extends BaseController
 
     public function indexAction(Request $req)
     {
-        $user = $this->app['sentry']->getUser();
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        $user = $sentry->getUser();
 
         // Get list of talks where majority of admins 'favorited' them
         $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use Cartalyst\Sentry\Sentry;
 use OpenCFP\Http\Controller\BaseController;
 use OpenCFP\Http\Controller\FlashableTrait;
 use Pagerfanta\View\TwitterBootstrap3View;
@@ -18,7 +19,10 @@ class TalksController extends BaseController
             return $this->redirectTo('login');
         }
 
-        $admin_user_id = $this->app['sentry']->getUser()->getId();
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        $admin_user_id = $sentry->getUser()->getId();
         $options = [
             'order_by' => $req->get('order_by'),
             'sort' => $req->get('sort'),
@@ -132,9 +136,12 @@ class TalksController extends BaseController
             return $this->app->redirect($this->url('admin_talks'));
         }
 
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
         // Mark talk as viewed by admin
         $talk_meta = $meta_mapper->where([
-                'admin_user_id' => $this->app['sentry']->getUser()->getId(),
+                'admin_user_id' => $sentry->getUser()->getId(),
                 'talk_id' => (int)$req->get('id'),
             ])
             ->first();
@@ -145,7 +152,7 @@ class TalksController extends BaseController
 
         if (!$talk_meta->viewed) {
             $talk_meta->viewed = true;
-            $talk_meta->admin_user_id = $this->app['sentry']->getUser()->getId();
+            $talk_meta->admin_user_id = $sentry->getUser()->getId();
             $talk_meta->talk_id = $talk_id;
             $meta_mapper->save($talk_meta);
         }
@@ -184,7 +191,10 @@ class TalksController extends BaseController
             return false;
         }
 
-        $admin_user_id = (int)$this->app['sentry']->getUser()->getId();
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        $admin_user_id = (int) $sentry->getUser()->getId();
         $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
 
         $talk_rating = (int)$req->get('rating');
@@ -225,7 +235,10 @@ class TalksController extends BaseController
             return false;
         }
 
-        $admin_user_id = (int) $this->app['sentry']->getUser()->getId();
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        $admin_user_id = (int) $sentry->getUser()->getId();
         $status = true;
 
         if ($req->get('delete') !== null) {
@@ -293,7 +306,11 @@ class TalksController extends BaseController
         }
 
         $talk_id = (int)$req->get('id');
-        $admin_user_id = (int)$this->app['sentry']->getUser()->getId();
+
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        $admin_user_id = (int) $sentry->getUser()->getId();
 
         $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\TalkComment::class);
         $comment = $mapper->get();

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users\UserNotFoundException;
 use OpenCFP\Http\Form\ForgotForm;
 use OpenCFP\Http\Form\ResetForm;
@@ -42,7 +43,10 @@ class ForgotController extends BaseController
         $data = $form->getData();
 
         try {
-            $user = $this->app['sentry']->getUserProvider()->findByLogin($data['email']);
+            /* @var Sentry $sentry */
+            $sentry = $this->app['sentry'];
+
+            $user = $sentry->getUserProvider()->findByLogin($data['email']);
         } catch (UserNotFoundException $e) {
             $this->app['session']->set('flash', $this->successfulSendFlashParameters($data['email']));
 
@@ -72,7 +76,10 @@ class ForgotController extends BaseController
         $errorMessage = "The reset you have requested appears to be invalid, please try again.";
         $error = 0;
         try {
-            $user = $this->app['sentry']->getUserProvider()->findById($req->get('user_id'));
+            /* @var Sentry $sentry */
+            $sentry = $this->app['sentry'];
+
+            $user = $sentry->getUserProvider()->findById($req->get('user_id'));
 
             if (!$user->checkResetPasswordCode($req->get('reset_code'))) {
                 $error++;
@@ -120,7 +127,10 @@ class ForgotController extends BaseController
         $error = 0;
 
         try {
-            $user = $this->app['sentry']->getUserProvider()->findById($req->get('user_id'));
+            /* @var Sentry $sentry */
+            $sentry = $this->app['sentry'];
+
+            $user = $sentry->getUserProvider()->findById($req->get('user_id'));
         } catch (UserNotFoundException $e) {
             $error++;
         }
@@ -149,7 +159,10 @@ class ForgotController extends BaseController
         $password = $postArray['reset']['password']['password'];
 
         try {
-            $user = $this->app['sentry']->getUserProvider()->findById($user_id);
+            /* @var Sentry $sentry */
+            $sentry = $this->app['sentry'];
+
+            $user = $sentry->getUserProvider()->findById($user_id);
         } catch (UserNotFoundException $e) {
             echo $e;
             die();

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use OpenCFP\Http\Form\SignupForm;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,11 +13,14 @@ class ProfileController extends BaseController
 
     public function editAction(Request $req)
     {
-        if (!$this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        if (!$sentry->check()) {
             return $this->redirectTo('login');
         }
 
-        $user = $this->app['sentry']->getUser();
+        $user = $sentry->getUser();
 
         if ((string) $user->getId() !== $req->get('id')) {
             $this->app['session']->set('flash', [
@@ -54,11 +58,14 @@ class ProfileController extends BaseController
 
     public function processAction(Request $req)
     {
-        if (!$this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        if (!$sentry->check()) {
             return $this->redirectTo('login');
         }
 
-        $user = $this->app['sentry']->getUser();
+        $user = $sentry->getUser();
 
         if ((string) $user->getId() !== $req->get('id')) {
             $this->app['session']->set('flash', [
@@ -162,7 +169,10 @@ class ProfileController extends BaseController
 
     public function passwordAction(Request $req)
     {
-        if (!$this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        if (!$sentry->check()) {
             return $this->redirectTo('login');
         }
 
@@ -171,11 +181,14 @@ class ProfileController extends BaseController
 
     public function passwordProcessAction(Request $req)
     {
-        if (!$this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        if (!$sentry->check()) {
             return $this->redirectTo('login');
         }
 
-        $user = $this->app['sentry']->getUser();
+        $user = $sentry->getUser();
 
         /**
          * Okay, the logic is kind of weird but we can use the SignupForm

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use OpenCFP\Domain\Services\Login;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -20,7 +21,10 @@ class SecurityController extends BaseController
     public function processAction(Request $req, Application $app)
     {
         try {
-            $page = new Login($app['sentry']);
+            /* @var Sentry $sentry */
+            $sentry = $app['sentry'];
+
+            $page = new Login($sentry);
 
             if ($page->authenticate($req->get('email'), $req->get('password'))) {
                 // This is for redirecting to OAuth endpoint if we arrived
@@ -60,7 +64,10 @@ class SecurityController extends BaseController
 
     public function outAction()
     {
-        $this->app['sentry']->logout();
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+        
+        $sentry->logout();
 
         return $this->redirectTo('homepage');
     }

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users\UserExistsException;
 use OpenCFP\Http\Form\SignupForm;
 use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
@@ -15,7 +16,10 @@ class SignupController extends BaseController
 
     public function indexAction(Request $req, $currentTimeString = 'now')
     {
-        if ($this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        if ($sentry->check()) {
             return $this->redirectTo('dashboard');
         }
 
@@ -96,10 +100,13 @@ class SignupController extends BaseController
                     'activated' => 1,
                 ];
 
-                $user = $app['sentry']->getUserProvider()->create($user_data);
+                /* @var Sentry $sentry */
+                $sentry = $app['sentry'];
+
+                $user = $sentry->getUserProvider()->create($user_data);
 
                 // Add them to the proper group
-                $user->addGroup($app['sentry']
+                $user->addGroup($sentry
                     ->getGroupProvider()
                     ->findByName('Speakers')
                 );
@@ -118,7 +125,7 @@ class SignupController extends BaseController
                 // This is for redirecting to OAuth endpoint if we arrived
                 // as part of the Authorization Code Grant flow.
                 if ($this->app['session']->has('redirectTo')) {
-                    $this->app['sentry']->login($user);
+                    $sentry->login($user);
 
                     return new RedirectResponse($this->app['session']->get('redirectTo'));
                 }

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use OpenCFP\Application\NotAuthorizedException;
 use OpenCFP\Application\Speakers;
 use OpenCFP\Http\Form\TalkForm;
@@ -39,8 +40,11 @@ class TalkController extends BaseController
         /* @var Speakers $speakers */
         $speakers = $this->app['application.speakers'];
 
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
         /////////
-        if (!$this->app['sentry']->check()) {
+        if (!$sentry->check()) {
             return $this->redirectTo('login');
         }
 
@@ -64,7 +68,10 @@ class TalkController extends BaseController
      */
     public function editAction(Request $req)
     {
-        if (!$this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        if (!$sentry->check()) {
             return $this->redirectTo('login');
         }
 
@@ -87,7 +94,7 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $user = $this->app['sentry']->getUser();
+        $user = $sentry->getUser();
 
         $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk_info = $talk_mapper->get($talk_id)->toArray();
@@ -122,7 +129,10 @@ class TalkController extends BaseController
      */
     public function createAction(Request $req)
     {
-        if (! $this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        if (!$sentry->check()) {
             return $this->redirectTo('login');
         }
 
@@ -163,7 +173,10 @@ class TalkController extends BaseController
      */
     public function processCreateAction(Request $req)
     {
-        if (! $this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        if (!$sentry->check()) {
             return $this->redirectTo('login');
         }
 
@@ -178,7 +191,7 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $user = $this->app['sentry']->getUser();
+        $user = $sentry->getUser();
 
         $request_data = [
             'title' => $req->get('title'),
@@ -256,11 +269,14 @@ class TalkController extends BaseController
 
     public function updateAction(Request $req)
     {
-        if (! $this->app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
+        if (!$sentry->check()) {
             return $this->redirectTo('login');
         }
 
-        $user = $this->app['sentry']->getUser();
+        $user = $sentry->getUser();
 
         $request_data = [
             'id' => $req->get('id'),
@@ -344,7 +360,10 @@ class TalkController extends BaseController
 
     public function deleteAction(Request $req, Application $app)
     {
-        if (! $app['sentry']->check()) {
+        /* @var Sentry $sentry */
+        $sentry = $app['sentry'];
+        
+        if (!$sentry->check()) {
             return $app->json(['delete' => 'no-user']);
         }
 
@@ -353,7 +372,7 @@ class TalkController extends BaseController
             return $app->json(['delete' => 'no']);
         }
 
-        $user = $app['sentry']->getUser();
+        $user = $sentry->getUser();
         $talk_mapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk = $talk_mapper->get($req->get('tid'));
 

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Provider;
 
+use Cartalyst\Sentry\Sentry;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use League\OAuth2\Server\ResourceServer;
 use OpenCFP\Application\Speakers;
@@ -34,9 +35,12 @@ class ApplicationServiceProvider implements ServiceProviderInterface
             $talkMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
             $speakerRepository = new SpotSpeakerRepository($userMapper);
 
+            /* @var Sentry $sentry */
+            $sentry = $app['sentry'];
+            
             return new Speakers(
                 new CallForProposal(new \DateTime($app->config('application.enddate'))),
-                new SentryIdentityProvider($app['sentry'], $speakerRepository),
+                new SentryIdentityProvider($sentry, $speakerRepository),
                 $speakerRepository,
                 new SpotTalkRepository($talkMapper),
                 new EventDispatcher()

--- a/classes/Provider/Gateways/OAuthGatewayProvider.php
+++ b/classes/Provider/Gateways/OAuthGatewayProvider.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Provider\Gateways;
 
+use Cartalyst\Sentry\Sentry;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ServiceProviderInterface;
@@ -27,7 +28,10 @@ class OAuthGatewayProvider implements ServiceProviderInterface
             $userMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
             $speakerRepository = new SpotSpeakerRepository($userMapper);
 
-            $controller = new AuthorizationController($server, new SentryIdentityProvider($app['sentry'], $speakerRepository));
+            /* @var Sentry $sentry */
+            $sentry = $app['sentry'];
+            
+            $controller = new AuthorizationController($server, new SentryIdentityProvider($sentry, $speakerRepository));
             $controller->setApplication($app);
 
             return $controller;

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Provider\Gateways;
 
+use Cartalyst\Sentry\Sentry;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ServiceProviderInterface;
@@ -23,9 +24,12 @@ class WebGatewayProvider implements ServiceProviderInterface
             $app['twig']->addGlobal('current_page', $request->getRequestUri());
             $app['twig']->addGlobal('cfp_open', strtotime('now') < strtotime($app->config('application.enddate') . ' 11:59 PM'));
 
-            if ($app['sentry']->check()) {
-                $app['twig']->addGlobal('user', $app['sentry']->getUser());
-                $app['twig']->addGlobal('user_is_admin', $app['sentry']->getUser()->hasAccess('admin'));
+            /* @var Sentry $sentry */
+            $sentry = $app['sentry'];
+            
+            if ($sentry->check()) {
+                $app['twig']->addGlobal('user', $sentry->getUser());
+                $app['twig']->addGlobal('user_is_admin', $sentry->getUser()->hasAccess('admin'));
             }
 
             if ($app['session']->has('flash')) {

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Test\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use Mockery as m;
 use OpenCFP\Application;
 use OpenCFP\Domain\Speaker\SpeakerProfile;

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Test\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use DateTime;
 use Mockery as m;
 use OpenCFP\Application;
@@ -66,6 +67,9 @@ class TalkControllerTest extends \PHPUnit_Framework_TestCase
         $swiftmailer->shouldReceive('send')->andReturn(true);
         $this->app['mailer'] = $swiftmailer;
 
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
         // Get our request object to return expected data
         $talk_data = [
             'title' => 'Test Title With Ampersand',
@@ -77,7 +81,7 @@ class TalkControllerTest extends \PHPUnit_Framework_TestCase
             'slides' => '',
             'other' => '',
             'sponsor' => '',
-            'user_id' => $this->app['sentry']->getUser()->getId(),
+            'user_id' => $sentry->getUser()->getId(),
         ];
 
         $this->setPost($talk_data);
@@ -125,6 +129,9 @@ class TalkControllerTest extends \PHPUnit_Framework_TestCase
         $controller = new TalkController();
         $controller->setApplication($this->app);
 
+        /* @var Sentry $sentry */
+        $sentry = $this->app['sentry'];
+
         // Get our request object to return expected data
         $talk_data = [
             'title' => 'Test Submission',
@@ -136,7 +143,7 @@ class TalkControllerTest extends \PHPUnit_Framework_TestCase
             'slides' => '',
             'other' => '',
             'sponsor' => '',
-            'user_id' => $this->app['sentry']->getUser()->getId(),
+            'user_id' => $sentry->getUser()->getId(),
         ];
 
         $this->setPost($talk_data);


### PR DESCRIPTION
This PR

* [x] introduces an explaining variable `$sentry` when fetching `Cartalyst\Sentry\Sentry` from container

Follows #375.