### PR TITLE
Update Requirements Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ merge master to your private branch and get updates when desired!
  * PHP 7.0+
  * Apache 2+ with `mod_rewrite` enabled and an `AllowOverride all` directive in your `<Directory>` block is the recommended web server
  * Composer requirements are listed in [composer.json](composer.json).
- * You may need to install `php5-intl` extension for PHP. (`php-intl` on CentOS/RHEL-based distributions)
+ * You may need to install `php7.0-intl` extension for PHP. (`php-intl` on CentOS/RHEL-based distributions)
 
 <a name="installation" />
 ## Installation


### PR DESCRIPTION
Update the requirements section to specify installing the PHP7+ `intl` extension (same version as the minimum requirement for PHP).

`php7.0-intl` is the name of the package in *Debian Testing* and *Ubuntu 16.04+*, I assumed these were the target platforms, please correct me if I'm wrong.