### PR TITLE
Fix: Keep require and require-dev sections close to each other

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,15 @@
         "ircmaxell/random-lib": "^1.1",
         "monolog/monolog": "^1.17"
     },
+    "require-dev": {
+        "codeclimate/php-test-reporter": "0.2.0",
+        "fzaninotto/faker": "^1.5.0",
+        "johnkary/phpunit-speedtrap": "~1.0@dev",
+        "mockery/mockery": "1.0.*@dev",
+        "phpunit/dbunit": "1.3.2",
+        "phpunit/phpunit": "^4.8",
+        "friendsofphp/php-cs-fixer": "^2.0.0"
+    },
     "autoload": {
         "psr-4": {
             "OpenCFP\\": "classes/"
@@ -49,14 +58,5 @@
         "psr-4": {
             "OpenCFP\\Test\\": "tests/"
         }
-    },
-    "require-dev": {
-        "codeclimate/php-test-reporter": "0.2.0",
-        "fzaninotto/faker": "^1.5.0",
-        "johnkary/phpunit-speedtrap": "~1.0@dev",
-        "mockery/mockery": "1.0.*@dev",
-        "phpunit/dbunit": "1.3.2",
-        "phpunit/phpunit": "^4.8",
-        "friendsofphp/php-cs-fixer": "^2.0.0"
     }
 }


### PR DESCRIPTION
This PR

* [x] keeps the `require` and `require-dev` sections in `composer.json` close to one another

Not exactly related to #433.