### PR TITLE
Enhancement: Use SymfonyStyle to streamline console output

### DIFF
--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -8,6 +8,7 @@ use OpenCFP\Console\BaseCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class AdminDemoteCommand extends BaseCommand
 {
@@ -35,20 +36,34 @@ EOF
 
         $email = $input->getArgument('email');
 
-        $output->writeln(sprintf('Retrieving account from <info>%s</info>...', $email));
+        $io = new SymfonyStyle(
+            $input,
+            $output
+        );
+
+        $io->title('OpenCFP');
+
+        $io->section(sprintf(
+            'Demoting account with email %s from Admin',
+            $email
+        ));
 
         try {
             $user = $sentry->getUserProvider()->findByLogin($email);
         } catch (UserNotFoundException $e) {
-            $output->writeln(sprintf('<error>Error:</error> Could not find user by %s', $email));
+            $io->error(sprintf(
+                'Could not find account with email %s.',
+                $email
+            ));
 
             return 1;
         }
 
-        $output->writeln('  Found account...');
-
         if (! $user->hasAccess('admin')) {
-            $output->writeln(sprintf('The account <info>%s</info> is not in the Admin group', $email));
+            $io->error(sprintf(
+                'Account with email %s is not in the Admin group.',
+                $email
+            ));
 
             return 1;
         }
@@ -56,7 +71,9 @@ EOF
         $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
         $user->removeGroup($adminGroup);
 
-        $output->writeln(sprintf('  Removed <info>%s</info> from the Admin group', $email));
-        $output->writeln('Done!');
+        $io->success(sprintf(
+            'Removed account with email %s from the Admin group',
+            $email
+        ));
     }
 }

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -8,6 +8,7 @@ use OpenCFP\Console\BaseCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class AdminPromoteCommand extends BaseCommand
 {
@@ -35,20 +36,34 @@ EOF
 
         $email = $input->getArgument('email');
 
-        $output->writeln(sprintf('Retrieving account from <info>%s</info>...', $email));
+        $io = new SymfonyStyle(
+            $input,
+            $output
+        );
+
+        $io->title('OpenCFP');
+
+        $io->section(sprintf(
+            'Promoting account with email %s to Admin',
+            $email
+        ));
 
         try {
             $user = $sentry->getUserProvider()->findByLogin($email);
         } catch (UserNotFoundException $e) {
-            $output->writeln(sprintf('<error>Error:</error> Could not find user by %s', $email));
+            $io->error(sprintf(
+                'Could not find account with email %s.',
+                $email
+            ));
 
             return 1;
         }
 
-        $output->writeln('  Found account...');
-
         if ($user->hasAccess('admin')) {
-            $output->writeln(sprintf('The account <info>%s</info> already has Admin access', $email));
+            $io->error(sprintf(
+                'Account with email %s already is in the Admin group.',
+                $email
+            ));
 
             return 1;
         }
@@ -56,7 +71,9 @@ EOF
         $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
         $user->addGroup($adminGroup);
 
-        $output->writeln(sprintf('  Added <info>%s</info> to the Admin group', $email));
-        $output->writeln('Done!');
+        $io->success(sprintf(
+            'Added account with email %s to the Admin group',
+            $email
+        ));
     }
 }

--- a/classes/Console/Command/ClearCacheCommand.php
+++ b/classes/Console/Command/ClearCacheCommand.php
@@ -5,6 +5,7 @@ namespace OpenCFP\Console\Command;
 use OpenCFP\Console\BaseCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ClearCacheCommand extends BaseCommand
 {
@@ -17,18 +18,29 @@ class ClearCacheCommand extends BaseCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln('Clearing all caches...');
+        $io = new SymfonyStyle(
+            $input,
+            $output
+        );
+
+        $io->title('OpenCFP');
+
+        $io->section('Clearing caches');
 
         $paths = [
             $this->app->cachePurifierPath(),
             $this->app->cacheTwigPath(),
         ];
 
-        array_walk($paths, function ($path) use ($output) {
-            $output->writeln(sprintf('  <info>✓</info> %s', $path));
+        array_walk($paths, function ($path) use ($io) {
             passthru(sprintf('rm -rf %s/*', $path));
+
+            $io->writeln(sprintf(
+                '  * %s',
+                $path
+            ));
         });
 
-        $output->writeln('Done!');
+        $io->success('Cleared caches.');
     }
 }


### PR DESCRIPTION
This PR

* [x] uses `SymfonyStyle` to streamline the console application output

Follows #380.