### PR TITLE
Remove -e as an environment option

### DIFF
--- a/bin/opencfp
+++ b/bin/opencfp
@@ -12,7 +12,7 @@ use OpenCFP\Application as ApplicationContainer;
 
 $basePath = realpath(dirname(__DIR__));
 $input = new ArgvInput();
-$environment = $input->getParameterOption(array('--env', '-e'), getenv('CFP_ENV') ?: 'development');
+$environment = $input->getParameterOption(array('--env'), getenv('CFP_ENV') ?: 'development');
 
 $container = new ApplicationContainer($basePath, Environment::fromString($environment));
 $app = new Application($container);


### PR DESCRIPTION
Given that the -e option for specifying the environment
in which the command should run is not documented any where,
we remove it.

This way it won't clash any more with the user:create command
and specifying the email of the new user with -e.

Fixes #471 
