### PR TITLE
Initial refactor to use a strategy class for handling ratings

### DIFF
--- a/classes/Domain/Services/Authentication.php
+++ b/classes/Domain/Services/Authentication.php
@@ -25,6 +25,14 @@ interface Authentication
     public function user(): UserInterface;
 
     /**
+     * Returns current authenticated User Id.
+     *
+     * @return int
+     * @throws NotAuthenticatedException
+     */
+    public function userId(): int;
+
+    /**
      * Determines whether or not the user is logged in.
      *
      * @return bool

--- a/classes/Domain/Services/TalkRating/TalkRatingException.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace OpenCFP\Domain\Services\TalkRating;
+
+class TalkRatingException extends \RuntimeException
+{
+    public static function invalidRating($rating)
+    {
+        return new self(sprintf('Invalid talk rating: %s', $rating));
+    }
+}

--- a/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace OpenCFP\Domain\Services\TalkRating;
+
+interface TalkRatingStrategy
+{
+    public function isValidRating($rating): bool;
+
+    public function rate(int $talkId, $rating);
+}

--- a/classes/Domain/Services/TalkRating/YesNoRating.php
+++ b/classes/Domain/Services/TalkRating/YesNoRating.php
@@ -39,7 +39,7 @@ class YesNoRating implements TalkRatingStrategy
 
     private function fetchMetaInfo(int $talkId): TalkMeta
     {
-        $adminUserId = (int) $this->auth->user()->getId();
+        $adminUserId = $this->auth->userId();
         $talkMeta = $this->mapper->where([
             'admin_user_id' => $adminUserId,
             'talk_id' => $talkId,

--- a/classes/Domain/Services/TalkRating/YesNoRating.php
+++ b/classes/Domain/Services/TalkRating/YesNoRating.php
@@ -29,7 +29,7 @@ class YesNoRating implements TalkRatingStrategy
     public function rate(int $talkId, $rating)
     {
         if (!$this->isValidRating($rating)) {
-            return; //maybe throw here instead?
+            throw TalkRatingException::invalidRating($rating);
         }
 
         $meta = $this->fetchMetaInfo($talkId);

--- a/classes/Domain/Services/TalkRating/YesNoRating.php
+++ b/classes/Domain/Services/TalkRating/YesNoRating.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace OpenCFP\Domain\Services\TalkRating;
+
+use OpenCFP\Domain\Entity\TalkMeta;
+use OpenCFP\Domain\Services\Authentication;
+use Spot\MapperInterface;
+
+class YesNoRating implements TalkRatingStrategy
+{
+    private $mapper;
+    private $auth;
+
+    public function __construct(MapperInterface $mapper, Authentication $auth)
+    {
+        $this->mapper = $mapper;
+        $this->auth = $auth;
+    }
+
+    public function isValidRating($rating): bool
+    {
+        if ($rating < -1 || $rating > 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function rate(int $talkId, $rating)
+    {
+        if (!$this->isValidRating($rating)) {
+            return; //maybe throw here instead?
+        }
+
+        $meta = $this->fetchMetaInfo($talkId);
+        $meta->rating = $rating;
+        $this->mapper->save($meta);
+    }
+
+    private function fetchMetaInfo(int $talkId): TalkMeta
+    {
+        $adminUserId = (int) $this->auth->user()->getId();
+        $talkMeta = $this->mapper->where([
+            'admin_user_id' => $adminUserId,
+            'talk_id' => $talkId,
+        ])
+            ->first();
+
+        if (!$talkMeta) {
+            $talkMeta = $this->mapper->get();
+            $talkMeta->admin_user_id = $adminUserId;
+            $talkMeta->talk_id = $talkId;
+        }
+
+        return $talkMeta;
+    }
+}

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -67,7 +67,7 @@ class ExportsController extends BaseController
     {
         $sort = [ 'created_at' => 'DESC' ];
 
-        $admin_user_id = $this->service(Authentication::class)->user()->getId();
+        $admin_user_id = $this->service(Authentication::class)->userId();
         $mapper = $this->service('spot')->mapper('OpenCFP\Domain\Entity\Talk');
         $talks = $mapper->getAllPagerFormatted($admin_user_id, $sort, $attributed, $where);
 

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -26,7 +26,7 @@ class TalksController extends BaseController
         /* @var Authentication $auth */
         $auth = $this->service(Authentication::class);
 
-        $admin_user_id = $auth->user()->getId();
+        $admin_user_id = $auth->userId();
         $options = [
             'order_by' => $req->get('order_by'),
             'sort' => $req->get('sort'),
@@ -154,7 +154,7 @@ class TalksController extends BaseController
 
         // Mark talk as viewed by admin
         $talk_meta = $meta_mapper->where([
-                'admin_user_id' => $auth->user()->getId(),
+                'admin_user_id' => $auth->userId(),
                 'talk_id' => (int)$req->get('id'),
             ])
             ->first();
@@ -165,7 +165,7 @@ class TalksController extends BaseController
 
         if (!$talk_meta->viewed) {
             $talk_meta->viewed = true;
-            $talk_meta->admin_user_id = $auth->user()->getId();
+            $talk_meta->admin_user_id = $auth->userId();
             $talk_meta->talk_id = $talk_id;
             $meta_mapper->save($talk_meta);
         }
@@ -236,7 +236,7 @@ class TalksController extends BaseController
         /** @var Authentication $auth */
         $auth = $this->service(Authentication::class);
 
-        $admin_user_id = (int) $auth->user()->getId();
+        $admin_user_id = $auth->userId();
         $status = true;
 
         if ($req->get('delete') !== null) {

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Domain\Entity\Talk;
 use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
 use OpenCFP\Domain\Services\TalkRating\YesNoRating;
 use OpenCFP\Http\Controller\BaseController;
 use OpenCFP\Http\Controller\FlashableTrait;
@@ -204,21 +205,18 @@ class TalksController extends BaseController
 
         /** @var Authentication $auth */
         $auth = $this->service(Authentication::class);
-
-        $admin_user_id = (int) $auth->user()->getId();
         $mapper = $this->service('spot')->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
-
-        $talk_rating = (int)$req->get('rating');
-        $talk_id = (int)$req->get('id');
 
         $talkRatingStrategy = new YesNoRating($mapper, $auth);
 
-        // Check for invalid rating range
-        if (!$talkRatingStrategy->isValidRating($talk_rating)) {
+        try {
+            $talk_rating = (int) $req->get('rating');
+            $talk_id = (int) $req->get('id');
+
+            $talkRatingStrategy->rate($talk_id, $talk_rating);
+        } catch (TalkRatingException $e) {
             return false;
         }
-
-        $talkRatingStrategy->rate($talk_id, $talk_rating);
 
         return true;
     }

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -54,6 +54,12 @@ class SentryAuthentication implements Authentication
         return $user;
     }
 
+    public function userId(): int
+    {
+        return (int) $this->user()
+            ->getId();
+    }
+
     /**
      * Determines whether or not the user is logged in.
      *

--- a/tests/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -1,0 +1,68 @@
+<?php
+
+
+namespace OpenCFP\Test\Domain\Services\TalkRating;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery as m;
+use OpenCFP\Domain\Entity\TalkMeta;
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
+use OpenCFP\Domain\Services\TalkRating\YesNoRating;
+use Spot\MapperInterface;
+
+class YesNoRatingTest extends MockeryTestCase
+{
+    public function testRateThrowsExceptionOnInvalidRating()
+    {
+        $mockAuth = m::mock(Authentication::class);
+        $mockMapper = m::mock(MapperInterface::class);
+
+        $sut = new YesNoRating($mockMapper, $mockAuth);
+
+        $this->expectException(TalkRatingException::class);
+        $this->expectExceptionMessage('Invalid talk rating: 9001');
+
+        $sut->rate(7, 9001);
+    }
+
+    public function testRate()
+    {
+        $talkMeta = new TalkMeta();
+
+        $mockAuth = m::mock(Authentication::class);
+        $mockAuth->shouldReceive('userId')->andReturn(1);
+
+        $mockMapper = m::mock(MapperInterface::class);
+        $mockMapper->shouldReceive('where->first')->andReturn(false);
+        $mockMapper->shouldReceive('get')->andReturn($talkMeta);
+        $mockMapper->shouldReceive('save')->withArgs([$talkMeta]);
+
+        $sut = new YesNoRating($mockMapper, $mockAuth);
+
+        $sut->rate(7, 1);
+
+        self::assertEquals(1, $talkMeta->admin_user_id);
+        self::assertEquals(7, $talkMeta->talk_id);
+        self::assertEquals(1, $talkMeta->rating);
+    }
+
+    public function testRerate()
+    {
+        $talkMeta = new TalkMeta();
+        $talkMeta->rating = 0;
+
+        $mockAuth = m::mock(Authentication::class);
+        $mockAuth->shouldReceive('userId')->andReturn(1);
+
+        $mockMapper = m::mock(MapperInterface::class);
+        $mockMapper->shouldReceive('where->first')->andReturn($talkMeta);
+        $mockMapper->shouldReceive('save')->withArgs([$talkMeta]);
+
+        $sut = new YesNoRating($mockMapper, $mockAuth);
+
+        $sut->rate(7, 1);
+
+        self::assertEquals(1, $talkMeta->rating);
+    }
+}

--- a/tests/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Http/Controller/Admin/TalksControllerTest.php
@@ -36,6 +36,8 @@ class TalksControllerTest extends \PHPUnit\Framework\TestCase
         $auth = m::mock(Authentication::class);
         $auth->shouldReceive('check')->andReturn(true);
         $auth->shouldReceive('user')->andReturn($user);
+        $auth->shouldReceive('userId')->andReturn(1);
+
         $this->app[Authentication::class] = $auth;
         $this->app['user'] = $user;
     }


### PR DESCRIPTION
Playing with some options around talk ratings for #415 and #485 this is an initial refactor which removes the rating logic into a service class.

This piece of functionality is self contained and I'm going to suggest merging it, as the work going on around the migration away from spot my break the code.

This does introduce a minor bc break; the authentication interface gained a new method userId as a shortcut for retrieving the logged in user's id. This only presents a problem to people who've built their own authentication layer as a replacement to sentinel.

Further work required: (Future PR's)

- service locate the constructed strategy instead of calling new in the controller
- produce a similar service pattern for rendering the rating widget + rating score
- might also require some work around the logic for fetching unrated talks 

Once the above is completed, it should be possible to introduce new rating strategies controlled via config.

