### PR TITLE
Fix: Use null coalescing operator where possible

### DIFF
--- a/classes/Domain/AirportInfo.php
+++ b/classes/Domain/AirportInfo.php
@@ -44,9 +44,9 @@ class AirportInfo
     public static function fromData(array $data)
     {
         return new static(
-            $code = isset($data['code']) ? $data['code'] : null,
-            $name = isset($data['name']) ? $data['name'] : null,
-            $country = isset($data['country']) ? $data['country'] : null
+            $code = $data['code'] ?? null,
+            $name = $data['name'] ?? null,
+            $country = $data['country'] ?? null
         );
     }
 }

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -48,7 +48,7 @@ class Environment
      */
     public static function fromEnvironmentVariable()
     {
-        $environment = isset($_SERVER['CFP_ENV']) ? $_SERVER['CFP_ENV'] : 'development';
+        $environment = $_SERVER['CFP_ENV'] ?? 'development';
 
         return new self($environment);
     }

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -97,7 +97,7 @@ abstract class Form
      */
     public function getTaintedField($name, $default = null)
     {
-        return isset($this->_taintedData[$name]) ? $this->_taintedData[$name] : $default;
+        return $this->_taintedData[$name] ?? $default;
     }
 
     /**
@@ -119,7 +119,7 @@ abstract class Form
      */
     public function getOption($name, $default = null)
     {
-        return isset($this->_options[$name]) ? $this->_options[$name] : $default;
+        return $this->_options[$name] ?? $default;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] uses the null coalescing operator where possible