### PR TITLE
Fix: Introduce explaining variable when fetching Spot\Locator from container

### DIFF
--- a/classes/Http/Controller/Admin/AdminsController.php
+++ b/classes/Http/Controller/Admin/AdminsController.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Http\Controller\BaseController;
 use Pagerfanta\View\TwitterBootstrap3View;
+use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class AdminsController extends BaseController
@@ -59,7 +60,10 @@ class AdminsController extends BaseController
             return $this->redirectTo('admin_admins');
         }
 
-        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
+        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $user_data = $mapper->get($req->get('id'))->toArray();
         $user = $this->app['sentry']->getUserProvider()->findByLogin($user_data['email']);
 

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Http\Controller\BaseController;
+use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class DashboardController extends BaseController
@@ -11,11 +12,14 @@ class DashboardController extends BaseController
 
     public function indexAction(Request $req)
     {
-        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
+        $user_mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker_total = $user_mapper->all()->count();
 
-        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $favorite_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
+        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $favorite_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Favorite::class);
         $recent_talks = $talk_mapper->getRecent($this->app['sentry']->getUser()->getId());
 
         $templateData = [

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Http\Controller\BaseController;
+use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class ExportsController extends BaseController
@@ -30,7 +31,10 @@ class ExportsController extends BaseController
             return $this->redirectTo('login');
         }
 
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+
+        $mapper = $spot->mapper('OpenCFP\Domain\Entity\Talk');
         $talks = $mapper->all();
 
         foreach ($talks as $talk) {
@@ -54,7 +58,11 @@ class ExportsController extends BaseController
 
         $sort = [ "created_at" => "DESC" ];
         $admin_user_id = $this->app['sentry']->getUser()->getId();
-        $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
+
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
+        $mapper = $spot->mapper('OpenCFP\Domain\Entity\Talk');
         $talks = $mapper->getAllPagerFormatted($admin_user_id, $sort, $attributed, $where);
 
         foreach ($talks as $talk => $info) {

--- a/classes/Http/Controller/Admin/ReviewController.php
+++ b/classes/Http/Controller/Admin/ReviewController.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Http\Controller\BaseController;
 use Pagerfanta\View\TwitterBootstrap3View;
+use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class ReviewController extends BaseController
@@ -14,8 +15,11 @@ class ReviewController extends BaseController
     {
         $user = $this->app['sentry']->getUser();
 
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
         // Get list of talks where majority of admins 'favorited' them
-        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $options = [
             'order_by' => $req->get('order_by'),
             'sort' => $req->get('sort'),

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -9,6 +9,7 @@ use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 use Pagerfanta\View\TwitterBootstrap3View;
 use Silex\Application;
+use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class SpeakersController extends BaseController
@@ -18,7 +19,10 @@ class SpeakersController extends BaseController
 
     public function indexAction(Request $req)
     {
-        $rawSpeakers = $this->app['spot']
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
+        $rawSpeakers = $spot
             ->mapper(\OpenCFP\Domain\Entity\User::class)
             ->all()
             ->order(['first_name' => 'ASC'])
@@ -86,8 +90,11 @@ class SpeakersController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
         // Get info about the speaker
-        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+        $user_mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker_details = $user_mapper->get($req->get('id'));
 
         if (empty($speaker_details)) {
@@ -119,7 +126,7 @@ class SpeakersController extends BaseController
         }
 
         // Get info about the talks
-        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talks = $talk_mapper->getByUser($req->get('id'))->toArray();
 
         // Build and render the template
@@ -143,7 +150,10 @@ class SpeakersController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
+        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker = $mapper->get($req->get('id'));
         $response = $mapper->delete($speaker);
 

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -5,6 +5,7 @@ namespace OpenCFP\Http\Controller\Admin;
 use OpenCFP\Http\Controller\BaseController;
 use OpenCFP\Http\Controller\FlashableTrait;
 use Pagerfanta\View\TwitterBootstrap3View;
+use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class TalksController extends BaseController
@@ -72,7 +73,10 @@ class TalksController extends BaseController
 
     private function getFilteredTalks($filter = null, $admin_user_id, $options = [])
     {
-        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+
+        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
         if ($filter === null) {
             return $talk_mapper->getAllPagerFormatted($admin_user_id, $options);
         }
@@ -113,9 +117,12 @@ class TalksController extends BaseController
             return $this->redirectTo('login');
         }
 
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+
         // Get info about the talks
-        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $meta_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
+        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $meta_mapper = $spot->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
         $talk_id = $req->get('id');
 
         $talk = $talk_mapper->where(['id' => $talk_id])
@@ -155,7 +162,7 @@ class TalksController extends BaseController
             ->toArray();
 
         // Get info about our speaker
-        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+        $user_mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker = $user_mapper->get($talk->user_id)->toArray();
 
         // Grab all the other talks and filter out the one we have
@@ -185,7 +192,11 @@ class TalksController extends BaseController
         }
 
         $admin_user_id = (int)$this->app['sentry']->getUser()->getId();
-        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
+
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+
+        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
 
         $talk_rating = (int)$req->get('rating');
         $talk_id = (int)$req->get('id');
@@ -232,7 +243,10 @@ class TalksController extends BaseController
             $status = false;
         }
 
-        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+
+        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Favorite::class);
 
         if ($status == false) {
             // Delete the record that matches
@@ -278,7 +292,10 @@ class TalksController extends BaseController
             $status = false;
         }
 
-        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+
+        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk = $mapper->get($req->get('id'));
         $talk->selected = $status;
         $mapper->save($talk);
@@ -295,7 +312,10 @@ class TalksController extends BaseController
         $talk_id = (int)$req->get('id');
         $admin_user_id = (int)$this->app['sentry']->getUser()->getId();
 
-        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\TalkComment::class);
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
+        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\TalkComment::class);
         $comment = $mapper->get();
 
         $comment->talk_id = $talk_id;

--- a/classes/Http/Controller/PagesController.php
+++ b/classes/Http/Controller/PagesController.php
@@ -2,6 +2,8 @@
 
 namespace OpenCFP\Http\Controller;
 
+use Spot\Locator;
+
 class PagesController extends BaseController
 {
     public function showHomepage()
@@ -21,7 +23,10 @@ class PagesController extends BaseController
 
     private function getContextWithTalksCount()
     {
-        $numberOfTalks = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class)->all()->count();
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+
+        $numberOfTalks = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class)->all()->count();
 
         return [
             'number_of_talks' => $numberOfTalks,

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Http\Form\SignupForm;
 use Silex\Application;
+use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class ProfileController extends BaseController
@@ -28,7 +29,10 @@ class ProfileController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $mapper = $this->app['spot']->mapper('\OpenCFP\Domain\Entity\User');
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
+        $mapper = $spot->mapper('\OpenCFP\Domain\Entity\User');
         $speaker_data = $mapper->get($user->getId())->toArray();
 
         $form_data = [
@@ -114,7 +118,10 @@ class ProfileController extends BaseController
                 $processor->process($file, $sanitized_data['speaker_photo']);
             }
 
-            $mapper = $this->app['spot']->mapper('\OpenCFP\Domain\Entity\User');
+            /* @var Locator $spot */
+            $spot = $this->app['spot'];
+            
+            $mapper = $spot->mapper('\OpenCFP\Domain\Entity\User');
             $user = $mapper->get($user->getId());
             $user->email = $sanitized_data['email'];
             $user->first_name = $sanitized_data['first_name'];
@@ -233,7 +240,10 @@ class ProfileController extends BaseController
      */
     protected function saveUser($app, $sanitized_data)
     {
-        $mapper = $this->app['spot']->mapper('\OpenCFP\Domain\Entity\User');
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
+        $mapper = $spot->mapper('\OpenCFP\Domain\Entity\User');
         $user = $mapper->get($sanitized_data['user_id']);
         $user->email = $sanitized_data['email'];
         $user->first_name = $sanitized_data['first_name'];

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -6,6 +6,7 @@ use Cartalyst\Sentry\Users\UserExistsException;
 use OpenCFP\Http\Form\SignupForm;
 use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
 use Silex\Application;
+use Spot\Locator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -104,8 +105,11 @@ class SignupController extends BaseController
                     ->findByName('Speakers')
                 );
 
+                /* @var Locator $spot */
+                $spot = $app['spot'];
+                
                 // Add in the extra speaker information
-                $mapper = $app['spot']->mapper('\OpenCFP\Domain\Entity\User');
+                $mapper = $spot->mapper('\OpenCFP\Domain\Entity\User');
 
                 $speaker = $mapper->get($user->id);
                 $speaker->info = $sanitized_data['speaker_info'];

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -6,6 +6,7 @@ use OpenCFP\Application\NotAuthorizedException;
 use OpenCFP\Application\Speakers;
 use OpenCFP\Http\Form\TalkForm;
 use Silex\Application;
+use Spot\Locator;
 use Swift_Message;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -89,7 +90,10 @@ class TalkController extends BaseController
 
         $user = $this->app['sentry']->getUser();
 
-        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+
+        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk_info = $talk_mapper->get($talk_id)->toArray();
 
         if ($talk_info['user_id'] !== (int) $user->getId()) {
@@ -212,7 +216,10 @@ class TalkController extends BaseController
                 'user_id' => (int) $user->getId(),
             ];
 
-            $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+            /* @var Locator $spot */
+            $spot = $this->app['spot'];
+
+            $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
             $talk = $talk_mapper->create($data);
 
             $this->app['session']->set('flash', [
@@ -296,7 +303,10 @@ class TalkController extends BaseController
                 'user_id' => (int) $user->getId(),
             ];
 
-            $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+            /* @var Locator $spot */
+            $spot = $this->app['spot'];
+
+            $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
             $talk = $mapper->get($data['id']);
 
             foreach ($data as $field => $value) {
@@ -354,7 +364,11 @@ class TalkController extends BaseController
         }
 
         $user = $app['sentry']->getUser();
-        $talk_mapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+
+        /* @var Locator $spot */
+        $spot = $app['spot'];
+        
+        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk = $talk_mapper->get($req->get('tid'));
 
         if ($talk->user_id !== (int) $user->getId()) {
@@ -376,7 +390,10 @@ class TalkController extends BaseController
      */
     protected function sendSubmitEmail(Application $app, $email, $talk_id)
     {
-        $mapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        /* @var Locator $spot */
+        $spot = $app['spot'];
+        
+        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk = $mapper->get($talk_id);
 
         // Build our email that we will send

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -21,6 +21,7 @@ use OpenCFP\Infrastructure\Persistence\SpotTalkRepository;
 use RandomLib\Factory;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
+use Spot\Locator;
 
 class ApplicationServiceProvider implements ServiceProviderInterface
 {
@@ -30,8 +31,11 @@ class ApplicationServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['application.speakers'] = $app->share(function ($app) {
-            $userMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
-            $talkMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+            /* @var Locator $spot */
+            $spot = $app['spot'];
+            
+            $userMapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
+            $talkMapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
             $speakerRepository = new SpotSpeakerRepository($userMapper);
 
             return new Speakers(
@@ -83,8 +87,11 @@ class ApplicationServiceProvider implements ServiceProviderInterface
         });
 
         $app['application.speakers.api'] = $app->share(function ($app) {
-            $userMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
-            $talkMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+            /* @var Locator $spot */
+            $spot = $app['spot'];
+            
+            $userMapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
+            $talkMapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
             $speakerRepository = new SpotSpeakerRepository($userMapper);
 
             return new Speakers(

--- a/classes/Provider/Gateways/OAuthGatewayProvider.php
+++ b/classes/Provider/Gateways/OAuthGatewayProvider.php
@@ -5,6 +5,7 @@ namespace OpenCFP\Provider\Gateways;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ServiceProviderInterface;
+use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class OAuthGatewayProvider implements ServiceProviderInterface
@@ -24,7 +25,10 @@ class OAuthGatewayProvider implements ServiceProviderInterface
             $server->addGrantType(new AuthCodeGrant);
             $server->addGrantType(new RefreshTokenGrant);
 
-            $userMapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+            /* @var Locator $spot */
+            $spot = $app['spot'];
+            
+            $userMapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
             $speakerRepository = new SpotSpeakerRepository($userMapper);
 
             $controller = new AuthorizationController($server, new SentryIdentityProvider($app['sentry'], $speakerRepository));
@@ -34,8 +38,11 @@ class OAuthGatewayProvider implements ServiceProviderInterface
         });
 
         $app['controller.oauth.clients'] = $app->share(function ($app) {
+            /* @var Locator $spot */
+            $spot = $app['spot'];
+            
             return new ClientRegistrationController(
-            $app['spot']->mapper(\OpenCFP\Domain\OAuth\Client::class),
+            $spot->mapper(\OpenCFP\Domain\OAuth\Client::class),
             $app['spot']->mapper(\OpenCFP\Domain\OAuth\Endpoint::class),
             $app['security.random']
             );

--- a/tests/Domain/Entity/FavoriteTest.php
+++ b/tests/Domain/Entity/FavoriteTest.php
@@ -23,12 +23,15 @@ class FavoriteTest extends \PHPUnit_Framework_TestCase
             'dbname' => 'sqlite::memory',
             'driver' => 'pdo_sqlite',
         ]);
-        $this->app['spot'] = new \Spot\Locator($cfg);
-        $this->mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
+        $spot = new \Spot\Locator($cfg);
+
+        $this->app['spot'] = $spot;
+        
+        $this->mapper = $spot->mapper(\OpenCFP\Domain\Entity\Favorite::class);
         $this->mapper->migrate();
 
         // Create a talk
-        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $data = [
             'title' => 'Favorite Entity Test',
             'description' => 'This is a stubbed talk for a Favorite Entity Test',

--- a/tests/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/Domain/Entity/Mapper/TalkTest.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Test\Domain\Entity\Mapper;
 
 use OpenCFP\Application;
 use OpenCFP\Environment;
+use Spot\Locator;
 
 /**
  * @group db
@@ -22,11 +23,14 @@ class TalkTest extends \PHPUnit_Framework_TestCase
             'dbname' => 'sqlite::memory',
             'driver' => 'pdo_sqlite',
         ]);
-        $this->app['spot'] = new \Spot\Locator($cfg);
-        $this->mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+
+        $spot = new \Spot\Locator($cfg);
+
+        $this->app['spot'] = $spot;
+        $this->mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
 
         foreach ($this->entities as $entity) {
-            $this->app['spot']->mapper('OpenCFP\Domain\Entity\\' . $entity)->migrate();
+            $spot->mapper('OpenCFP\Domain\Entity\\' . $entity)->migrate();
         }
     }
 
@@ -38,7 +42,11 @@ class TalkTest extends \PHPUnit_Framework_TestCase
         // Create a test talk
         $admin_user_id = 1;
         $admin_majority = 3;
-        $mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+
+        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
 
         $talk_data = [
             'title' => 'Admin Favorite Talk',
@@ -68,8 +76,11 @@ class TalkTest extends \PHPUnit_Framework_TestCase
 
     private function createAdminFavoredTalks($admin_user_id, $admin_majority, $talk)
     {
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
         // Create a test user
-        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+        $user_mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $user_mapper->create([
             'id' => $admin_user_id,
             'email' => 'test@test.com',
@@ -79,7 +90,7 @@ class TalkTest extends \PHPUnit_Framework_TestCase
         ]);
 
         // Create $admin_majority favorite records linked to that talk
-        $favorite_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
+        $favorite_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Favorite::class);
         $favorite_mapper->create(['admin_user_id' => $admin_user_id, 'talk_id' => $talk->id]);
 
         for ($x = 1; $x <= $admin_majority; $x++) {

--- a/tests/Domain/Entity/TalkTest.php
+++ b/tests/Domain/Entity/TalkTest.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Test\Domain\Entity;
 
 use OpenCFP\Application;
 use OpenCFP\Environment;
+use Spot\Locator;
 
 /**
  * @group db
@@ -22,12 +23,14 @@ class TalkTest extends \PHPUnit_Framework_TestCase
             'dbname' => 'sqlite::memory',
             'driver' => 'pdo_sqlite',
         ]);
-        $this->app['spot'] = new \Spot\Locator($cfg);
+        $spot = new \Spot\Locator($cfg);
 
-        $this->mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $this->app['spot'] = $spot;
+
+        $this->mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
 
         foreach ($this->entities as $entity) {
-            $this->app['spot']->mapper('OpenCFP\Domain\Entity\\' . $entity)->migrate();
+            $spot->mapper('OpenCFP\Domain\Entity\\' . $entity)->migrate();
         }
     }
 
@@ -56,12 +59,15 @@ class TalkTest extends \PHPUnit_Framework_TestCase
      */
     public function getRecentFindsMostRecentTalks()
     {
+        /* @var Locator $spot */
+        $spot = $this->app['spot'];
+        
         // Create a favorites table, can be empty
-        $favorite_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Favorite::class);
+        $favorite_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Favorite::class);
         $favorite_mapper->migrate();
 
         // Create users entity
-        $user_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\User::class);
+        $user_mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $user_mapper->migrate();
 
         // Create 11 talks

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -26,10 +26,12 @@ class TalkControllerTest extends \PHPUnit_Framework_TestCase
             'dbname' => 'sqlite::memory',
             'driver' => 'pdo_sqlite',
         ]);
-        $this->app['spot'] = new \Spot\Locator($cfg);
+        $spot = new \Spot\Locator($cfg);
+        
+        $this->app['spot'] = $spot;
 
         // Initialize the talk table in the sqlite database
-        $talk_mapper = $this->app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk_mapper->migrate();
 
         // Set things up so Sentry believes we're logged in


### PR DESCRIPTION
This PR

* [x] introduces an explaining variable `$spot` when fetching `Spot\Locator` from container

Follows #375.