### PR TITLE
Enhancement: Enable yoda_style fixer and enforce non-yoda-style comparisons

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,6 +16,11 @@ $config = PhpCsFixer\Config::create()
         'psr0' => false,
         'single_quote' => true,
         'trailing_comma_in_multiline_array' => true,
+        'yoda_style' => [
+            'equal' => false,
+            'identical' => false,
+            'less_and_greater' => false,
+        ],
     ])
     ->setFinder($finder);
 

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -245,7 +245,7 @@ class SignupForm extends Form
     {
         if (preg_match('/https:\/\/joind\.in\/user\/[a-zA-Z0-9]{1,25}/', $this->_cleanData['url'])
             || !isset($this->_cleanData['url'])
-            || '' == $this->_cleanData['url']
+            || $this->_cleanData['url'] == ''
         ) {
             return true;
         } else {

--- a/classes/Infrastructure/Persistence/SpotSpeakerRepository.php
+++ b/classes/Infrastructure/Persistence/SpotSpeakerRepository.php
@@ -26,7 +26,7 @@ class SpotSpeakerRepository implements SpeakerRepository
     {
         $speaker = $this->mapper->get($speakerId);
 
-        if (false === $speaker) {
+        if ($speaker === false) {
             throw new EntityNotFoundException;
         }
 

--- a/classes/Provider/ControllerResolver.php
+++ b/classes/Provider/ControllerResolver.php
@@ -13,7 +13,7 @@ class ControllerResolver extends \Silex\ControllerResolver
      */
     protected function createController($controller)
     {
-        if (false !== strpos($controller, '::')) {
+        if (strpos($controller, '::') !== false) {
             $instance = parent::createController($controller);
 
             // Injects container from side rather than constructor.
@@ -24,7 +24,7 @@ class ControllerResolver extends \Silex\ControllerResolver
             return $instance;
         }
 
-        if (false === strpos($controller, ':')) {
+        if (strpos($controller, ':') === false) {
             throw new \LogicException(sprintf('Unable to parse the controller name "%s".', $controller));
         }
 

--- a/classes/Provider/Gateways/ApiGatewayProvider.php
+++ b/classes/Provider/Gateways/ApiGatewayProvider.php
@@ -33,7 +33,7 @@ class ApiGatewayProvider implements ServiceProviderInterface, BootableProviderIn
         $api->before(function (Request $request) {
             $request->headers->set('Accept', 'application/json');
 
-            if (0 === strpos($request->headers->get('Content-Type'), 'application/json')) {
+            if (strpos($request->headers->get('Content-Type'), 'application/json') === 0) {
                 $data = json_decode($request->getContent(), true);
                 $request->request->replace(is_array($data) ? $data : []);
             }

--- a/classes/Provider/Gateways/OAuthGatewayProvider.php
+++ b/classes/Provider/Gateways/OAuthGatewayProvider.php
@@ -68,7 +68,7 @@ class OAuthGatewayProvider implements ServiceProviderInterface, BootableProvider
         $oauth->before(function (Request $request, Application $app) {
             $request->headers->set('Accept', 'application/json');
 
-            if (0 === strpos($request->headers->get('Content-Type'), 'application/json')) {
+            if (strpos($request->headers->get('Content-Type'), 'application/json') === 0) {
                 $data = json_decode($request->getContent(), true);
                 $request->request->replace(is_array($data) ? $data : []);
             }

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.2.0",
-        "friendsofphp/php-cs-fixer": "^2.0.0",
+        "friendsofphp/php-cs-fixer": "^2.7.1",
         "fzaninotto/faker": "^1.5.0",
         "mockery/mockery": "1.0.*@dev",
         "phpunit/phpunit": "~6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "def02f8bf52dc636ee29943583b0d6f9",
+    "content-hash": "c47b81f02e1eabebb93927cc1bf97091",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -2184,9 +2184,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 },
                 {
                     "name": "Chris Corbyn"


### PR DESCRIPTION
This PR

* [x] explicitly requires `friendsofphp/php-cs-fixer:^2.7.1` (already locked to, but `composer.json` doesn't reflect it) 
* [x] enables the `yoda_style` fixer and enforces non-yoda-style comparisons
* [x] runs `make cs`

Follows https://github.com/opencfp/opencfp/pull/500#pullrequestreview-67378081.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**yoda_style** [`@Symfony`]
>
>Write conditions in Yoda style (`true`), non-Yoda style (`false`) or ignore those conditions (`null`) based on configuration.
>
>Configuration options:
>
>- `equal` (`bool`, `null`): style for equal (`==`, `!=`) statements; defaults to `true`
>- `identical` (`bool`, `null`): style for identical (`===`, `!==`) statements; defaults to `true`
>- `less_and_greater` (`bool`, `null`): style for less and greater than (`<`, `<=`, `>`, `>=`) statements; defaults to `null`