### PR TITLE
Fix: Undefined class

### DIFF
--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -120,7 +120,7 @@ class DashboardControllerTest extends \PHPUnit_Framework_TestCase
             'getPhoto' => '',
         ]);
 
-        $speakersDouble = m::mock(OpenCFP\Application\Speakers::class)
+        $speakersDouble = m::mock(\OpenCFP\Application\Speakers::class)
             ->shouldReceive('findProfile')
             ->andReturn($profile)
             ->getMock();


### PR DESCRIPTION
This PR

* [x] prepends a class reference with `\` so it can be resolved
