### PR TITLE
Fix csv issues

### DIFF
--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -85,6 +85,31 @@ class ExportsController extends BaseController
         return $this->csvReturn($talks, $filename);
     }
 
+    /**
+     * Adds a ' in front of items that start with =,+,- or @
+     * This stops the cell from being executed as a formula in excel/google sheets etc.
+     *
+     * @param string $info
+     * @return string
+     */
+    private function csvFormat($info)
+    {
+        if ($this->startsWith($info, '=')
+                || $this->startsWith($info, '+')
+                || $this->startsWith($info, '-')
+                || $this->startsWith($info, '@')
+            ) {
+            $info = "'". $info;
+        }
+        return $info;
+    }
+
+    private function startsWith($haystack, $needle)
+    {
+        $length = strlen($needle);
+        return (substr($haystack, 0, $length) === $needle);
+    }
+
     private function csvReturn($contents, $filename = 'data')
     {
         if (count($contents) === 0) {
@@ -108,7 +133,9 @@ class ExportsController extends BaseController
 
         fputcsv($output, array_keys($contents[0]));
 
-        foreach ($contents as $i => $content) {
+        foreach ($contents as $content) {
+            $content = array_map([$this,'csvFormat'], $content);
+
             fputcsv($output, array_values($content));
         }
 


### PR DESCRIPTION
**Steps required to reproduce the problem**

1. Create a talk
2. Make the description an excel executable formula like =2+3
3. Export csv of talks

**Expected Result**

* The cell with the talk description displays =2+3

**Actual Result**

* The cell displays 5

This particular instance isn't anything bad, but as detailed here: https://www.contextis.com/blog/comma-separated-vulnerabilities this could be used for all sorts of malpractice.

This fixes the issue by adding a ' in front of all cells that start with any of  ```= - + @``` to stop the formulas from executing

cc: @chartjes 
