### PR TITLE
Remove rating when repeatedly clicking thumbs up/down

### DIFF
--- a/web/assets/js/admin/talk.js
+++ b/web/assets/js/admin/talk.js
@@ -49,18 +49,27 @@ Talk.prototype.rate = function(rating) {
   var url = this.baseUrl + this.id + '/rate';
   var data = { id: this.id, rating: rating };
 
+  if (this.$el.find('i').hasClass('admin-icon--selected')) {
+    data.rating = 0;
+  }
+
   $.ajax({
     type: "POST",
     url: url,
     data: data,
     success: function() {
-      if (rating === -1) {
+      if (data.rating === -1) {
         $('#talk-downvote-' + _this.id + ' i').addClass('admin-icon--selected');
         $('#talk-upvote-' + _this.id + ' i').removeClass('admin-icon--selected');
       }
 
-      if (rating === 1) {
+      if (data.rating === 1) {
         $('#talk-upvote-' + _this.id + ' i').addClass('admin-icon--selected');
+        $('#talk-downvote-' + _this.id + ' i').removeClass('admin-icon--selected');
+      }
+
+      if (data.rating === 0) {
+        $('#talk-upvote-' + _this.id + ' i').removeClass('admin-icon--selected');
         $('#talk-downvote-' + _this.id + ' i').removeClass('admin-icon--selected');
       }
     },


### PR DESCRIPTION
This PR

* [x] If I click thumbs up on an already thumbs-upped talk removes the rating.
* [x] If I click thumbs down on an already thumbs-downed talk removes the rating.

Rationale: for [our event](http://apply.wp-europe.org/) we would like to split scoring the talks – some people only rate development talks, some people only rate development ones, etc. Sometimes, however, we rate the wrong talk, one that we shouldn't have rated at all and being able to remove the rating would be super nice.