### PR TITLE
Fix: Return error codes instead of exiting with 1

### DIFF
--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -54,7 +54,8 @@ EOF
 
             if (! $user->hasAccess('admin')) {
                 $output->writeln(sprintf('The account <info>%s</info> is not in the Admin group', $email));
-                exit(1);
+
+                return 1;
             }
 
             $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
@@ -62,10 +63,10 @@ EOF
             $output->writeln(sprintf('  Removed <info>%s</info> from the Admin group', $email));
         } catch (UserNotFoundException $e) {
             $output->writeln(sprintf('<error>Error:</error> Could not find user by %s', $email));
-            exit(1);
+
+            return 1;
         }
 
         $output->writeln('Done!');
-        exit(0);
     }
 }

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -54,7 +54,8 @@ EOF
 
             if ($user->hasAccess('admin')) {
                 $output->writeln(sprintf('The account <info>%s</info> already has Admin access', $email));
-                exit(1);
+
+                return 1;
             }
 
             $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
@@ -62,10 +63,10 @@ EOF
             $output->writeln(sprintf('  Added <info>%s</info> to the Admin group', $email));
         } catch (UserNotFoundException $e) {
             $output->writeln(sprintf('<error>Error:</error> Could not find user by %s', $email));
-            exit(1);
+
+            return 1;
         }
 
         $output->writeln('Done!');
-        exit(0);
     }
 }


### PR DESCRIPTION
This PR

* [x] returns `1` instead of exiting and removes `exit(0)`

Related to #380.

:information_desk_person: Not sure if it hasn't always been that way, but one is supposed to return either `null` or an `int` from `execute()`.
