### PR TITLE
Adds a few more unit tests

### DIFF
--- a/classes/Http/Form/Login.php
+++ b/classes/Http/Form/Login.php
@@ -24,14 +24,14 @@ class Login extends AbstractType
                 new Assert\NotBlank(),
             ],
             'required' => true,
-            'attr' => ['placeholder' => 'you@domain.org', 'class' => 'form-control']])
+            'attr' => ['placeholder' => 'you@domain.org', 'class' => 'form-control'], ])
             ->add('password', PasswordType::class, [
                 'label' => 'Password',
                 'constraints' => [
                     new Assert\NotBlank(),
                 ],
                 'attr' => ['class' => 'form-control', 'placeholder' => 'Password'],
-                'required' => true
+                'required' => true,
             ]);
     }
 

--- a/classes/Http/Form/ResetForm.php
+++ b/classes/Http/Form/ResetForm.php
@@ -2,6 +2,9 @@
 namespace OpenCFP\Http\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -9,23 +12,23 @@ class ResetForm extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('password', 'repeated', [
+        $builder->add('password', RepeatedType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
                     new Assert\Length(['min' => 5]), ],
-                'type' => 'password',
+                'type' => PasswordType::class,
                 'first_options' => ['label' => 'Password (minimum 5 characters)'],
                 'second_options' => ['label' => 'Password (confirm)'],
                 'first_name' => 'password',
                 'second_name' => 'password2',
                 'invalid_message' => 'Passwords did not match', ])
-            ->add('user_id', 'hidden')
-            ->add('reset_code', 'hidden')
+            ->add('user_id', HiddenType::class)
+            ->add('reset_code', HiddenType::class)
             ->getForm();
     }
 
     public function getName()
     {
-        return 'reset';
+        return 'reset_form';
     }
 }

--- a/tests/Http/Form/Entity/LoginTest.php
+++ b/tests/Http/Form/Entity/LoginTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace OpenCFP\Test\Http\Form\Entity;
+
+use OpenCFP\Http\Form\Entity\Login as LoginEntity;
+
+class LoginTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var LoginEntity
+     */
+    protected $loginEntity;
+
+    protected function setUp()
+    {
+        $this->loginEntity = new LoginEntity();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * Test that the entity can return an array of its stored values.
+     *
+     * @test
+     */
+    public function canReturnAnArrayOfStoredValues()
+    {
+        $expectedValuesArray = [
+            'email' => 'you@domain.org',
+            'password' => 'test',
+        ];
+
+        $this->loginEntity->setEmail($expectedValuesArray['email']);
+        $this->loginEntity->setPassword($expectedValuesArray['password']);
+
+        $this->assertSame(
+            $expectedValuesArray['email'],
+            $this->loginEntity->getEmail()
+        );
+        $this->assertSame(
+            $expectedValuesArray['password'],
+            $this->loginEntity->getPassword()
+        );
+
+        $this->assertEquals($expectedValuesArray, $this->loginEntity->createArray());
+    }
+}

--- a/tests/Http/Form/Entity/ProfileTest.php
+++ b/tests/Http/Form/Entity/ProfileTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace OpenCFP\Test\Http\Form\Entity;
+
+use OpenCFP\Http\Form\Entity\Profile;
+
+class ProfileTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Profile
+     */
+    protected $profileEntity;
+
+    protected function setUp()
+    {
+        $this->profileEntity = new Profile();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * Test that the entity can store and return all of its values.
+     *
+     * @test
+     */
+    public function canTransformEloquentUser()
+    {
+        $fakeEloquentUser = new \stdClass();
+        $fakeEloquentUser->id = 1;
+        $fakeEloquentUser->email = 'you@domain.org';
+        $fakeEloquentUser->first_name = 'John';
+        $fakeEloquentUser->last_name = 'Doe';
+        $fakeEloquentUser->company = 'ACME';
+        $fakeEloquentUser->twitter = '@twitter';
+        $fakeEloquentUser->airport = 'AAA';
+        $fakeEloquentUser->transportation = true;
+        $fakeEloquentUser->hotel = true;
+        $fakeEloquentUser->bio = 'Who is this guy?';
+        $fakeEloquentUser->info = 'Some info.';
+        $fakeEloquentUser->photo_path = '/tmp/somefolder/image.png';
+
+        $this->profileEntity->transformEloquentUser($fakeEloquentUser);
+
+        $this->assertSame($fakeEloquentUser->id, $this->profileEntity->getId());
+        $this->assertSame($fakeEloquentUser->email, $this->profileEntity->getEmail());
+        $this->assertSame($fakeEloquentUser->first_name, $this->profileEntity->getFirstName());
+        $this->assertSame($fakeEloquentUser->last_name, $this->profileEntity->getLastName());
+        $this->assertSame($fakeEloquentUser->company, $this->profileEntity->getCompany());
+        $this->assertSame($fakeEloquentUser->twitter, $this->profileEntity->getTwitter());
+        $this->assertSame($fakeEloquentUser->airport, $this->profileEntity->getAirport());
+        $this->assertSame($fakeEloquentUser->transportation, $this->profileEntity->getTransportation());
+        $this->assertSame($fakeEloquentUser->hotel, $this->profileEntity->getHotel());
+        $this->assertSame($fakeEloquentUser->bio, $this->profileEntity->getBio());
+        $this->assertSame($fakeEloquentUser->info, $this->profileEntity->getInfo());
+        $this->assertSame($fakeEloquentUser->photo_path, $this->profileEntity->getPhotoPath());
+    }
+}

--- a/tests/Http/Form/Entity/UserTest.php
+++ b/tests/Http/Form/Entity/UserTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace OpenCFP\Test\Http\Form\Entity;
+
+use OpenCFP\Http\Form\Entity\User;
+
+class UserTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var User
+     */
+    protected $userEntity;
+
+    protected function setUp()
+    {
+        $this->userEntity = new User();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * Test that the entity can return an array of its stored values.
+     *
+     * @test
+     */
+    public function canReturnAnArrayOfStoredValues()
+    {
+        $expectedValuesArray = [
+            'email' => 'you@domain.org',
+            'password' => 'test',
+            'permissions' => 'guest',
+            'last_login' => '03-20-2017',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'created_at' => '03-20-2017',
+            'updated_at' => '03-20-2017',
+            'company' => 'ACME',
+            'twitter' => '@twitter',
+            'airport' => 'AAA',
+            'url' => 'http://www.example.com',
+            'transportation' => true,
+            'hotel' => true,
+            'bio' => 'Who is this guy?',
+            'info' => 'Some info.',
+            'photo_path' => '/tmp/somefolder/image.png',
+            'agree_coc' => true,
+            'id' => 1,
+        ];
+
+        $this->userEntity->setEmail($expectedValuesArray['email']);
+        $this->userEntity->setPassword($expectedValuesArray['password']);
+        $this->userEntity->setPermissions($expectedValuesArray['permissions']);
+        $this->userEntity->setLastLogin($expectedValuesArray['last_login']);
+        $this->userEntity->setFirstName($expectedValuesArray['first_name']);
+        $this->userEntity->setLastName($expectedValuesArray['last_name']);
+        $this->userEntity->setCreatedAt($expectedValuesArray['created_at']);
+        $this->userEntity->setUpdatedAt($expectedValuesArray['updated_at']);
+        $this->userEntity->setCompany($expectedValuesArray['company']);
+        $this->userEntity->setTwitter($expectedValuesArray['twitter']);
+        $this->userEntity->setAirport($expectedValuesArray['airport']);
+        $this->userEntity->setUrl($expectedValuesArray['url']);
+        $this->userEntity->setTransportation($expectedValuesArray['transportation']);
+        $this->userEntity->setHotel($expectedValuesArray['hotel']);
+        $this->userEntity->setBio($expectedValuesArray['bio']);
+        $this->userEntity->setInfo($expectedValuesArray['info']);
+        $this->userEntity->setPhotoPath($expectedValuesArray['photo_path']);
+        $this->userEntity->setAgreeCoc($expectedValuesArray['agree_coc']);
+        $this->userEntity->setId($expectedValuesArray['id']);
+
+        $this->assertSame(
+            $expectedValuesArray['email'],
+            $this->userEntity->getEmail()
+        );
+        $this->assertSame(
+            $expectedValuesArray['password'],
+            $this->userEntity->getPassword()
+        );
+        $this->assertSame(
+            $expectedValuesArray['permissions'],
+            $this->userEntity->getPermissions()
+        );
+        $this->assertSame(
+            $expectedValuesArray['last_login'],
+            $this->userEntity->getLastLogin()
+        );
+        $this->assertSame(
+            $expectedValuesArray['first_name'],
+            $this->userEntity->getFirstName()
+        );
+        $this->assertSame(
+            $expectedValuesArray['last_name'],
+            $this->userEntity->getLastName()
+        );
+        $this->assertSame(
+            $expectedValuesArray['created_at'],
+            $this->userEntity->getCreatedAt()
+        );
+        $this->assertSame(
+            $expectedValuesArray['updated_at'],
+            $this->userEntity->getUpdatedAt()
+        );
+        $this->assertSame(
+            $expectedValuesArray['company'],
+            $this->userEntity->getCompany()
+        );
+        $this->assertSame(
+            $expectedValuesArray['twitter'],
+            $this->userEntity->getTwitter()
+        );
+        $this->assertSame(
+            $expectedValuesArray['airport'],
+            $this->userEntity->getAirport()
+        );
+        $this->assertSame(
+            $expectedValuesArray['url'],
+            $this->userEntity->getUrl()
+        );
+        $this->assertSame(
+            $expectedValuesArray['transportation'],
+            $this->userEntity->getTransportation()
+        );
+        $this->assertSame(
+            $expectedValuesArray['hotel'],
+            $this->userEntity->getHotel()
+        );
+        $this->assertSame(
+            $expectedValuesArray['bio'],
+            $this->userEntity->getBio()
+        );
+        $this->assertSame(
+            $expectedValuesArray['info'],
+            $this->userEntity->getInfo()
+        );
+        $this->assertSame(
+            $expectedValuesArray['photo_path'],
+            $this->userEntity->getPhotoPath()
+        );
+        $this->assertSame(
+            $expectedValuesArray['agree_coc'],
+            $this->userEntity->getAgreeCoc()
+        );
+        $this->assertSame(
+            $expectedValuesArray['id'],
+            $this->userEntity->getId()
+        );
+
+        $this->assertEquals($expectedValuesArray, $this->userEntity->createArray());
+    }
+}

--- a/tests/Http/Form/LoginTest.php
+++ b/tests/Http/Form/LoginTest.php
@@ -5,9 +5,7 @@ namespace OpenCFP\Test\Http\Form;
 use Mockery as m;
 use OpenCFP\Http\Form\Entity\Login as LoginEntity;
 use OpenCFP\Http\Form\Login as LoginForm;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
-use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -22,16 +20,6 @@ class LoginTest extends \PHPUnit\Framework\TestCase
     protected $factory;
 
     /**
-     * @var FormBuilder
-     */
-    protected $builder;
-
-    /**
-     * @var EventDispatcher
-     */
-    protected $dispatcher;
-
-    /**
      * @var ValidatorInterface
      */
     private $validator;
@@ -41,8 +29,13 @@ class LoginTest extends \PHPUnit\Framework\TestCase
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())
             ->getFormFactory();
-        $this->dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->builder = new FormBuilder(null, null, $this->dispatcher, $this->factory);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        m::close();
     }
 
     protected function getExtensions()
@@ -60,7 +53,14 @@ class LoginTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    public function testSubmitValidData()
+    /**
+     * Test that form object correctly synchronizes the different
+     * data formats, correctly sets user-submitted data for all
+     * fields on form submission and correctly creates its view.
+     *
+     * @test
+     */
+    public function submitValidData()
     {
         $formData = [
             'email' => 'you@domain.org',
@@ -87,5 +87,19 @@ class LoginTest extends \PHPUnit\Framework\TestCase
         foreach (array_keys($formData) as $key) {
             $this->assertArrayHasKey($key, $children);
         }
+    }
+
+    /**
+     * Test that the form object correctly returns its name.
+     *
+     * @test
+     */
+    public function getFormName()
+    {
+        $form = $this->factory
+            ->createBuilder(LoginForm::class, new LoginEntity())
+            ->getForm();
+
+        $this->assertSame('login', $form->getName());
     }
 }

--- a/tests/Http/Form/ResetFormTest.php
+++ b/tests/Http/Form/ResetFormTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace OpenCFP\Test\Http\Form;
+
+use Mockery as m;
+use OpenCFP\Http\Form\ResetForm;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\Forms;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ResetFormTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $factory;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    protected function setUp()
+    {
+        $this->factory = Forms::createFormFactoryBuilder()
+            ->addExtensions($this->getExtensions())
+            ->getFormFactory();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    protected function getExtensions()
+    {
+        $this->validator = m::mock(ValidatorInterface::class);
+        $this->validator
+            ->shouldReceive('validate')
+            ->andReturn(new ConstraintViolationList());
+        $this->validator
+            ->shouldReceive('getMetadataFor')
+            ->andReturn(new ClassMetadata('Symfony\Component\Form\Form'));
+
+        return [
+            new ValidatorExtension($this->validator),
+        ];
+    }
+
+    /**
+     * Test that form object correctly synchronizes the different
+     * data formats, correctly sets user-submitted data for all
+     * fields on form submission and correctly creates its view.
+     *
+     * @test
+     */
+    public function submitValidData()
+    {
+        $formData = [
+            'password' => [
+                'password' => 'test',
+                'password2' => 'test',
+            ],
+            'user_id' => '42',
+            'reset_code' => '123',
+        ];
+
+        $form = $this->factory
+            ->createBuilder(ResetForm::class)
+            ->getForm();
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        // Repeated password field becomes single field after form submission
+        $formData['password'] = 'test';
+
+        $this->assertTrue($form->isSynchronized());
+
+        $this->assertEquals($formData, $form->getData());
+
+        $view = $form->createView();
+        $children = $view->children;
+
+        foreach (array_keys($formData) as $key) {
+            $this->assertArrayHasKey($key, $children);
+        }
+    }
+
+    /**
+     * Test that the form object correctly returns its name.
+     *
+     * @test
+     */
+    public function getFormName()
+    {
+        $form = $this->factory
+            ->createBuilder(ResetForm::class)
+            ->getForm();
+
+        $this->assertSame('reset_form', $form->getName());
+    }
+}

--- a/tests/Http/Form/TalkFormTest.php
+++ b/tests/Http/Form/TalkFormTest.php
@@ -15,6 +15,11 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $this->purifier = new \HTMLPurifier();
     }
 
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
     /**
      * Test that form object correctly detects if all the required fields
      * are in the user-submitted data


### PR DESCRIPTION
This PR

*  	Completes the Login form tests 
*  	Creates the ResetForm tests and modifies the ResetForm class 
*  	Creates the tests for the OpenCFP/Http/Form/Entity/Login class
*  	Creates the tests for the OpenCFP/Http/Form/Entity/Profile class
*  	Creates the tests for the OpenCFP/Http/Form/Entity/User class
* 	Modifies the TalkForm test class

Follows N/A.
Related to N/A.
Fixes N/A.
