### PR TITLE
Fix 398

### DIFF
--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -160,7 +160,9 @@ class SpeakersController extends BaseController
         $mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker = $mapper->get($req->get('id'));
 
-        $spot->config()->connection()->beginTransaction();
+        $connection = $spot->config()->connection();
+
+        $connection->beginTransaction();
 
         try {
             $this->removeSpeakerTalks($speaker);
@@ -170,14 +172,14 @@ class SpeakersController extends BaseController
         }
 
         if ($response === false) {
-            $spot->config()->connection()->rollBack();
+            $connection->rollBack();
 
             $ext = "Unable to delete the requested user";
             $type = 'error';
             $short = 'Error';
         } else {
-            $spot->config()->connection()->commit();
-            
+            $connection->commit();
+
             $ext = "Successfully deleted the requested user";
             $type = 'success';
             $short = 'Success';

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -160,9 +160,16 @@ class SpeakersController extends BaseController
         $mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $speaker = $mapper->get($req->get('id'));
 
-        $this->removeSpeakerTalks($speaker);
+        $spot->config()->connection()->beginTransaction();
 
-        $response = $mapper->delete($speaker);
+        try {
+            $this->removeSpeakerTalks($speaker);
+            $response = $mapper->delete($speaker);
+        } catch (\Exception $e) {
+            $spot->config()->connection()->rollBack();
+        }
+
+        $spot->config()->connection()->commit();
 
         $ext = "Successfully deleted the requested user";
         $type = 'success';

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -168,6 +168,7 @@ class SpeakersController extends BaseController
             $spot->config()->connection()->commit();
         } catch (\Exception $e) {
             $spot->config()->connection()->rollBack();
+            $response = false;
         }
 
         $ext = "Successfully deleted the requested user";

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -165,11 +165,10 @@ class SpeakersController extends BaseController
         try {
             $this->removeSpeakerTalks($speaker);
             $response = $mapper->delete($speaker);
+            $spot->config()->connection()->commit();
         } catch (\Exception $e) {
             $spot->config()->connection()->rollBack();
         }
-
-        $spot->config()->connection()->commit();
 
         $ext = "Successfully deleted the requested user";
         $type = 'success';

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -165,20 +165,22 @@ class SpeakersController extends BaseController
         try {
             $this->removeSpeakerTalks($speaker);
             $response = $mapper->delete($speaker);
-            $spot->config()->connection()->commit();
         } catch (\Exception $e) {
-            $spot->config()->connection()->rollBack();
             $response = false;
         }
 
-        $ext = "Successfully deleted the requested user";
-        $type = 'success';
-        $short = 'Success';
-
         if ($response === false) {
+            $spot->config()->connection()->rollBack();
+
             $ext = "Unable to delete the requested user";
             $type = 'error';
             $short = 'Error';
+        } else {
+            $spot->config()->connection()->commit();
+            
+            $ext = "Successfully deleted the requested user";
+            $type = 'success';
+            $short = 'Success';
         }
 
         // Set flash message

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -137,6 +137,10 @@ class SpeakersControllerTest extends \PHPUnit_Framework_TestCase
         $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\TalkComment::class)->andReturn($talkCommentsMapper);
         $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\TalkMeta::class)->andReturn($talkMetaMapper);
 
+        // All of this stuff should be done in a transaction
+        $spot->shouldReceive('config->connection->beginTransaction')->once();
+        $spot->shouldReceive('config->connection->commit')->once();
+        
         $this->app['spot'] = $spot;
 
         // Execute the controller and capture the output

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -83,7 +83,6 @@ class SpeakersControllerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @group wip
      */
     public function speaker_talks_comments_and_meta_should_be_removed_when_speaker_is_deleted()
     {

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -5,6 +5,8 @@ namespace OpenCFP\Test\Http\Controller\Admin;
 use Mockery as m;
 use OpenCFP\Application;
 use OpenCFP\Environment;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 
@@ -77,5 +79,75 @@ class SpeakersControllerTest extends \PHPUnit_Framework_TestCase
             'Could not find requested speaker',
             $this->app['session']->get('flash')
         );
+    }
+
+    /**
+     * @test
+     * @group wip
+     */
+    public function speaker_talks_comments_and_meta_should_be_removed_when_speaker_is_deleted()
+    {
+        $spot = m::mock(\Spot\Locator::class);
+        $speaker = m::mock(\OpenCFP\Domain\Entity\User::class);
+        $talk = m::mock(\OpenCFP\Domain\Entity\Talk::class);
+        $userMapper = m::mock(\Spot\Mapper::class);
+        $talkMapper = m::mock(\Spot\Mapper::class);
+        $talkCommentsMapper = m::mock(\Spot\Mapper::class);
+        $talkMetaMapper = m::mock(\Spot\Mapper::class);
+
+        // Create a session object
+        $this->app['session'] = new Session(new MockFileSessionStorage);
+
+        // Use our pre-configured Application object
+        ob_start();
+        $this->app->run();
+        ob_end_clean();
+
+        // We're deleting speaker numero uno
+        $request = m::mock(Request::class);
+        $request->shouldReceive('get')->with('id')->atLeast()->once()->andReturn(1);
+
+        // We get the speaker from mapper
+        $userMapper->shouldReceive('get')->with(1)->once()->andReturn($speaker);
+
+        // Speaker is handed off to `removeSpeakerTalks`
+        // and we get all their talks in a collection
+        // Note: this is the `talks` relation, but under the hood
+        //       Spot actually calls the relation method on entity
+        $speaker->shouldReceive('relation->execute')->once()->andReturn([$talk]);
+
+        // That talk also has comments and meta information
+        // Note: these actually return entities for comment and meta
+        //       but in the interest of brevity are faked as strings
+        $talk->shouldReceive('relation->execute')->times(2)->andReturn(['comment'], ['meta']);
+
+        // We loop over each of those and delete them using mapper
+        $talkCommentsMapper->shouldReceive('delete')->once()->with('comment');
+        $talkMetaMapper->shouldReceive('delete')->once()->with('meta');
+
+        // Finally, we delete the talk itself
+        $talkMapper->shouldReceive('delete')->once()->with($talk);
+
+        // Once all those pesky talks are gone, we remove the speaker!
+        $userMapper->shouldReceive('delete')->once()->with($speaker);
+
+        // So lets wire all this into spot locator and replace
+        // into the application instance
+        $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\User::class)->andReturn($userMapper);
+        $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\Talk::class)->andReturn($talkMapper);
+        $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\TalkComment::class)->andReturn($talkCommentsMapper);
+        $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\TalkMeta::class)->andReturn($talkMetaMapper);
+
+        $this->app['spot'] = $spot;
+
+        // Execute the controller and capture the output
+        $controller = new \OpenCFP\Http\Controller\Admin\SpeakersController();
+        $controller->setApplication($this->app);
+        $response = $controller->deleteAction($request);
+
+        // Assert mock expectations.
+        m::close();
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
     }
 }


### PR DESCRIPTION
This PR resolves the issue reported in #398. 

There may be better ways of doing this (a migration that sets up foreign key relations to automatically cascade deletes when a talk is removed), but this seems to get the job done. I need someone to double-check the work for readability as the test is kinda gnarly with the amount of arranging we have to do.
