### PR TITLE
Fix: Do not try too much

### DIFF
--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -39,23 +39,24 @@ EOF
 
         try {
             $user = $sentry->getUserProvider()->findByLogin($email);
-            $output->writeln('  Found account...');
-
-            if (! $user->hasAccess('admin')) {
-                $output->writeln(sprintf('The account <info>%s</info> is not in the Admin group', $email));
-
-                return 1;
-            }
-
-            $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
-            $user->removeGroup($adminGroup);
-            $output->writeln(sprintf('  Removed <info>%s</info> from the Admin group', $email));
         } catch (UserNotFoundException $e) {
             $output->writeln(sprintf('<error>Error:</error> Could not find user by %s', $email));
 
             return 1;
         }
 
+        $output->writeln('  Found account...');
+
+        if (! $user->hasAccess('admin')) {
+            $output->writeln(sprintf('The account <info>%s</info> is not in the Admin group', $email));
+
+            return 1;
+        }
+
+        $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
+        $user->removeGroup($adminGroup);
+
+        $output->writeln(sprintf('  Removed <info>%s</info> from the Admin group', $email));
         $output->writeln('Done!');
     }
 }

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -39,23 +39,24 @@ EOF
 
         try {
             $user = $sentry->getUserProvider()->findByLogin($email);
-            $output->writeln('  Found account...');
-
-            if ($user->hasAccess('admin')) {
-                $output->writeln(sprintf('The account <info>%s</info> already has Admin access', $email));
-
-                return 1;
-            }
-
-            $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
-            $user->addGroup($adminGroup);
-            $output->writeln(sprintf('  Added <info>%s</info> to the Admin group', $email));
         } catch (UserNotFoundException $e) {
             $output->writeln(sprintf('<error>Error:</error> Could not find user by %s', $email));
 
             return 1;
         }
 
+        $output->writeln('  Found account...');
+
+        if ($user->hasAccess('admin')) {
+            $output->writeln(sprintf('The account <info>%s</info> already has Admin access', $email));
+
+            return 1;
+        }
+
+        $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
+        $user->addGroup($adminGroup);
+
+        $output->writeln(sprintf('  Added <info>%s</info> to the Admin group', $email));
         $output->writeln('Done!');
     }
 }


### PR DESCRIPTION
This PR

* [x] tries not to `try` too hard

Follows #380.

💁There's probably no need to extend the `try` and `catch` block further than trying to find a user, especially if we're only catching `UserNotFoundException`s.
