### PR TITLE
Move globals registration to not fight with exception handler

### DIFF
--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -25,9 +25,6 @@ class WebGatewayProvider implements ServiceProviderInterface
             /* @var Twig_Environment $twig */
             $twig = $app['twig'];
 
-            $twig->addGlobal('current_page', $request->getRequestUri());
-            $twig->addGlobal('cfp_open', strtotime('now') < strtotime($app->config('application.enddate') . ' 11:59 PM'));
-
             if ($app['sentry']->check()) {
                 $twig->addGlobal('user', $app['sentry']->getUser());
                 $twig->addGlobal('user_is_admin', $app['sentry']->getUser()->hasAccess('admin'));

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -29,6 +29,11 @@ class TwigServiceProvider implements ServiceProviderInterface
         /* @var Twig_Environment $twig */
         $twig = $app['twig'];
 
+        $twig->addGlobal('current_page', function() use ($app) {
+            return $app['request']->getRequestUri();
+        });
+        $twig->addGlobal('cfp_open', strtotime('now') < strtotime($app->config('application.enddate') . ' 11:59 PM'));
+
         if (!$app->isProduction()) {
             $twig->addExtension(new Twig_Extension_Debug);
         }

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -29,7 +29,7 @@ class TwigServiceProvider implements ServiceProviderInterface
         /* @var Twig_Environment $twig */
         $twig = $app['twig'];
 
-        $twig->addGlobal('current_page', function() use ($app) {
+        $twig->addGlobal('current_page', function () use ($app) {
             return $app['request']->getRequestUri();
         });
         $twig->addGlobal('cfp_open', strtotime('now') < strtotime($app->config('application.enddate') . ' 11:59 PM'));


### PR DESCRIPTION
This PR resolves an unreported error when requesting a page that does not exist. I noticed this messing around with the Sunshine PHP CFP site. There are two Twig globals registered in a before handler: `cfp_open` and `current_page`. When an exception happens in the routing layer, it looks like before middlware are not executed. This causes Twig to throw an exception when attempting to render the 404 page because neither of these globals are registered.

I moved them outside the before handler into the `TwigServiceProvider`. Additionally, I had to lazy-load the `current_page` value because `Request` is not available outside a web request in Silex. This way, we can register the global and it resolves at runtime in the correct context.

Before:

![image](https://cloud.githubusercontent.com/assets/2453394/17788586/68a06c7c-655c-11e6-95ed-0c5e1fcfbdaa.png)

After:

![image](https://cloud.githubusercontent.com/assets/2453394/17788599/740fa528-655c-11e6-9db3-d4b54ea827a5.png)
