### PR TITLE
Fix: Class should probably be abstract

### DIFF
--- a/classes/Console/BaseCommand.php
+++ b/classes/Console/BaseCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class BaseCommand extends Command
+abstract class BaseCommand extends Command
 {
     /**
      * @var ApplicationContainer


### PR DESCRIPTION
This PR

* [x] turns `BaseCommand` into an `abstract` class