### PR TITLE
Fixes #391

### DIFF
--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -167,8 +167,8 @@ class Talk extends Mapper
         $talks = $this->query(
             "SELECT t.*, SUM(m.rating) AS total_rating, COUNT(m.rating) as review_count FROM talks t "
             . "LEFT JOIN talk_meta m ON t.id = m.talk_id "
-            . "WHERE rating > 0 "
             . "GROUP BY m.`talk_id` "
+            . "HAVING total_rating > 0 "
             . "ORDER BY {$options['order_by']} {$options['sort']}",
             ['user_id' => $admin_user_id]
         );

--- a/templates/layouts/admin.twig
+++ b/templates/layouts/admin.twig
@@ -50,7 +50,7 @@
                 <li><a href="{{ url('admin_speakers') }}"><img data-src="/assets/img/icons/people.svg" alt="Speakers" class="svg-inject nav-icon icon-12"> Speakers</a></li>
                 <li><a href="{{ url('admin_admins') }}"><img data-src="/assets/img/icons/people.svg" alt="Admins" class="svg-inject nav-icon icon-12"> Admins</a></li>
                 <li><a href="{{ url('admin_talks') }}"><img data-src="/assets/img/icons/microphone.svg" alt="Talks" class="svg-inject nav-icon icon-12"> Talks</a></li>
-                <li><a href="{{ url('admin_reviews') }}"><img data-src="/assets/img/icons/review.svg" alt="Review Talks" class="svg-inject nav-icon icon-12"> Review Talks</a></li>
+                <li><a href="{{ url('admin_reviews') }}"><img data-src="/assets/img/icons/review.svg" alt="Review Talks" class="svg-inject nav-icon icon-12"> Top Rated Talks</a></li>
 
                 <li>
                     <a href=""><img data-src="/assets/img/icons/download.svg" alt="Export Talks List" class="svg-inject nav-icon icon-12"> Export</a>


### PR DESCRIPTION
This PR

* [x] Changes the review menu item name to Top rated talks (to match page heading and function)
* [x] Includes all ratings in total, not just positive ones.

Previous behaviour only listed out positive votes on a talk; showing the total vote count as equal to the rating. This could lead to erroneous results. The new behaviour only filters our talks after the rating has been totalled, so that negative votes affect the result and ratings count as well.

Fixes #391.

