### PR TITLE
fix enddate

### DIFF
--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -35,20 +35,24 @@ class DashboardController extends BaseController
     /**
      * Check to see if the CfP for this app is still open
      *
-     * @param integer $currentTime
+     * @param integer|\DateTimeInterface $currentTime
      *
      * @return boolean
      */
     public function isCfpOpen($currentTime = null)
     {
-        if (!$currentTime) {
-            $currentTime = strtotime('now');
+        if (! $currentTime) {
+            $currentTime = new \Datetime();
         }
 
-        if ($currentTime < strtotime($this->app->config('application.enddate') . ' 11:59 PM')) {
-            return true;
+        if (! $currentTime instanceof \DateTimeInterface) {
+            $currentTime = new \DateTime('@' . $currentTime);
         }
 
-        return false;
+        if ($currentTime > new \DateTime($this->app->config('application.enddate') . ' 11:59 PM')) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -49,7 +49,12 @@ class DashboardController extends BaseController
             $currentTime = new \DateTime('@' . $currentTime);
         }
 
-        if ($currentTime > new \DateTime($this->app->config('application.enddate') . ' 11:59 PM')) {
+        $enddate = new \DateTime($this->app->config('application.enddate'));
+        if ($enddate->format('H:i:s') == '00:00:00') {
+            $enddate->add(new \DateInterval('PT23H59M'));
+        }
+
+        if ($currentTime > $enddate) {
             return false;
         }
 

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -24,7 +24,13 @@ class SignupController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        if (strtotime($this->app->config('application.enddate') . ' 11:59 PM') < strtotime($currentTimeString)) {
+        $current = new \DateTime($currentTimeString);
+        $endDate = new \DateTime($this->app->config('application.enddate'));
+        if ($endDate->format('H:i:s') == '00:00:00') {
+            $endDate->add(new \DateInterval('PT23H59M'));
+        }
+
+        if ($endDate < $current) {
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -20,12 +20,17 @@ class TalkController extends BaseController
     /**
      * Check to see if the CfP for this app is still open
      *
-     * @param  integer $current_time
+     * @param  DateTimeInterface $current_time
      * @return boolean
      */
-    public function isCfpOpen($current_time)
+    public function isCfpOpen(\DateTimeInterface $current_time)
     {
-        if ($current_time < strtotime($this->app->config('application.enddate') . ' 11:59 PM')) {
+        $enddate = new \DateTime($this->app->config('application.enddate'));
+        if ($enddate->format('H:i:s') == '00:00:00') {
+            $enddate->add(new \DateInterval('PT23H59M'));
+        }
+
+        if ($current_time < $enddate) {
             return true;
         }
 
@@ -151,7 +156,7 @@ class TalkController extends BaseController
 
         // You can only edit talks while the CfP is open
         // This will redirect to "view" the talk in a read-only template
-        if (! $this->isCfpOpen(strtotime('now'))) {
+        if (! $this->isCfpOpen(new \DateTimeImmutable('now'))) {
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Read Only',
@@ -218,7 +223,7 @@ class TalkController extends BaseController
         }
 
         // You can only create talks while the CfP is open
-        if (! $this->isCfpOpen(strtotime('now'))) {
+        if (! $this->isCfpOpen(new \DateTimeImmutable('now'))) {
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
@@ -266,7 +271,7 @@ class TalkController extends BaseController
         }
 
         // You can only create talks while the CfP is open
-        if (! $this->isCfpOpen(strtotime('now'))) {
+        if (! $this->isCfpOpen(new \DateTimeImmutable('now'))) {
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
@@ -491,7 +496,7 @@ class TalkController extends BaseController
         }
 
         // You can only delete talks while the CfP is open
-        if (! $this->isCfpOpen(strtotime('now'))) {
+        if (! $this->isCfpOpen(new \DateTimeImmutable('now'))) {
             return $app->json(['delete' => 'no']);
         }
 

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -33,7 +33,12 @@ class TwigServiceProvider implements ServiceProviderInterface
         $twig->addGlobal('current_page', function () use ($app) {
             return $app['request']->getRequestUri();
         });
-        $twig->addGlobal('cfp_open', strtotime('now') < strtotime($app->config('application.enddate') . ' 11:59 PM'));
+
+        $enddate = new \DateTimeImmutable($this->app->config('application.enddate'));
+        if ($enddate->format('H:i:s') == '00:00:00') {
+            $enddate->add(new \DateInterval('PT23H59M'));
+        }
+        $twig->addGlobal('cfp_open', new \DateTimeImmutable('now') < $enddate);
 
         if (!$app->isProduction()) {
             $twig->addExtension(new Twig_Extension_Debug);

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -34,7 +34,7 @@ class TwigServiceProvider implements ServiceProviderInterface
             return $app['request']->getRequestUri();
         });
 
-        $enddate = new \DateTimeImmutable($this->app->config('application.enddate'));
+        $enddate = new \DateTimeImmutable($app->config('application.enddate'));
         if ($enddate->format('H:i:s') == '00:00:00') {
             $enddate->add(new \DateInterval('PT23H59M'));
         }

--- a/composer.lock
+++ b/composer.lock
@@ -1913,25 +1913,28 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04T07:54:35+00:00"
+            "time": "2017-01-02 20:30:24"
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.4",
+            "version": "v2.8.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "5273f4724dc5288fe7a33cb08077ab9852621f2c"
+                "reference": "4537f2413348fe271c2c4b09da219ed615d79f9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/5273f4724dc5288fe7a33cb08077ab9852621f2c",
-                "reference": "5273f4724dc5288fe7a33cb08077ab9852621f2c",
+                "url": "https://api.github.com/repos/symfony/config/zipball/4537f2413348fe271c2c4b09da219ed615d79f9c",
+                "reference": "4537f2413348fe271c2c4b09da219ed615d79f9c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
                 "symfony/filesystem": "~2.3|~3.0.0"
+            },
+            "require-dev": {
+                "symfony/yaml": "~2.7|~3.0.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -1966,24 +1969,25 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04T07:54:35+00:00"
+            "time": "2017-01-02 20:30:24"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.4",
+            "version": "v2.8.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9a5aef5fc0d4eff86853d44202b02be8d5a20154"
+                "reference": "2e18b8903d9c498ba02e1dfa73f64d4894bb6912"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9a5aef5fc0d4eff86853d44202b02be8d5a20154",
-                "reference": "9a5aef5fc0d4eff86853d44202b02be8d5a20154",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2e18b8903d9c498ba02e1dfa73f64d4894bb6912",
+                "reference": "2e18b8903d9c498ba02e1dfa73f64d4894bb6912",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
+                "symfony/debug": "~2.7,>=2.7.2|~3.0.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
@@ -2026,20 +2030,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-17T09:19:04+00:00"
+            "time": "2017-01-08 20:43:03"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.8.4",
+            "version": "v2.8.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "07b7ced3ae0c12918477c095453ea8595000810e"
+                "reference": "f45daea42232d9ca5cf561ec64f0d4aea820877f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/07b7ced3ae0c12918477c095453ea8595000810e",
-                "reference": "07b7ced3ae0c12918477c095453ea8595000810e",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/f45daea42232d9ca5cf561ec64f0d4aea820877f",
+                "reference": "f45daea42232d9ca5cf561ec64f0d4aea820877f",
                 "shasum": ""
             },
             "require": {

--- a/templates/_header.twig
+++ b/templates/_header.twig
@@ -7,7 +7,7 @@
                 <div class="col-md-9">
                     {% if cfp_open %}
                         <h1 class="headline headline-alpha">Call For Papers Now Open!</h1>
-                        <h3 class="headline headline-alpha">Submissions accepted until {{ site.enddate }}</h3>
+                        <h3 class="headline headline-alpha">Submissions accepted until {{ site.enddate | date(site.date_format) }}</h3>
                     {% else %}
                         <h1 class="headline headline-alpha">
                             {% if site.show_submission_count %}

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -174,6 +174,8 @@ class DashboardControllerTest extends \PHPUnit_Framework_TestCase
             [0, $yesterday, false],
             [new \DateTime('2017-12-09'), '2017-12-10', true],
             [new \DateTime('2017-12-11'), '2017-12-10', false],
+            [new \DateTime('2017-12-10T23:58:59'), '2017-12-10', true],
+            [new \DateTime('2017-12-10T23:59:01'), '2017-12-10', false],
         ];
     }
 }

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -176,6 +176,8 @@ class DashboardControllerTest extends \PHPUnit_Framework_TestCase
             [new \DateTime('2017-12-11'), '2017-12-10', false],
             [new \DateTime('2017-12-10T23:58:59'), '2017-12-10', true],
             [new \DateTime('2017-12-10T23:59:01'), '2017-12-10', false],
+            [new \DateTime('2017-12-10T16:59:59'), '2017-12-10T17:00:00', true],
+            [new \DateTime('2017-12-10T17:00:01'), '2017-12-10T17:00:00', false],
         ];
     }
 }


### PR DESCRIPTION
This PR moves calls from ```strtotime``` to ```DateTime```.

Additionally the configuration entry ```enddate``` can now be used to also add a time when the CfP ends. You should then also adapt the ```date_format``` to include the time. When no time is given in the config-value the current behaviour is used to let the CfP run until 23:59 of the given day. 

> Note: The CFP will still end 59 seconds before midnight!

* [x] replace ```strtotime``` with ```DateTime```

Fixes #450.
