### PR TITLE
Fix active navigation class

### DIFF
--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -10,6 +10,7 @@ use Silex\Application;
 use Silex\ControllerCollection;
 use Symfony\Component\HttpFoundation\Request;
 use Twig_Environment;
+use Twig_SimpleFunction;
 
 class WebGatewayProvider implements BootableProviderInterface, ServiceProviderInterface
 {
@@ -27,10 +28,12 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
             /* @var Twig_Environment $twig */
             $twig = $app['twig'];
 
-            $twig->addGlobal('current_page', function () use ($app) {
-                return $app['request']->getRequestUri();
-            });
-            $twig->addGlobal('cfp_open', strtotime('now') < strtotime($app->config('application.enddate') . ' 11:59 PM'));
+            $twig->addGlobal('current_page', $request->getRequestUri());
+            $twig->addGlobal('cfp_open', $app['callforproposal']->isOpen());
+
+            $twig->addFunction(new Twig_SimpleFunction('active', function ($route) use ($app, $request) {
+                return $app['url_generator']->generate($route) == $request->getRequestUri();
+            }));
 
             // Authentication
             if ($app[Authentication::class]->check()) {

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -7,6 +7,7 @@ use OpenCFP\Http\View\TalkHelper;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Silex\Provider\TwigServiceProvider as SilexTwigServiceProvider;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 use Twig_Extension_Debug;
 use Twig_SimpleFunction;
@@ -45,12 +46,6 @@ class TwigServiceProvider implements ServiceProviderInterface
             $twig->addFunction(new Twig_SimpleFunction('assets', function ($path) {
                 return '/assets/' . $path;
             }));
-
-            $twig->addGlobal('current_page', function () use ($app) {
-                return $app['request']->getRequestUri();
-            });
-
-            $twig->addGlobal('cfp_open', $app['callforproposal']->isOpen());
 
             $twig->addGlobal('site', $app->config('application'));
 

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -7,7 +7,6 @@ use OpenCFP\Http\View\TalkHelper;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Silex\Provider\TwigServiceProvider as SilexTwigServiceProvider;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 use Twig_Extension_Debug;
 use Twig_SimpleFunction;

--- a/templates/layouts/admin.twig
+++ b/templates/layouts/admin.twig
@@ -23,14 +23,14 @@
             <div class="collapse navbar-collapse">
                 {% block navigation %}
                     <ul class="nav navbar-nav navbar-right">
-                        <li{% if path('speaker_package') == current_page %} class="active"{% endif %}><a href="{{ url('speaker_package') }}">Speaker Package</a></li>
-                        <li{% if path('talk_ideas') == current_page %} class="active"{% endif %}><a href="{{ url('talk_ideas') }}">Talk Ideas</a></li>
-                        <li{% if path('dashboard') == current_page %} class="active"{% endif %}><a href="{{ url('dashboard') }}">Dashboard</a></li>
-                        <li class="{% if path('admin') == current_page %}active{% endif %} hidden-xs">
+                        <li{% if active('speaker_package') %} class="active"{% endif %}><a href="{{ url('speaker_package') }}">Speaker Package</a></li>
+                        <li{% if active('talk_ideas') %} class="active"{% endif %}><a href="{{ url('talk_ideas') }}">Talk Ideas</a></li>
+                        <li{% if active('dashboard') %} class="active"{% endif %}><a href="{{ url('dashboard') }}">Dashboard</a></li>
+                        <li class="{% if active('admin') %}active{% endif %} hidden-xs">
                             <a href="{{ url('admin') }}">Admin</a>
                         </li>
                         <li class="dropdown visible-xs">
-                            <a href="#" class="{% if path('admin') == current_page %}active{% endif %} dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Admin <span class="caret"></span></a>
+                            <a href="#" class="{% if active('admin') %}active{% endif %} dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Admin <span class="caret"></span></a>
                             <ul class="dropdown-menu">
                                 <li><a href="{{ url('admin') }}">Admin</a></li>
                                 <li><a href="{{ url('admin_speakers') }}">Speakers</a></li>

--- a/templates/layouts/dashboard-nowrap.twig
+++ b/templates/layouts/dashboard-nowrap.twig
@@ -23,8 +23,8 @@
             <div class="collapse navbar-collapse">
                 {% block navigation %}
                     <ul class="nav navbar-nav navbar-right">
-                        <li{% if path('speaker_package') == current_page %} class="active"{% endif %}><a href="{{ url('speaker_package') }}">Speaker Package</a></li>
-                        <li{% if path('talk_ideas') == current_page %} class="active"{% endif %}><a href="{{ url('talk_ideas') }}">Talk Ideas</a></li>
+                        <li{% if active('speaker_package') %} class="active"{% endif %}><a href="{{ url('speaker_package') }}">Speaker Package</a></li>
+                        <li{% if active('talk_ideas') %} class="active"{% endif %}><a href="{{ url('talk_ideas') }}">Talk Ideas</a></li>
                         {% if user is defined and user is not empty %}
                             <li><a href="{{ url('dashboard') }}">Dashboard</a></li>
                             {% if user_is_admin %}

--- a/templates/layouts/dashboard.twig
+++ b/templates/layouts/dashboard.twig
@@ -23,11 +23,11 @@
             <div class="collapse navbar-collapse">
                 {% block navigation %}
                     <ul class="nav navbar-nav navbar-right">
-                        <li{% if path('speaker_package') == current_page %} class="active"{% endif %}><a href="{{ url('speaker_package') }}">Speaker Package</a></li>
-                        <li{% if path('talk_ideas') == current_page %} class="active"{% endif %}><a href="{{ url('talk_ideas') }}">Talk Ideas</a></li>
+                        <li{% if active('speaker_package') %} class="active"{% endif %}><a href="{{ url('speaker_package') }}">Speaker Package</a></li>
+                        <li{% if active('talk_ideas') %} class="active"{% endif %}><a href="{{ url('talk_ideas') }}">Talk Ideas</a></li>
 
                         {% if user is defined and user is not empty %}
-                            <li{% if path('dashboard') == current_page %} class="active"{% endif %}><a href="{{ url('dashboard') }}">Dashboard</a></li>
+                            <li{% if active('dashboard') %} class="active"{% endif %}><a href="{{ url('dashboard') }}">Dashboard</a></li>
                             {% if user_is_admin %}
                                 <li><a href="{{ url('admin') }}">Admin</a></li>
                             {% endif %}

--- a/templates/layouts/default.twig
+++ b/templates/layouts/default.twig
@@ -25,8 +25,8 @@
             <div class="collapse navbar-collapse">
                 {% block navigation %}
                     <ul class="nav navbar-nav navbar-right">
-                        <li{% if path('speaker_package') == current_page %} class="active"{% endif %}><a href="{{ url('speaker_package') }}">Speaker Package</a></li>
-                        <li{% if path('talk_ideas') == current_page %} class="active"{% endif %}><a href="{{ url('talk_ideas') }}">Talk Ideas</a></li>
+                        <li{% if active('speaker_package') %} class="active"{% endif %}><a href="{{ url('speaker_package') }}">Speaker Package</a></li>
+                        <li{% if active('talk_ideas') %} class="active"{% endif %}><a href="{{ url('talk_ideas') }}">Talk Ideas</a></li>
                         {% if user is defined and user is not empty %}
                             <li><a href="{{ url('dashboard') }}">Dashboard</a></li>
                             {% if user_is_admin %}


### PR DESCRIPTION
This PR

* [x] Corrects an issue where `current_page` returned a closure that when compared against the current `path($route)`, always evaluated as false, leaving the active CSS class for navigation items never applied.
* [x] Removes duplicate global registrations from service providers (Twig and WebGateway)

I'm working on a Sass-based restyling of the application and in the process of simplifying our templates / markup, came across this bug present on `master`.

**Before**

![image](https://user-images.githubusercontent.com/2453394/31579832-053eb29e-b10d-11e7-8b5f-d2cacf11fffd.png)

**After**

![image](https://user-images.githubusercontent.com/2453394/31579828-f24723c4-b10c-11e7-9015-c31af1842853.png)
