### PR TITLE
Fix arrival and departures displayed dates in the header

### DIFF
--- a/templates/_header.twig
+++ b/templates/_header.twig
@@ -32,7 +32,7 @@
         <div class="row">
             {% if site.event_location is defined and site.date_format is defined %}
             <div class="col-md-8"><h3 class="headline headline--alpha">
-                {{ site.title }} is  on {{ site.arrival|date(site.date_format) }} to {{ site.departure|date(site.date_format) }} in {{ site.event_location }}
+                {{ site.title }} is  on {{ site.arrival|date(site.date_format, false) }} to {{ site.departure|date(site.date_format, false) }} in {{ site.event_location }}
             </h3></div>
             {%  else %}
                 <div class="col-md-8"><h3 class="headline headline--alpha">For More Information About The Conference</h3></div>


### PR DESCRIPTION
This PR resolves the issue #426 

If the date is already a DateTime object, and if you want to keep its current timezone, pass false as the timezone value : http://twig.sensiolabs.org/doc/filters/date.html#timezone

