### PR TITLE
Fixes double encoding of &, < and >

### DIFF
--- a/classes/Provider/Gateways/RequestCleaner.php
+++ b/classes/Provider/Gateways/RequestCleaner.php
@@ -32,8 +32,11 @@ class RequestCleaner
             if (is_array($value)) {
                 $sanitized[$key] = $this->clean($value);
             } else {
-                $sanitized[$key] = $this->purifier->purify($value);
-                ;
+                $sanitized[$key] = preg_replace(
+                    ['/&amp;/', '/&lt;\b/', '/\b&gt;/'],
+                    ['&', '<', '>'],
+                    $this->purifier->purify($value)
+                );
             }
         }
 


### PR DESCRIPTION
This PR 

- [x] fixes an issue where &, < and > are encoded to ```&amp;```, ```&lt;``` and ```&gt;``` which will be encoded to ```&amp;mp;```, ```&amp;lt;``` and ```&amp;gt;``` resp.

The introduced code revokes the encoding of the three characters after sanitization.

Fixes #444.
