### PR TITLE
Fix: Remove accessor only used in test

### DIFF
--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -37,9 +37,4 @@ class Application extends ConsoleApplication
             new ClearCacheCommand,
         ];
     }
-
-    public function getContainer()
-    {
-        return $this->app;
-    }
 }

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -49,7 +49,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $baseApp = new \OpenCFP\Application(BASE_PATH, Environment::testing());
         $application = new Application($baseApp);
 
-        $this->assertSame($baseApp, $application->getContainer());
+        $this->assertAttributeSame($baseApp, 'app', $application);
     }
 
     public function testHasDefaultCommands()


### PR DESCRIPTION
This PR

* [x] removes an accessor which is only used in a test

Follows #437.