### PR TITLE
Not Rated Talks Query is Incorrect

### DIFF
--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -303,8 +303,8 @@ class Talk extends Mapper
 
         $talks = $this->query(
             "SELECT t.* FROM talks t "
-            . "LEFT JOIN talk_meta m ON t.id = m.talk_id "
-            . "WHERE (m.rating = 0 AND m.admin_user_id = :user_id) OR m.rating IS NULL "
+            . "LEFT JOIN talk_meta m ON (t.id = m.talk_id AND m.admin_user_id = :user_id)"
+            . "WHERE m.rating = 0 OR m.rating IS NULL "
             . "ORDER BY {$options['order_by']} {$options['sort']}",
             ['user_id' => $admin_user_id]
         );


### PR DESCRIPTION
The not rated talks attempts to create a left join but in the where
statement attempts to look at the admin user id.  Unfortunately, this
will cause any talks that are not yet in talk_meta with the admin user
id to not be found.

The proper join query includes the admin user id as that is what you are
attempting to key off of rather than in the where portion of the query.
This will resolve where the talk does not yet exist in talk_meta and
will provide not yet rated talks properly in the admin area.