### PR TITLE
Enhancement: Add PHP 7.1 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 matrix:
   fast_finish: true
   include:
+    - php: 7.1
     - php: 7.0
       env: WITH_COVERAGE=true
     - php: 5.6


### PR DESCRIPTION
This PR

* [x] adds PHP 7.1 to the Travis build matrix

💁‍♂️ Maybe also time to move forward and drop PHP 5.5 and PHP 5.6?