### PR TITLE
Fix: Remove useless docblocks

### DIFF
--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -11,11 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AdminDemoteCommand extends BaseCommand
 {
-    /**
-     * Configure the command options.
-     *
-     * @return void
-     */
     protected function configure()
     {
         $this
@@ -33,13 +28,6 @@ EOF
 );
     }
 
-    /**
-     * Execute the command.
-     *
-     * @param  \Symfony\Component\Console\Input\InputInterface   $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
-     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         /** @var Sentry $sentry */

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -11,11 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AdminPromoteCommand extends BaseCommand
 {
-    /**
-     * Configure the command options.
-     *
-     * @return void
-     */
     protected function configure()
     {
         $this
@@ -33,13 +28,6 @@ EOF
 );
     }
 
-    /**
-     * Execute the command.
-     *
-     * @param  \Symfony\Component\Console\Input\InputInterface   $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
-     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         /** @var Sentry $sentry */

--- a/classes/Console/Command/ClearCacheCommand.php
+++ b/classes/Console/Command/ClearCacheCommand.php
@@ -8,11 +8,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ClearCacheCommand extends BaseCommand
 {
-    /**
-     * Configure the command options.
-     *
-     * @return void
-     */
     protected function configure()
     {
         $this
@@ -20,13 +15,6 @@ class ClearCacheCommand extends BaseCommand
             ->setDescription('Clears the caches');
     }
 
-    /**
-     * Execute the command.
-     *
-     * @param  \Symfony\Component\Console\Input\InputInterface   $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
-     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Clearing all caches...');


### PR DESCRIPTION
This PR

* [x] removes useless docblocks from console commands 

:information_desk_person: No need to repeat what is automatically inherited from the parent. As a heads-up, this can be part of a series cleaning up console commands!