### PR TITLE
Update default order by for review

### DIFF
--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -159,7 +159,7 @@ class Talk extends Mapper
         $options = $this->getSortOptions(
             $options,
             [
-                'order_by' => 'rating',
+                'order_by' => 'review_count',
                 'sort' => 'DESC',
             ]
         );

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -159,23 +159,17 @@ class Talk extends Mapper
         $options = $this->getSortOptions(
             $options,
             [
-                'order_by' => 'review_count',
+                'order_by' => 'total_rating',
                 'sort' => 'DESC',
             ]
         );
-
-        $additionalOrderBy = '';
-        if ($options['order_by'] !== 'total_rating') {
-            $additionalOrderBy = ", total_rating DESC";
-        }
 
         $talks = $this->query(
             "SELECT t.*, SUM(m.rating) AS total_rating, COUNT(m.rating) as review_count FROM talks t "
             . "LEFT JOIN talk_meta m ON t.id = m.talk_id "
             . "WHERE rating > 0 "
             . "GROUP BY m.`talk_id` "
-            . "ORDER BY {$options['order_by']} {$options['sort']}"
-            . $additionalOrderBy,
+            . "ORDER BY {$options['order_by']} {$options['sort']}",
             ['user_id' => $admin_user_id]
         );
 

--- a/migrations/20150702132854_fix_defaults_for_users_table.php
+++ b/migrations/20150702132854_fix_defaults_for_users_table.php
@@ -21,14 +21,14 @@ class FixDefaultsForUsersTable extends AbstractMigration
         $users->changeColumn('permissions', 'text', ['null' => true]);
         $users->changeColumn('activated', 'boolean', ['default' => 0]);
         $users->changeColumn('activation_code', 'string', ['null' => true]);
-        $users->changeColumn('activated_at', 'datetime', ['null' => true, 'default' => '0000-00-00 00:00:00']);
-        $users->changeColumn('last_login', 'datetime', ['null' => true, 'default' => '0000-00-00 00:00:00']);
+        $users->changeColumn('activated_at', 'datetime', ['null' => true, 'default' => '1970-01-01 00:00:00']);
+        $users->changeColumn('last_login', 'datetime', ['null' => true, 'default' => '1970-01-01 00:00:00']);
         $users->changeColumn('persist_code', 'string', ['null' => true]);
         $users->changeColumn('reset_password_code', 'string', ['null' => true]);
         $users->changeColumn('first_name', 'string', ['null' => true]);
         $users->changeColumn('last_name', 'string', ['null' => true]);
-        $users->changeColumn('created_at', 'datetime', ['default' => '0000-00-00 00:00:00']);
-        $users->changeColumn('updated_at', 'datetime', ['default' => '0000-00-00 00:00:00']);
+        $users->changeColumn('created_at', 'datetime', ['default' => '1970-01-01 00:00:00']);
+        $users->changeColumn('updated_at', 'datetime', ['default' => '1970-01-01 00:00:00']);
 
         // Custom fields
         $users->changeColumn('company', 'string', ['null' => true]);


### PR DESCRIPTION
In the TopRatedByUserId query, the default order_by was set to rating, but the column was named review_count.


Fixes #407 

(migrations updated as a result of merging upstream into my branch)