### PR TITLE
Enhancement: Enable single_quote fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -14,6 +14,7 @@ $config = PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'ordered_imports' => true,
         'psr0' => false,
+        'single_quote' => true,
         'trailing_comma_in_multiline_array' => true,
     ])
     ->setFinder($finder);

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -204,7 +204,7 @@ class Application extends SilexApplication
      */
     public function uploadPath()
     {
-        return $this->basePath() . "/web/uploads";
+        return $this->basePath() . '/web/uploads';
     }
 
     /**
@@ -213,7 +213,7 @@ class Application extends SilexApplication
      */
     public function templatesPath()
     {
-        return $this->basePath() . "/templates";
+        return $this->basePath() . '/templates';
     }
 
     /**
@@ -222,7 +222,7 @@ class Application extends SilexApplication
      */
     public function publicPath()
     {
-        return $this->basePath() . "/web";
+        return $this->basePath() . '/web';
     }
 
     /**
@@ -231,7 +231,7 @@ class Application extends SilexApplication
      */
     public function assetsPath()
     {
-        return $this->basePath() . "/web/assets";
+        return $this->basePath() . '/web/assets';
     }
 
     /**
@@ -240,7 +240,7 @@ class Application extends SilexApplication
      */
     public function cacheTwigPath()
     {
-        return $this->basePath() . "/cache/twig";
+        return $this->basePath() . '/cache/twig';
     }
 
     /**
@@ -249,7 +249,7 @@ class Application extends SilexApplication
      */
     public function cachePurifierPath()
     {
-        return $this->basePath() . "/cache/htmlpurifier";
+        return $this->basePath() . '/cache/htmlpurifier';
     }
 
     /**

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -130,9 +130,9 @@ class Talk extends Mapper
         );
 
         $talks = $this->query(
-            "SELECT t.* FROM talks t "
-            . "LEFT JOIN favorites f ON t.id = f.talk_id "
-            . "WHERE f.admin_user_id = :user_id "
+            'SELECT t.* FROM talks t '
+            . 'LEFT JOIN favorites f ON t.id = f.talk_id '
+            . 'WHERE f.admin_user_id = :user_id '
             . "ORDER BY {$options['order_by']} {$options['sort']}",
             ['user_id' => $admin_user_id]
         );
@@ -165,10 +165,10 @@ class Talk extends Mapper
         );
 
         $talks = $this->query(
-            "SELECT t.*, SUM(m.rating) AS total_rating, COUNT(m.rating) as review_count FROM talks t "
-            . "LEFT JOIN talk_meta m ON t.id = m.talk_id "
-            . "GROUP BY m.`talk_id` "
-            . "HAVING total_rating > 0 "
+            'SELECT t.*, SUM(m.rating) AS total_rating, COUNT(m.rating) as review_count FROM talks t '
+            . 'LEFT JOIN talk_meta m ON t.id = m.talk_id '
+            . 'GROUP BY m.`talk_id` '
+            . 'HAVING total_rating > 0 '
             . "ORDER BY {$options['order_by']} {$options['sort']}",
             ['user_id' => $admin_user_id]
         );
@@ -200,9 +200,9 @@ class Talk extends Mapper
         );
 
         $talks = $this->query(
-            "SELECT t.* FROM talks t "
-            . "LEFT JOIN talk_meta m ON t.id = m.talk_id "
-            . "WHERE (m.viewed = 0 AND m.admin_user_id = :user_id) OR m.viewed IS NULL "
+            'SELECT t.* FROM talks t '
+            . 'LEFT JOIN talk_meta m ON t.id = m.talk_id '
+            . 'WHERE (m.viewed = 0 AND m.admin_user_id = :user_id) OR m.viewed IS NULL '
             . "ORDER BY {$options['order_by']} {$options['sort']}",
             ['user_id' => $admin_user_id]
         );
@@ -234,9 +234,9 @@ class Talk extends Mapper
         );
 
         $talks = $this->query(
-            "SELECT t.* FROM talks t "
-            . "RIGHT JOIN talk_meta m ON t.id = m.talk_id "
-            . "WHERE m.admin_user_id = :user_id AND m.viewed = 1 "
+            'SELECT t.* FROM talks t '
+            . 'RIGHT JOIN talk_meta m ON t.id = m.talk_id '
+            . 'WHERE m.admin_user_id = :user_id AND m.viewed = 1 '
             . "ORDER BY {$options['order_by']} {$options['sort']}",
             ['user_id' => $admin_user_id]
         );
@@ -268,9 +268,9 @@ class Talk extends Mapper
         );
 
         $talks = $this->query(
-            "SELECT t.* FROM talks t "
-            . "RIGHT JOIN talk_meta m ON t.id = m.talk_id "
-            . "WHERE m.admin_user_id = :user_id AND (m.rating = 1 OR m.rating = -1) "
+            'SELECT t.* FROM talks t '
+            . 'RIGHT JOIN talk_meta m ON t.id = m.talk_id '
+            . 'WHERE m.admin_user_id = :user_id AND (m.rating = 1 OR m.rating = -1) '
             . "ORDER BY {$options['order_by']} {$options['sort']}",
             ['user_id' => $admin_user_id]
         );
@@ -302,9 +302,9 @@ class Talk extends Mapper
         );
 
         $talks = $this->query(
-            "SELECT t.* FROM talks t "
-            . "LEFT JOIN talk_meta m ON (t.id = m.talk_id AND m.admin_user_id = :user_id)"
-            . "WHERE m.rating = 0 OR m.rating IS NULL "
+            'SELECT t.* FROM talks t '
+            . 'LEFT JOIN talk_meta m ON (t.id = m.talk_id AND m.admin_user_id = :user_id)'
+            . 'WHERE m.rating = 0 OR m.rating IS NULL '
             . "ORDER BY {$options['order_by']} {$options['sort']}",
             ['user_id' => $admin_user_id]
         );

--- a/classes/Domain/Entity/User.php
+++ b/classes/Domain/Entity/User.php
@@ -65,7 +65,7 @@ class User extends Entity
         $json = $permissions;
 
         if (is_string($permissions) && json_decode($permissions) === null) {
-            return "{}";
+            return '{}';
         }
 
         if (is_array($permissions)) {

--- a/classes/Domain/Services/Login.php
+++ b/classes/Domain/Services/Login.php
@@ -35,7 +35,7 @@ class Login
     public function authenticate($user, $password)
     {
         if (empty($user) || empty($password)) {
-            $this->authenticationMessage = "Missing Email or Password";
+            $this->authenticationMessage = 'Missing Email or Password';
 
             return false;
         }
@@ -49,7 +49,7 @@ class Login
                 false
             );
         } catch (UserNotFoundException $e) {
-            $this->authenticationMessage = "Invalid Email or Password";
+            $this->authenticationMessage = 'Invalid Email or Password';
 
             return false;
         } catch (UserNotActivatedException $e) {

--- a/classes/Http/API/ApiController.php
+++ b/classes/Http/API/ApiController.php
@@ -102,7 +102,7 @@ class ApiController
     {
         if ($this->statusCode === Response::HTTP_OK) {
             trigger_error(
-                "You need to stellar reason to error with a 200 HTTP status code, Mr. Spock.",
+                'You need to stellar reason to error with a 200 HTTP status code, Mr. Spock.',
                 E_USER_WARNING
             );
         }

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -65,7 +65,7 @@ class ExportsController extends BaseController
 
     private function talksExportAction($attributed, $where = null)
     {
-        $sort = [ "created_at" => "DESC" ];
+        $sort = [ 'created_at' => 'DESC' ];
 
         /* @var Sentry $sentry */
         $sentry = $this->service('sentry');

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -121,7 +121,7 @@ class SpeakersController extends BaseController
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "Could not find requested speaker",
+                'ext' => 'Could not find requested speaker',
             ]);
 
             return $this->app->redirect($this->url('admin_speakers'));
@@ -189,13 +189,13 @@ class SpeakersController extends BaseController
         if ($response === false) {
             $connection->rollBack();
 
-            $ext = "Unable to delete the requested user";
+            $ext = 'Unable to delete the requested user';
             $type = 'error';
             $short = 'Error';
         } else {
             $connection->commit();
 
-            $ext = "Successfully deleted the requested user";
+            $ext = 'Successfully deleted the requested user';
             $type = 'success';
             $short = 'Success';
         }

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -86,27 +86,27 @@ class TalksController extends BaseController
         }
 
         switch (strtolower($filter)) {
-            case "selected":
+            case 'selected':
                 return $talk_mapper->getSelected($admin_user_id, $options);
                 break;
 
-            case "notviewed":
+            case 'notviewed':
                 return $talk_mapper->getNotViewedByUserId($admin_user_id, $options);
                 break;
 
-            case "notrated":
+            case 'notrated':
                 return $talk_mapper->getNotRatedByUserId($admin_user_id, $options);
                 break;
 
-            case "rated":
+            case 'rated':
                 return $talk_mapper->getRatedByUserId($admin_user_id, $options);
                 break;
 
-            case "viewed":
+            case 'viewed':
                 return $talk_mapper->getViewedByUserId($admin_user_id, $options);
                 break;
 
-            case "favorited":
+            case 'favorited':
                 return $talk_mapper->getFavoritesByUserId($admin_user_id, $options);
                 break;
 
@@ -136,7 +136,7 @@ class TalksController extends BaseController
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "Could not find requested talk",
+                'ext' => 'Could not find requested talk',
             ]);
 
             return $this->app->redirect($this->url('admin_talks'));
@@ -344,7 +344,7 @@ class TalksController extends BaseController
         $this->service('session')->set('flash', [
                 'type' => 'success',
                 'short' => 'Success',
-                'ext' => "Comment Added!",
+                'ext' => 'Comment Added!',
             ]);
 
         return $this->app->redirect($this->url('admin_talk_view', ['id' => $talk_id]));

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -34,7 +34,7 @@ class ForgotController extends BaseController
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "Please enter a properly formatted email address",
+                'ext' => 'Please enter a properly formatted email address',
             ]);
 
             return $this->redirectTo('forgot_password');
@@ -59,7 +59,7 @@ class ForgotController extends BaseController
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "We were unable to send your password reset request. Please try again",
+                'ext' => 'We were unable to send your password reset request. Please try again',
             ]);
 
             return $this->redirectTo('forgot_password');
@@ -76,7 +76,7 @@ class ForgotController extends BaseController
             throw new Exception();
         }
 
-        $errorMessage = "The reset you have requested appears to be invalid, please try again.";
+        $errorMessage = 'The reset you have requested appears to be invalid, please try again.';
         $error = 0;
         try {
             /* @var Sentry $sentry */
@@ -131,7 +131,7 @@ class ForgotController extends BaseController
             return $this->render('user/reset_password.twig', ['form' => $form->createView()]);
         }
 
-        $errorMessage = "The reset you have requested appears to be invalid, please try again.";
+        $errorMessage = 'The reset you have requested appears to be invalid, please try again.';
         $error = 0;
 
         try {
@@ -188,7 +188,7 @@ class ForgotController extends BaseController
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "Please select a different password than your current one.",
+                'ext' => 'Please select a different password than your current one.',
             ]);
 
             return $this->redirectTo('login');
@@ -209,7 +209,7 @@ class ForgotController extends BaseController
         $this->service('session')->set('flash', [
             'type' => 'error',
             'short' => 'Error',
-            'ext' => "Password reset failed, please contact the administrator.",
+            'ext' => 'Password reset failed, please contact the administrator.',
         ]);
 
         return $this->redirectTo('homepage');

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -152,7 +152,7 @@ class ProfileController extends BaseController
                 $this->service('session')->set('flash', [
                     'type' => 'success',
                     'short' => 'Success',
-                    'ext' => "Successfully updated your information!",
+                    'ext' => 'Successfully updated your information!',
                 ]);
 
                 return $this->redirectTo('dashboard');
@@ -212,7 +212,7 @@ class ProfileController extends BaseController
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => implode("<br>", $form->getErrorMessages()),
+                'ext' => implode('<br>', $form->getErrorMessages()),
             ]);
 
             return $this->redirectTo('password_edit');
@@ -229,7 +229,7 @@ class ProfileController extends BaseController
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => "Unable to update your password in the database. Please try again.",
+                'ext' => 'Unable to update your password in the database. Please try again.',
             ]);
 
             return $this->redirectTo('password_edit');
@@ -238,7 +238,7 @@ class ProfileController extends BaseController
         $this->service('session')->set('flash', [
             'type' => 'success',
             'short' => 'Success',
-            'ext' => "Changed your password.",
+            'ext' => 'Changed your password.',
         ]);
 
         return $this->redirectTo('password_edit');

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -165,7 +165,7 @@ class SignupController extends BaseController
             $app['session']->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
-                'ext' => implode("<br>", $form->getErrorMessages()),
+                'ext' => implode('<br>', $form->getErrorMessages()),
             ]);
         }
 

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -336,13 +336,13 @@ class TalkController extends BaseController
         $this->service('session')->set('flash', [
             'type' => 'error',
             'short' => 'Error',
-            'ext' => implode("<br>", $form->getErrorMessages()),
+            'ext' => implode('<br>', $form->getErrorMessages()),
         ]);
 
         $this->service('session')->set('flash', [
             'type' => 'error',
             'short' => 'Error',
-            'ext' => implode("<br>", $form->getErrorMessages()),
+            'ext' => implode('<br>', $form->getErrorMessages()),
         ]);
         $data['flash'] = $this->getFlash($this->app);
 
@@ -444,7 +444,7 @@ class TalkController extends BaseController
         $this->service('session')->set('flash', [
             'type' => 'error',
             'short' => 'Error',
-            'ext' => implode("<br>", $form->getErrorMessages()),
+            'ext' => implode('<br>', $form->getErrorMessages()),
         ]);
 
         $data['flash'] = $this->getFlash($this->app);

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -93,14 +93,14 @@ class SignupForm extends Form
 
         // Check if uploaded file is greater than 5MB
         if ($this->_taintedData['speaker_photo']->getClientSize() > (5 * 1048576)) {
-            $this->_addErrorMessage("Speaker photo can not be larger than 5MB");
+            $this->_addErrorMessage('Speaker photo can not be larger than 5MB');
 
             return false;
         }
 
         // Check if photo is in the mime-type white list
         if (!in_array($this->_taintedData['speaker_photo']->getMimeType(), $allowedMimeTypes)) {
-            $this->_addErrorMessage("Speaker photo must be a jpg or png");
+            $this->_addErrorMessage('Speaker photo must be a jpg or png');
 
             return false;
         }
@@ -117,7 +117,7 @@ class SignupForm extends Form
     public function validateEmail()
     {
         if (!isset($this->_taintedData['email']) || $this->_taintedData['email'] == '') {
-            $this->_addErrorMessage("Missing email");
+            $this->_addErrorMessage('Missing email');
 
             return false;
         }
@@ -125,7 +125,7 @@ class SignupForm extends Form
         $response = filter_var($this->_taintedData['email'], FILTER_VALIDATE_EMAIL);
 
         if (!$response) {
-            $this->_addErrorMessage("Invalid email address format");
+            $this->_addErrorMessage('Invalid email address format');
 
             return false;
         }
@@ -144,25 +144,25 @@ class SignupForm extends Form
         $passwd2 = $this->_cleanData['password2'];
 
         if ($passwd == '' || $passwd2 == '') {
-            $this->_addErrorMessage("Missing passwords");
+            $this->_addErrorMessage('Missing passwords');
 
             return false;
         }
 
         if ($passwd !== $passwd2) {
-            $this->_addErrorMessage("The submitted passwords do not match");
+            $this->_addErrorMessage('The submitted passwords do not match');
 
             return false;
         }
 
         if (strlen($passwd) < 5 && strlen($passwd2) < 5) {
-            $this->_addErrorMessage("The submitted password must be at least 5 characters long");
+            $this->_addErrorMessage('The submitted password must be at least 5 characters long');
 
             return false;
         }
 
-        if ($passwd !== str_replace(" ", "", $passwd)) {
-            $this->_addErrorMessage("The submitted password contains invalid characters");
+        if ($passwd !== str_replace(' ', '', $passwd)) {
+            $this->_addErrorMessage('The submitted password contains invalid characters');
 
             return false;
         }
@@ -212,19 +212,19 @@ class SignupForm extends Form
         $last_name = $this->_cleanData['last_name'];
 
         if (empty($last_name)) {
-            $this->_addErrorMessage("Last name was blank or contained unwanted characters");
+            $this->_addErrorMessage('Last name was blank or contained unwanted characters');
 
             return false;
         }
 
         if (strlen($last_name) > 255) {
-            $this->_addErrorMessage("Last name cannot be longer than 255 characters");
+            $this->_addErrorMessage('Last name cannot be longer than 255 characters');
 
             return false;
         }
 
         if ($last_name !== $this->_taintedData['last_name']) {
-            $this->_addErrorMessage("Last name data did not match after sanitizing");
+            $this->_addErrorMessage('Last name data did not match after sanitizing');
 
             return false;
         }
@@ -260,7 +260,7 @@ class SignupForm extends Form
         $speakerInfo = $this->_purifier->purify($speakerInfo);
 
         if (empty($speakerInfo)) {
-            $this->_addErrorMessage("You submitted speaker info but it was empty after sanitizing");
+            $this->_addErrorMessage('You submitted speaker info but it was empty after sanitizing');
             $validation_response = false;
         }
 
@@ -283,7 +283,7 @@ class SignupForm extends Form
         $speaker_bio = $this->_purifier->purify($speaker_bio);
 
         if (empty($speaker_bio)) {
-            $this->_addErrorMessage("You submitted speaker bio information but it was empty after sanitizing");
+            $this->_addErrorMessage('You submitted speaker bio information but it was empty after sanitizing');
             $validation_response = false;
         }
 

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -75,7 +75,7 @@ class TalkForm extends Form
     public function validateTitle()
     {
         if (empty($this->_taintedData['title'])) {
-            $this->_addErrorMessage("Please fill in the title");
+            $this->_addErrorMessage('Please fill in the title');
 
             return false;
         }
@@ -83,7 +83,7 @@ class TalkForm extends Form
         $title = $this->_cleanData['title'];
 
         if (strlen($title) > 100) {
-            $this->_addErrorMessage("Your talk title has to be 100 characters or less");
+            $this->_addErrorMessage('Your talk title has to be 100 characters or less');
 
             return false;
         }
@@ -99,7 +99,7 @@ class TalkForm extends Form
     public function validateDescription()
     {
         if (empty($this->_cleanData['description'])) {
-            $this->_addErrorMessage("Your description was missing");
+            $this->_addErrorMessage('Your description was missing');
 
             return false;
         }
@@ -117,13 +117,13 @@ class TalkForm extends Form
         $validTalkTypes = $this->getOption('types');
 
         if (empty($this->_cleanData['type']) || !isset($this->_cleanData['type'])) {
-            $this->_addErrorMessage("You must choose what type of talk you are submitting");
+            $this->_addErrorMessage('You must choose what type of talk you are submitting');
 
             return false;
         }
 
         if (!isset($validTalkTypes[$this->_cleanData['type']])) {
-            $this->_addErrorMessage("You did not choose a valid talk type");
+            $this->_addErrorMessage('You did not choose a valid talk type');
 
             return false;
         }
@@ -136,13 +136,13 @@ class TalkForm extends Form
         $validLevels = $this->getOption('levels');
 
         if (empty($this->_cleanData['level']) || !isset($this->_cleanData['level'])) {
-            $this->_addErrorMessage("You must choose what level of talk you are submitting");
+            $this->_addErrorMessage('You must choose what level of talk you are submitting');
 
             return false;
         }
 
         if (!isset($validLevels[$this->_cleanData['level']])) {
-            $this->_addErrorMessage("You did not choose a valid talk level");
+            $this->_addErrorMessage('You did not choose a valid talk level');
 
             return false;
         }
@@ -155,12 +155,12 @@ class TalkForm extends Form
         $validCategories = $this->getOption('categories');
 
         if (empty($this->_cleanData['category']) || !isset($this->_cleanData['category'])) {
-            $this->_addErrorMessage("You must choose what category of talk you are submitting");
+            $this->_addErrorMessage('You must choose what category of talk you are submitting');
             return false;
         }
 
         if (!isset($validCategories[$this->_cleanData['category']])) {
-            $this->_addErrorMessage("You did not choose a valid talk category");
+            $this->_addErrorMessage('You did not choose a valid talk category');
             return false;
         }
 

--- a/tests/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/Domain/Entity/Mapper/TalkTest.php
@@ -66,7 +66,7 @@ class TalkTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $talk->id,
             $admin_favorite['id'],
-            "Did not get expected list of admin-favorited talks"
+            'Did not get expected list of admin-favorited talks'
         );
     }
 

--- a/tests/Domain/Entity/TalkTest.php
+++ b/tests/Domain/Entity/TalkTest.php
@@ -39,7 +39,7 @@ class TalkTest extends \PHPUnit\Framework\TestCase
      */
     public function utf8CharactersCorrectlyEncoded()
     {
-        $title = "Battle: Feature Branches VS Feature Switching (╯°□°)╯︵ ┻━┻ ︵ ╯(°□° ╯)";
+        $title = 'Battle: Feature Branches VS Feature Switching (╯°□°)╯︵ ┻━┻ ︵ ╯(°□° ╯)';
         $data = [
             'title' => $title,
             'description' => 'Talk with UTF-8 characters in the title',
@@ -74,7 +74,7 @@ class TalkTest extends \PHPUnit\Framework\TestCase
         $this->bulkCreateTalks(11);
         $recent_talks = $this->mapper->getRecent(1);
 
-        $this->assertCount(10, $recent_talks, "Talk::getRecent() did not grab 10 talks out of 11");
+        $this->assertCount(10, $recent_talks, 'Talk::getRecent() did not grab 10 talks out of 11');
     }
 
     //

--- a/tests/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Http/Controller/Admin/TalksControllerTest.php
@@ -58,7 +58,7 @@ class TalksControllerTest extends \PHPUnit\Framework\TestCase
         $talkData = [0 => [
             'id' => 1,
             'title' => 'Test Title',
-            'description' => "The title should contain this & that",
+            'description' => 'The title should contain this & that',
             'meta' => [
                 'rating' => 5,
             ],

--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -52,13 +52,13 @@ class SignupControllerTest extends \PHPUnit\Framework\TestCase
         $req = m::mock('Symfony\Component\HttpFoundation\Request');
         $controller->indexAction($req, $currentTimeString);
 
-        $expectedMessage = "Sorry, the call for papers has ended.";
+        $expectedMessage = 'Sorry, the call for papers has ended.';
         $session_details = $app['session']->get('flash');
 
         $this->assertContains(
             $expectedMessage,
             $session_details['ext'],
-            "Did not get cfp closed message"
+            'Did not get cfp closed message'
         );
     }
 
@@ -203,7 +203,7 @@ class SignupControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertContains(
             $expectedMessage,
             $session_details['ext'],
-            "Did not successfully create an account"
+            'Did not successfully create an account'
         );
     }
 
@@ -292,7 +292,7 @@ class SignupControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertContains(
             $expectedMessage,
             $session_details['ext'],
-            "Did not successfully create an account"
+            'Did not successfully create an account'
         );
     }
 }

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -97,7 +97,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         // Get our request object to return expected data
         $talk_data = [
             'title' => 'Test Title With Ampersand',
-            'description' => "The title should contain this & that",
+            'description' => 'The title should contain this & that',
             'type' => 'regular',
             'level' => 'entry',
             'category' => 'other',
@@ -149,7 +149,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         // Get our request object to return expected data
         $talk_data = [
             'title' => 'Test Submission',
-            'description' => "Make sure we can submit before end and not after.",
+            'description' => 'Make sure we can submit before end and not after.',
             'type' => 'regular',
             'level' => 'entry',
             'category' => 'other',
@@ -183,7 +183,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
          * However, if I update application configuration to make
          * the CFP end date to be "yesterday" then we get flash as expected.
          */
-        $yesterday = new DateTime("yesterday");
+        $yesterday = new DateTime('yesterday');
 
         $this->app['callforproposal'] = new CallForProposal(new DateTime($yesterday->format('M. jS, Y')));
 

--- a/tests/Http/Form/SignupFormTest.php
+++ b/tests/Http/Form/SignupFormTest.php
@@ -80,7 +80,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $this->assertFalse(
             $form->validateEmail(),
-            "Validating empty email did not fail"
+            'Validating empty email did not fail'
         );
     }
 
@@ -134,7 +134,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue(
             $form->validatePasswords(),
-            "Valid passwords did not survive validation and sanitization"
+            'Valid passwords did not survive validation and sanitization'
         );
     }
 
@@ -163,7 +163,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $this->assertContains(
             $expectedMessage,
             $form->getErrorMessages(),
-            "Did not get expected error message"
+            'Did not get expected error message'
         );
     }
 
@@ -175,10 +175,10 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function badPasswordProvider()
     {
         return [
-            ['foo', 'foo', "The submitted password must be at least 5 characters long", false],
-            ['bar', 'foo', "The submitted passwords do not match", false],
-            [null, null, "Missing passwords", false],
-            ['password with spaces', 'password with spaces', "The submitted password contains invalid characters", false],
+            ['foo', 'foo', 'The submitted password must be at least 5 characters long', false],
+            ['bar', 'foo', 'The submitted passwords do not match', false],
+            [null, null, 'Missing passwords', false],
+            ['password with spaces', 'password with spaces', 'The submitted password contains invalid characters', false],
         ];
     }
 
@@ -283,7 +283,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $expectedResponse,
             $form->validateAll(),
-            "All submitted data did not validate as expected"
+            'All submitted data did not validate as expected'
         );
     }
 
@@ -302,7 +302,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
             'last_name' => 'McTesterton',
         ];
         $baseDataWithSpeakerInfo = $baseData;
-        $baseDataWithSpeakerInfo['speaker_info'] = "Testing speaker info data";
+        $baseDataWithSpeakerInfo['speaker_info'] = 'Testing speaker info data';
 
         return [
             [$baseData, true],
@@ -327,7 +327,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $expectedResponse,
             $form->validateSpeakerInfo(),
-            "Speaker info was not validated as expected"
+            'Speaker info was not validated as expected'
         );
     }
 
@@ -347,7 +347,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $expectedResponse,
             $form->validateSpeakerBio(),
-            "Speaker bio was not validated as expected"
+            'Speaker bio was not validated as expected'
         );
     }
 
@@ -380,7 +380,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $expectedData,
             $sanitizedData,
-            "Data was not sanitized properly"
+            'Data was not sanitized properly'
         );
     }
 
@@ -404,7 +404,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => "",
+            'last_name' => '',
         ];
 
         $goodDataIn = [
@@ -412,7 +412,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => "McTesterton",
+            'last_name' => 'McTesterton',
         ];
 
         $goodDataOut = $goodDataIn;
@@ -422,8 +422,8 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => "McTesterton",
-            'speaker_info' => "<a href=\"http://lolcoin.com/redeem\">Speaker bio</a>",
+            'last_name' => 'McTesterton',
+            'speaker_info' => '<a href="http://lolcoin.com/redeem">Speaker bio</a>',
         ];
 
         $badSpeakerInfoOut = [
@@ -431,8 +431,8 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => "McTesterton",
-            'speaker_info' => "<a href=\"http://lolcoin.com/redeem\">Speaker bio</a>",
+            'last_name' => 'McTesterton',
+            'speaker_info' => '<a href="http://lolcoin.com/redeem">Speaker bio</a>',
         ];
 
         $goodSpeakerInfoIn = [
@@ -440,8 +440,8 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
             'password' => 'xxxxxx',
             'password2' => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => "McTesterton",
-            'speaker_info' => "Find my bio at http://littlehart.net",
+            'last_name' => 'McTesterton',
+            'speaker_info' => 'Find my bio at http://littlehart.net',
         ];
 
         $goodSpeakerInfoOut = $goodSpeakerInfoIn;

--- a/tests/Http/Form/TalkFormTest.php
+++ b/tests/Http/Form/TalkFormTest.php
@@ -60,7 +60,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
             'user_id' => 1,
         ];
         $extendedData = $goodData;
-        $extendedData['extra'] = "Extra data in \$_POST but we ignore it";
+        $extendedData['extra'] = 'Extra data in $_POST but we ignore it';
 
         return [
             [serialize($badData), false],
@@ -145,8 +145,8 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         return [
             [substr($faker->text(90), 0, 90), true],
             [null, false],
-            ["This is a string that could be more than 100 characters long but will we really know for sure until I check it out?", false],
-            ["A little bit of this & that", true],
+            ['This is a string that could be more than 100 characters long but will we really know for sure until I check it out?', false],
+            ['A little bit of this & that', true],
         ];
     }
 


### PR DESCRIPTION
This PR

* [x] enables the `single_quote` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.1.0#usage:

> **single_quote [`@Symfony`]**
Convert double quotes to single quotes for simple strings.
