### PR TITLE
Account for possibly missing `photo_path`

### DIFF
--- a/templates/admin/talks/view.twig
+++ b/templates/admin/talks/view.twig
@@ -52,7 +52,7 @@
                 <ul class="comment-list">
                 {% for comment in talk.comments %}
                     <li>
-                        <img src="{{ comment.user.photo_path ? '/uploads/' ~ comment.user.photo_path : '/assets/img/dummyphoto.jpg' }}" class="comment-photo" alt="{{ comment.user.first_name }} {{ comment.user.last_name }}">
+                        <img src="{{ comment.user.get('photo_path') ? '/uploads/' ~ comment.user.photo_path : '/assets/img/dummyphoto.jpg' }}" class="comment-photo" alt="{{ comment.user.first_name }} {{ comment.user.last_name }}">
                         <p>{{ comment.message }}</p>
                         <span class="comment-list__meta">
                             <span class="comment-list__author">{{ comment.user.first_name }} {{ comment.user.last_name }}</span> - {{ comment.created|date("F jS \\a\\t g:ia") }}


### PR DESCRIPTION
If a user doesn’t have a photo we are getting a Twig exception when trying to view their comments below a talk:

```
An exception has been thrown during the rendering of a template
("Method Spot\Relation\BelongsTo::photo_path does not exist")
```

This PR

* [x] Switches to `.get` in the Twig template.