### PR TITLE
user:create command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ OpenCFP is a PHP-based conference talk submission system.
    * [Using the API](#json-api-usage)
  * [Command-line Utilities](#command-line-utilities)
    * [Admin Group Management](#admin-group-management)
+   * [User Management](#user-management)
    * [Clear Caches](#clear-caches)
    * [Scripts to Rule Them All](#scripts-rule-all)
  * [Testing](#testing)
@@ -120,7 +121,7 @@ ways to do that with common shells assuming we're using `production`:
 * zsh:  `export CFP_ENV = production`
 * fish: `set -x CFP_ENV production`
 
-Again, just use your preferred environment in place of `production` if required. 
+Again, just use your preferred environment in place of `production` if required.
 
 <a name="installing-composer-dependencies" />
 ### Installing Composer Dependencies
@@ -587,6 +588,23 @@ Removing `speaker@opencfp.org` from the admin group:
 
 ```
 $ bin/opencfp admin:demote --env=production speaker@opencfp.org
+```
+
+<a name="user-management" />
+### User Management
+
+Users are needed for you system, and sometimes you want to add users via command line.
+
+Adding a speaker:
+
+```
+$ bin/opencfp user:create --first_name="Speaker" --last_name="Name" --email="speaker@opencfp.org" --password="somePassw0rd!"
+```
+
+Add an admin:
+
+```
+$ bin/opencfp user:create --first_name="Admin" --last_name="Name" --email="admin@opencfp.org" --password="somePassw0rd!" --admin
 ```
 
 <a name="clear-caches" />

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -4,6 +4,7 @@ use OpenCFP\Application as ApplicationContainer;
 use OpenCFP\Console\Command\AdminDemoteCommand;
 use OpenCFP\Console\Command\AdminPromoteCommand;
 use OpenCFP\Console\Command\ClearCacheCommand;
+use OpenCFP\Console\Command\UserCreateCommand;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
@@ -32,6 +33,7 @@ class Application extends ConsoleApplication
             new ListCommand,
             new AdminPromoteCommand,
             new AdminDemoteCommand,
+            new UserCreateCommand,
             new ClearCacheCommand,
         ];
     }

--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace OpenCFP\Console\Command;
+
+use OpenCFP\Console\BaseCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class UserCreateCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('user:create')
+            ->setDefinition([
+                new InputOption('first_name', 'f', InputOption::VALUE_REQUIRED, 'First Name of the user to create', null),
+                new InputOption('last_name', 'l', InputOption::VALUE_REQUIRED, 'Last Name of the user to create', null),
+                new InputOption('email', 'e',  InputOption::VALUE_REQUIRED, 'Email of the user to create', null),
+                new InputOption('password', 'p',  InputOption::VALUE_REQUIRED, 'Password of the user to create', null),
+                new InputOption('admin', 'a', InputOption::VALUE_NONE, 'Promote to administrator', null)
+            ])
+            ->setDescription('Creates a new user');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle(
+            $input,
+            $output
+        );
+
+        $io->title('OpenCFP');
+
+        $io->section('Creating User');
+
+        $user = $this->createUser([
+          'first_name' => $input->getOption('first_name'),
+          'last_name' => $input->getOption('last_name'),
+          'password' => $input->getOption('password'),
+          'email' => $input->getOption('email'),
+        ]);
+
+        if (false === $user) {
+          $io->error('User Already Exists!');
+          return 1;
+        }
+
+        $io->block('Account was created');
+
+        if ($input->getOption('admin')) {
+          $io->block('Promoting to admin.');
+          $this->promote($user);
+        }
+
+        $io->success('User Created!');
+    }
+
+    private function createUser($data)
+    {
+      try {
+          $user_data = [
+              'first_name' => $data['first_name'],
+              'last_name' => $data['last_name'],
+              'email' => $data['email'],
+              'password' => $data['password'],
+              'activated' => 1,
+          ];
+
+          /* @var Sentry $sentry */
+          $sentry = $this->app['sentry'];
+
+          $user = $sentry->getUserProvider()->create($user_data);
+
+
+          return $user;
+
+      } catch (UserExistsException $e) {
+          return false;
+      }
+    }
+
+    private function promote($user)
+    {
+      if ($user->hasAccess('admin')) {
+          $io->error(sprintf(
+              'Account with email %s already is in the Admin group.',
+              $email
+          ));
+
+          return false;
+      }
+
+      $sentry = $this->app['sentry'];
+      $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
+      $user->addGroup($adminGroup);
+
+      return true;
+    }
+}

--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -3,9 +3,8 @@
 namespace OpenCFP\Console\Command;
 
 use OpenCFP\Console\BaseCommand;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -20,7 +19,7 @@ class UserCreateCommand extends BaseCommand
                 new InputOption('last_name', 'l', InputOption::VALUE_REQUIRED, 'Last Name of the user to create', null),
                 new InputOption('email', 'e',  InputOption::VALUE_REQUIRED, 'Email of the user to create', null),
                 new InputOption('password', 'p',  InputOption::VALUE_REQUIRED, 'Password of the user to create', null),
-                new InputOption('admin', 'a', InputOption::VALUE_NONE, 'Promote to administrator', null)
+                new InputOption('admin', 'a', InputOption::VALUE_NONE, 'Promote to administrator', null),
             ])
             ->setDescription('Creates a new user');
     }
@@ -44,15 +43,15 @@ class UserCreateCommand extends BaseCommand
         ]);
 
         if (false === $user) {
-          $io->error('User Already Exists!');
-          return 1;
+            $io->error('User Already Exists!');
+            return 1;
         }
 
         $io->block('Account was created');
 
         if ($input->getOption('admin')) {
-          $io->block('Promoting to admin.');
-          $this->promote($user);
+            $io->block('Promoting to admin.');
+            $this->promote($user);
         }
 
         $io->success('User Created!');
@@ -60,8 +59,8 @@ class UserCreateCommand extends BaseCommand
 
     private function createUser($data)
     {
-      try {
-          $user_data = [
+        try {
+            $user_data = [
               'first_name' => $data['first_name'],
               'last_name' => $data['last_name'],
               'email' => $data['email'],
@@ -72,31 +71,30 @@ class UserCreateCommand extends BaseCommand
           /* @var Sentry $sentry */
           $sentry = $this->app['sentry'];
 
-          $user = $sentry->getUserProvider()->create($user_data);
+            $user = $sentry->getUserProvider()->create($user_data);
 
 
-          return $user;
-
-      } catch (UserExistsException $e) {
-          return false;
-      }
+            return $user;
+        } catch (UserExistsException $e) {
+            return false;
+        }
     }
 
     private function promote($user)
     {
-      if ($user->hasAccess('admin')) {
-          $io->error(sprintf(
+        if ($user->hasAccess('admin')) {
+            $io->error(sprintf(
               'Account with email %s already is in the Admin group.',
               $email
           ));
 
-          return false;
-      }
+            return false;
+        }
 
-      $sentry = $this->app['sentry'];
-      $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
-      $user->addGroup($adminGroup);
+        $sentry = $this->app['sentry'];
+        $adminGroup = $sentry->getGroupProvider()->findByName('Admin');
+        $user->addGroup($adminGroup);
 
-      return true;
+        return true;
     }
 }

--- a/migrations/20150702132854_fix_defaults_for_users_table.php
+++ b/migrations/20150702132854_fix_defaults_for_users_table.php
@@ -21,14 +21,14 @@ class FixDefaultsForUsersTable extends AbstractMigration
         $users->changeColumn('permissions', 'text', ['null' => true]);
         $users->changeColumn('activated', 'boolean', ['default' => 0]);
         $users->changeColumn('activation_code', 'string', ['null' => true]);
-        $users->changeColumn('activated_at', 'datetime', ['null' => true, 'default' => '0000-00-00 00:00:00']);
-        $users->changeColumn('last_login', 'datetime', ['null' => true, 'default' => '0000-00-00 00:00:00']);
+        $users->changeColumn('activated_at', 'datetime', ['null' => true, 'default' => '1970-01-01 00:00:00']);
+        $users->changeColumn('last_login', 'datetime', ['null' => true, 'default' => '1970-01-01 00:00:00']);
         $users->changeColumn('persist_code', 'string', ['null' => true]);
         $users->changeColumn('reset_password_code', 'string', ['null' => true]);
         $users->changeColumn('first_name', 'string', ['null' => true]);
         $users->changeColumn('last_name', 'string', ['null' => true]);
-        $users->changeColumn('created_at', 'datetime', ['default' => '0000-00-00 00:00:00']);
-        $users->changeColumn('updated_at', 'datetime', ['default' => '0000-00-00 00:00:00']);
+        $users->changeColumn('created_at', 'datetime', ['default' => '1970-01-01 00:00:00']);
+        $users->changeColumn('updated_at', 'datetime', ['default' => '1970-01-01 00:00:00']);
 
         // Custom fields
         $users->changeColumn('company', 'string', ['null' => true]);

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -56,6 +56,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
             Console\Command\ListCommand::class,
             Command\AdminDemoteCommand::class,
             Command\AdminPromoteCommand::class,
+            Command\UserCreateCommand::class,
             Command\ClearCacheCommand::class,
         ];
 


### PR DESCRIPTION
Add ability to create a user from the command line.  It also has a flag to auto promote to admin.

bin/opencfp user:create --first_name=Brian --last_name=Retterer --email="bretterer@gmail.com" --password="123456abcdef" --admin

Fixes #274
