### PR TITLE
Get path to HTML Purifier cache from app

### DIFF
--- a/classes/Provider/HtmlPurifierServiceProvider.php
+++ b/classes/Provider/HtmlPurifierServiceProvider.php
@@ -18,7 +18,7 @@ class HtmlPurifierServiceProvider implements ServiceProviderInterface
             if ($app->config('cache.enabled')) {
                 $cachePermissions = 0755;
                 $config->set('Cache.SerializerPermissions', $cachePermissions);
-                $cacheDirectory = $app->config('paths.cache.purifier');
+                $cacheDirectory = $app->cachePurifierPath();
 
                 if (!is_dir($cacheDirectory)) {
                     mkdir($cacheDirectory, $cachePermissions, true);


### PR DESCRIPTION
The app has a reusable method that tells us where
HTML Purifier should put the cache files.

Use it instead of trying to get the cache path from the config.

Fixes #472 