### PR TITLE
Fix: Actually mock Sentry

### DIFF
--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Test\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use Mockery as m;
 use OpenCFP\Application;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
@@ -32,7 +33,7 @@ class DashboardControllerTest extends \PHPUnit_Framework_TestCase
         $user->shouldReceive('hasAccess')->with('admin')->andReturn(true);
 
         // Create a test double for Sentry
-        $sentry = m::mock('StdClass');
+        $sentry = m::mock(Sentry::class);
         $sentry->shouldReceive('check')->times(3)->andReturn(true);
         $sentry->shouldReceive('getUser')->andReturn($user);
         $app['sentry'] = $sentry;
@@ -91,7 +92,7 @@ class DashboardControllerTest extends \PHPUnit_Framework_TestCase
         $user->shouldReceive('getId')->andReturn(1);
         $user->shouldReceive('id')->andReturn(1);
         $user->shouldReceive('hasAccess')->with('admin')->andReturn(false);
-        $sentry = m::mock('stdClass');
+        $sentry = m::mock(Sentry::class);
         $sentry->shouldReceive('check')->andReturn(true);
         $sentry->shouldReceive('getUser')->andReturn($user);
         $app['sentry'] = $sentry;

--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Test\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 use Mockery as m;
@@ -19,7 +20,7 @@ class SignupControllerTest extends \PHPUnit_Framework_TestCase
     public function signupAfterEnddateShowsError($endDateString, $currentTimeString)
     {
         // report that there is no active user
-        $sentry = m::mock('stdClass');
+        $sentry = m::mock(Sentry::class);
         $sentry->shouldReceive('check')->andReturn(false);
 
         $app = m::mock(\OpenCFP\Application::class);
@@ -147,7 +148,7 @@ class SignupControllerTest extends \PHPUnit_Framework_TestCase
         $app->shouldReceive('offsetGet')->with('purifier')->andReturn($purifier);
 
         // Create a pretend Sentry object that says everything is cool
-        $sentry = m::mock('stdClass');
+        $sentry = m::mock(Sentry::class);
         $user = m::mock(\OpenCFP\Domain\Entity\User::class);
         $user->shouldReceive('set');
         $user->shouldReceive('addGroup');

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Test\Http\Controller;
 
+use Cartalyst\Sentry\Sentry;
 use DateTime;
 use Mockery as m;
 use OpenCFP\Application;
@@ -38,7 +39,7 @@ class TalkControllerTest extends \PHPUnit_Framework_TestCase
         $user->shouldReceive('getLogin')->andReturn(uniqid() . '@grumpy-learning.com');
 
         // Create a test double for Sentry
-        $sentry = m::mock('StdClass');
+        $sentry = m::mock(Sentry::class);
         $sentry->shouldReceive('check')->andReturn(true);
         $sentry->shouldReceive('getUser')->andReturn($user);
         $this->app['sentry'] = $sentry;


### PR DESCRIPTION
This PR

* [x] actually uses `Cartalyst\Sentry\Sentry` (instead of `stdClass`) when mocking

Somewhat related to #376.