### PR TITLE
Use Illuminate Database for the admins dashboard controller

### DIFF
--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -25,4 +25,86 @@ class Talk extends Model
     {
         return $this->hasMany(TalkMeta::class, 'talk_id');
     }
+
+    /**
+     * Return a collection of recent talks
+     *
+     * @param $admin_id
+     * @param int $limit
+     *
+     * @return array|Talk[]
+     */
+    public function getRecent($admin_id, $limit = 10)
+    {
+        $talks = $this
+            ->orderBy('created_at')
+            ->with(['favorites', 'meta'])
+            ->get()
+            ->take($limit);
+        $formatted = [];
+        foreach ($talks as $talk) {
+            $formatted[] = $this->createdFormattedOutput($talk, $admin_id);
+        }
+        return $formatted;
+    }
+    /**
+     * Iterates over DBAL objects and returns a formatted result set
+     *
+     * @param  mixed   $talk
+     * @param  integer $admin_user_id
+     * @return array
+     */
+    public function createdFormattedOutput($talk, $admin_user_id, $userData = true)
+    {
+        if ($talk->favorites) {
+            foreach ($talk->favorites as $favorite) {
+                if ($favorite->admin_user_id == $admin_user_id) {
+                    $talk->favorite = 1;
+                }
+            }
+        }
+        $meta = $talk->meta->where('admin_user_id', $admin_user_id)->first();
+
+        $output = [
+            'id' => $talk->id,
+            'title' => $talk->title,
+            'type' => $talk->type,
+            'category' => $talk->category,
+            'created_at' => $talk->created_at,
+            'selected' => $talk->selected,
+            'favorite' => $talk->favorite,
+            'meta' => $meta ?: ['rating' => 0, 'viewed' => 0],
+            'description' => $talk->description,
+            'slides' => $talk->slides,
+            'other' => $talk->other,
+            'level' => $talk->level,
+            'desired' => $talk->desired,
+            'sponsor' => $talk->sponsor,
+        ];
+        if ($talk->speaker && $userData) {
+            $output['user'] = [
+                'id' => $talk->speaker->id,
+                'first_name' => $talk->speaker->first_name,
+                'last_name' => $talk->speaker->last_name,
+            ];
+            $output += [
+                'speaker_id' => $talk->speaker->id,
+                'speaker_first_name' => $talk->speaker->first_name,
+                'speaker_last_name' => $talk->speaker->last_name,
+                'speaker_email' => $talk->speaker->email,
+                'speaker_company' => $talk->speaker->company,
+                'speaker_twitter' => $talk->speaker->twitter,
+                'speaker_airport' => $talk->speaker->airport,
+                'speaker_hotel' => $talk->speaker->hotel,
+                'speaker_transportation' => $talk->speaker->transportation,
+                'speaker_info' => $talk->speaker->info,
+                'speaker_bio' => $talk->speaker->bio,
+            ];
+        }
+        if ($talk->total_rating) {
+            $output['total_rating'] = $talk->total_rating;
+            $output['review_count'] = $talk->review_count;
+        }
+        return $output;
+    }
 }

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -6,6 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class Talk extends Model
 {
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
     public function speaker()
     {
         return $this->belongsTo(User::class, 'user_id');

--- a/classes/Domain/Model/TalkMeta.php
+++ b/classes/Domain/Model/TalkMeta.php
@@ -8,6 +8,12 @@ class TalkMeta extends Model
 {
     protected $table = 'talk_meta';
     public $timestamps = false;
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
 
     public function talk()
     {

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -2,38 +2,35 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use OpenCFP\Domain\Model\Favorite;
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Http\Controller\BaseController;
-use Spot\Locator;
-use Symfony\Component\HttpFoundation\Request;
 
 class DashboardController extends BaseController
 {
     use AdminAccessTrait;
 
-    public function indexAction(Request $req)
+    public function indexAction()
     {
         if (!$this->userHasAccess()) {
             return $this->redirectTo('dashboard');
         }
 
-        /* @var Locator $spot */
-        $spot = $this->service('spot');
+        $speaker_total = User::all()->count();
 
-        $user_mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
-        $speaker_total = $user_mapper->all()->count();
-
-        $talk_mapper = $this->service('spot')->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $favorite_mapper = $this->service('spot')->mapper(\OpenCFP\Domain\Entity\Favorite::class);
+        $talkModel = new Talk();
+        $favoriteModel = new Favorite();
 
         $user = $this->service(Authentication::class)->user();
-        $recent_talks = $talk_mapper->getRecent($user->getId());
+        $recent_talks = $talkModel->getRecent($user->getId());
 
         $templateData = [
             'speakerTotal' => $speaker_total,
-            'talkTotal' => $talk_mapper->all()->count(),
-            'favoriteTotal' => $favorite_mapper->all()->count(),
-            'selectTotal' => $talk_mapper->all()->where(['selected' => 1])->count(),
+            'talkTotal' => $talkModel->all()->count(),
+            'favoriteTotal' => $favoriteModel->all()->count(),
+            'selectTotal' => $talkModel->all()->where('selected', 1)->count(),
             'talks' => $recent_talks,
         ];
 

--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -19,6 +19,11 @@ abstract class DatabaseTestCase extends \PHPUnit\Framework\TestCase
     protected $options;
 
     /**
+     * @var Capsule
+     */
+    protected $capsule;
+
+    /**
      * Make sure to call parent::setUp() if you override this.
      */
     protected function setUp()
@@ -67,7 +72,9 @@ abstract class DatabaseTestCase extends \PHPUnit\Framework\TestCase
         $capsule->getConnection()->setPdo($this->phinxPdo);
 
         $capsule->setAsGlobal();
+        $capsule->bootEloquent();
 
-        return $capsule;
+        $this->capsule = $capsule;
+        return $this->capsule;
     }
 }

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace OpenCFP\Test\Domain\Model;
+
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\TalkMeta;
+use OpenCFP\Test\DatabaseTestCase;
+
+/**
+ * @group db
+ */
+class TalkTest extends DatabaseTestCase
+{
+
+    /**
+     * Illuminate doesn't like the fact that we use the PDO begin transaction and rollback
+     * so we need to use the ones from the Illuminate capsule to do that instead.
+     */
+    public function setUp()
+    {
+        $this->migrate();
+        $this->getCapsule()->getConnection()->beginTransaction();
+    }
+
+    public function tearDown()
+    {
+        $this->capsule->getConnection()->rollBack();
+    }
+
+
+    /** @test */
+    public function getRecentReturnsAnArrayOfTalks()
+    {
+        $this->generateTalks();
+        $talk = new Talk;
+        $recent = $talk->getRecent(1);
+        $this->assertEquals(4, count($recent));
+        $anotherRecent = $talk->getRecent(1, 3);
+        $this->assertEquals(3, count($anotherRecent));
+    }
+
+    /**
+     * @test
+     */
+    public function createFormattedOutputWorksWithNoMeta()
+    {
+        $this->generateOneTalk();
+        $talk = new Talk;
+        $format =$talk->createdFormattedOutput($talk->first(), 1);
+
+        $this->assertEquals('One talk to rule them all', $format['title']);
+        $this->assertEquals('api', $format['category']);
+        $this->assertEquals(['rating' => 0, 'viewed' => 0], $format['meta']);
+        $this->assertTrue(!isset($format['user']));
+    }
+
+    /**
+     * @test
+     */
+    public function createFormattedOutputWorksWithMeta()
+    {
+        $this->generateOneTalk();
+        $talk = new Talk;
+
+        // Now to see if the meta gets put in correctly
+        $secondFormat =$talk->createdFormattedOutput($talk->first(), 2);
+
+        $this->assertEquals(1, $secondFormat['meta']->rating);
+        $this->assertEquals(1, $secondFormat['meta']->viewed);
+    }
+
+
+    private function generateOneTalk()
+    {
+        $talk = new Talk();
+
+        $talk->create(
+            [
+                'user_id' => 1,
+                'title' => 'One talk to rule them all',
+                'description' => 'Two is fine too',
+                'type' => 'regular',
+                'level' => 'entry',
+                'category' => 'api',
+            ]
+        );
+
+        $meta = new TalkMeta();
+        $meta->create(
+            [
+                'admin_user_id' => 2,
+                'rating' => 1,
+                'viewed' => 1,
+                'talk_id' => $talk->first()->id,
+                'created' => new \DateTime(),
+            ]
+        );
+    }
+
+
+    /**
+     * Helper function that generates some talks for us
+     */
+    private function generateTalks()
+    {
+        $talk = new Talk();
+
+        $talk->create(
+            [
+                'user_id' => 1,
+                'title' => 'One talk to rule them all',
+                'description' => 'Two is fine too',
+                'type' => 'regular',
+                'level' => 'entry',
+                'category' => 'api',
+            ]
+        );
+
+        $talk->create(
+            [
+                'user_id' => 1,
+                'title' => 'My second talk',
+                'description' => 'I told you two is fine',
+                'type' => 'regular',
+                'level' => 'entry',
+                'category' => 'api',
+            ]
+        );
+
+        $talk->create(
+            [
+                'user_id' => 1,
+                'title' => 'Third times a charm',
+                'description' => 'But you cant be too sure ',
+                'type' => 'regular',
+                'level' => 'entry',
+                'category' => 'api',
+            ]
+        );
+
+        $talk->create(
+            [
+                'user_id' => 1,
+                'title' => 'Lets do one more',
+                'description' => 'You know, just in case',
+                'type' => 'regular',
+                'level' => 'entry',
+                'category' => 'api',
+            ]
+        );
+    }
+}

--- a/tests/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Http/Controller/Admin/DashboardControllerTest.php
@@ -37,7 +37,7 @@ class DashboardControllerTest extends TestCase
         /**
          * Mocking for the user and Favorite models is done with overload: and full namespaces.
          * This is to force mockery to override the ones generated with the new keyword as well.
-         * We can't use them in the top of the file like normal classes either as that messes with the magic.
+         * We can't make use of the 'use' keyword to import them since that messes with the magic.
          */
         $userMock = m::mock('overload:' . \OpenCFP\Domain\Model\User::class);
         $userMock->shouldReceive('all->count')->andReturn('1');

--- a/tests/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Http/Controller/Admin/DashboardControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace OpenCFP\Test\Http\Controller\Admin;
+
+use Cartalyst\Sentry\Users\UserInterface;
+use Mockery as m;
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Test\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ *
+ * These slow down the tests a bit, but it is required for our overrides to work.
+ */
+class DashboardControllerTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function indexDisplaysListOfTalks()
+    {
+        // Set things up so Sentry believes we're logged in
+        $user = m::mock(UserInterface::class);
+        $user->shouldReceive('id')->andReturn(1);
+        $user->shouldReceive('getId')->andReturn(1);
+        $user->shouldReceive('hasAccess')->with('admin')->andReturn(true);
+        $user->shouldReceive('hasPermission')->with('admin')->andReturn(true);
+
+        // Create a test double for Sentry
+        $auth = m::mock(Authentication::class);
+        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('user')->andReturn($user);
+        $this->swap(Authentication::class, $auth);
+
+        /**
+         * Mocking for the user and Favorite models is done with overload: and full namespaces.
+         * This is to force mockery to override the ones generated with the new keyword as well.
+         * We can't use them in the top of the file like normal classes either as that messes with the magic.
+         */
+        $userMock = m::mock('overload:' . \OpenCFP\Domain\Model\User::class);
+        $userMock->shouldReceive('all->count')->andReturn('1');
+        $this->swap(\OpenCFP\Domain\Model\User::class, $userMock);
+
+        $favoriteMock = m::mock('overload:' . \OpenCFP\Domain\Model\Favorite::class);
+        $favoriteMock->shouldReceive('all->count')->andReturn('1');
+        $this->swap(\OpenCFP\Domain\Model\User::class, $favoriteMock);
+        $this->swap(\OpenCFP\Domain\Model\Favorite::class, $favoriteMock);
+
+        $this->talkListMock();
+
+        $this->get('/admin')
+            ->assertSuccessful()
+            ->assertSee('First Talk')
+            ->assertSee('The bug slayer strikes again!')
+            ->assertSee('The Bug Slayer')
+            ->assertSee('<h2>10</h2>');
+    }
+
+    /**
+     * Helper function that mocks a few talks for us.
+     */
+    private function talkListMock()
+    {
+        $talk = m::mock('overload:' . \OpenCFP\Domain\Model\Talk::class);
+        $talk->shouldReceive('all')->andReturn($talk);
+        $talk->shouldReceive('count')->andReturn(10);
+        $talk->shouldReceive('where')->andReturn($talk);
+        $talk->shouldReceive('getRecent')->andReturn([
+            [
+                'id' => 1,
+                'title' => 'First Talk',
+                'type' => 'regular',
+                'category' => 'api',
+                'created_at' => new \DateTime(),
+                'user' => [
+                    'id' => 1,
+                    'first_name' => 'Speaker',
+                    'last_name' => 'Name',
+                ],
+                'meta' => [
+                    'rating' => 0,
+                ],
+                'favorite' => 0,
+                'selected' => 0,
+            ],
+            [
+                'id' => 2,
+                'title' => 'The bug slayer strikes again!',
+                'type' => 'regular',
+                'category' => 'api',
+                'created_at' => new \DateTime(),
+                'user' => [
+                    'id' => 1,
+                    'first_name' => 'Daan',
+                    'last_name' => 'The Bug Slayer',
+                ],
+                'meta' => [
+                    'rating' => 0,
+                ],
+                'favorite' => 0,
+                'selected' => 1,
+            ],
+        ]);
+        $this->swap(\OpenCFP\Domain\Model\Talk::class, $talk);
+    }
+}


### PR DESCRIPTION
Related to #506.

This PR replaces all usage of spot in the admin dashboard controller with Illuminate Database models.
It also adds tests for this controller, and for the home made functions in the models.

Some small things besides that:
* Removed the Request object from the index function, since that was not used.
* Added an empty ```$guarded``` array to some models, so we can use the create() functionality.

To use the beginTransaction and rollBack functions you need to do so on the Capsule object in order for it to work
