### PR TITLE
Failed login throws 500 error

### DIFF
--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -33,7 +33,7 @@ class SecurityController extends BaseController
             }
 
             return $this->redirectTo('dashboard');
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',


### PR DESCRIPTION
A failed login was not catching all the exceptions correctly and thus throwing a 500 error instead of a nice error message; this fixes that problem
