### PR TITLE
print correct not-found filename on error

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -145,7 +145,7 @@ class Application extends SilexApplication
 
         if (!file_exists($this->configPath())) {
             throw new \InvalidArgumentException(
-                sprintf("The config file '%s' does not exist.", $this->filename)
+                sprintf("The config file '%s' does not exist.", $this->configPath())
             );
         }
 


### PR DESCRIPTION
This shows the correct path of the configuration file which couldn't be found.
