### PR TITLE
Allow sign up without joind.in url

### DIFF
--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -249,7 +249,10 @@ class SignupForm extends Form
 
     public function validateUrl()
     {
-        if (preg_match('/https:\/\/joind\.in\/user\/[a-zA-Z0-9]{1,25}/', $this->_cleanData['url'])) {
+        if (preg_match('/https:\/\/joind\.in\/user\/[a-zA-Z0-9]{1,25}/', $this->_cleanData['url'])
+            || !isset($this->_cleanData['url'])
+            || '' == $this->_cleanData['url']
+        ) {
             return true;
         } else {
             $this->_addErrorMessage('You did not enter a valid joind.in URL');

--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -211,6 +211,96 @@ class SignupControllerTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
+    public function signupWithOutJoindInWorks()
+    {
+        $app = m::mock(\OpenCFP\Application::class);
+        $app->shouldReceive('redirect');
+
+        // Create a session
+        $app->shouldReceive('offsetGet')->with('session')->andReturn(new Session(new MockFileSessionStorage()));
+
+        // Create our URL generator
+        $url = 'http://opencfp/signup';
+        $url_generator = m::mock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $url_generator->shouldReceive('generate')->andReturn($url);
+        $app->shouldReceive('offsetGet')->with('url_generator')->andReturn($url_generator);
+
+        // We need to set up our speaker information
+        $form_data = [
+            'formAction' => 'http://opencfp/signup',
+            'first_name' => 'Testy',
+            'last_name' => 'McTesterton',
+            'email' => 'test@opencfp.org',
+            'company' => null,
+            'twitter' => null,
+            'url' => '',
+            'password' => 'wutwut',
+            'password2' => 'wutwut',
+            'airport' => null,
+            'speaker_info' => null,
+            'speaker_bio' => null,
+            'transportation' => null,
+            'hotel' => null,
+            'buttonInfo' => 'Create my speaker profile',
+            'agree_coc' => null,
+        ];
+
+        // Set our HTMLPurifier we use for validation
+        $config = HTMLPurifier_Config::createDefault();
+        $purifier = new HTMLPurifier($config);
+        $app->shouldReceive('offsetGet')->with('purifier')->andReturn($purifier);
+        $app->shouldReceive('config')->with('application.coc_link')->andReturn(null);
+
+        // Create a pretend Sentry object that says everything is cool
+        $sentry = m::mock(Sentry::class);
+        $user = m::mock(\OpenCFP\Domain\Entity\User::class);
+        $user->shouldReceive('set');
+        $user->shouldReceive('addGroup');
+        $user->shouldReceive('relation');
+        $user->id = 1; // Any integer value is fine
+        $sentry->shouldReceive('getUserProvider->create')->andReturn($user);
+        $sentry->shouldReceive('getGroupProvider->findByName');
+
+        $app->shouldReceive('offsetGet')->with('sentry')->andReturn($sentry);
+
+        // Create an instance of our database
+        $speaker = new \stdClass;
+        $mapper = m::mock('stdClass');
+        $mapper->shouldReceive('get')->andReturn($speaker);
+        $mapper->shouldReceive('save');
+        $spot = m::mock(Locator::class);
+        $spot->shouldReceive('mapper')->andReturn($mapper);
+        $app->shouldReceive('offsetGet')->with('spot')->andReturn($spot);
+
+        // Create an instance of the controller and we're all set
+        $controller = new \OpenCFP\Http\Controller\SignupController();
+        $controller->setApplication($app);
+
+        $req = m::mock('Symfony\Component\HttpFoundation\Request');
+
+
+        foreach ($form_data as $field => $value) {
+            $req->shouldReceive('get')->with($field)->andReturn($value);
+        }
+
+        $files = m::mock('StdClass');
+        $files->shouldReceive('get')->with('speaker_photo')->andReturn(null);
+        $req->files = $files;
+
+        $controller->processAction($req, $app);
+        $expectedMessage = "You've successfully created your account!";
+        $session_details = $app['session']->get('flash');
+
+        $this->assertContains(
+            $expectedMessage,
+            $session_details['ext'],
+            'Did not successfully create an account'
+        );
+    }
+
+    /**
+     * @test
+     */
     public function signupCocWithValidInfoWorks()
     {
         $app = m::mock(\OpenCFP\Application::class);


### PR DESCRIPTION
Changed the check for the joind.in url so users are now allowed to sign up with either a valid url or no url at all.

Fixes #491.
