### PR TITLE
Move talk formatting to a new class

### DIFF
--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Domain\Entity\Mapper;
 
+use OpenCFP\Domain\Services\TalkFormatter;
 use Spot\Mapper;
 
 class Talk extends Mapper
@@ -414,62 +415,8 @@ class Talk extends Mapper
      */
     public function createdFormattedOutput($talk, $admin_user_id, $userData = true)
     {
-        if ($talk->favorites) {
-            foreach ($talk->favorites as $favorite) {
-                if ($favorite->admin_user_id == $admin_user_id) {
-                    $talk->favorite = 1;
-                }
-            }
-        }
-
-        $mapper = $this->getMapper(\OpenCFP\Domain\Entity\TalkMeta::class);
-        $talk_meta = $mapper->where(['talk_id' => $talk->id, 'admin_user_id' => $admin_user_id])
-            ->first();
-
-        $output = [
-            'id' => $talk->id,
-            'title' => $talk->title,
-            'type' => $talk->type,
-            'category' => $talk->category,
-            'created_at' => $talk->created_at,
-            'selected' => $talk->selected,
-            'favorite' => $talk->favorite,
-            'meta' => $talk_meta ?: $mapper->get(),
-            'description' => $talk->description,
-            'slides' => $talk->slides,
-            'other' => $talk->other,
-            'level' => $talk->level,
-            'desired' => $talk->desired,
-            'sponsor' => $talk->sponsor,
-        ];
-
-        if ($talk->speaker && $userData) {
-            $output['user'] = [
-                'id' => $talk->speaker->id,
-                'first_name' => $talk->speaker->first_name,
-                'last_name' => $talk->speaker->last_name,
-            ];
-
-            $output += [
-                'speaker_id' => $talk->speaker->id,
-                'speaker_first_name' => $talk->speaker->first_name,
-                'speaker_last_name' => $talk->speaker->last_name,
-                'speaker_email' => $talk->speaker->email,
-                'speaker_company' => $talk->speaker->company,
-                'speaker_twitter' => $talk->speaker->twitter,
-                'speaker_airport' => $talk->speaker->airport,
-                'speaker_hotel' => $talk->speaker->hotel,
-                'speaker_transportation' => $talk->speaker->transportation,
-                'speaker_info' => $talk->speaker->info,
-                'speaker_bio' => $talk->speaker->bio,
-            ];
-        }
-
-        if ($talk->total_rating) {
-            $output['total_rating'] = $talk->total_rating;
-            $output['review_count'] = $talk->review_count;
-        }
-
+        $format = new TalkFormatter();
+        $output = $format->createdFormattedOutput($talk, $admin_user_id, $userData);
         return $output;
     }
 

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Domain\Entity\Mapper;
 
-use OpenCFP\Domain\Services\TalkFormatter;
+use OpenCFP\Domain\Talk\TalkFormatter;
 use Spot\Mapper;
 
 class Talk extends Mapper

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -3,7 +3,6 @@
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Builder;
-use OpenCFP\Domain\Services\TalkFormatter;
 
 class Talk extends Eloquent
 {
@@ -40,19 +39,5 @@ class Talk extends Eloquent
             ->orderBy('created_at')
             ->with(['favorites', 'meta'])
             ->take($limit);
-    }
-    /**
-     * Iterates over DBAL objects and returns a formatted result set
-     *
-     * @param  mixed   $talk
-     * @param  integer $admin_user_id
-     * @return array
-     */
-    public function createdFormattedOutput($talk, $admin_user_id, $userData = true)
-    {
-        $format = new TalkFormatter();
-        $output = $format->createdFormattedOutput($talk, $admin_user_id, $userData);
-
-        return $output;
     }
 }

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Builder;
+use OpenCFP\Domain\Services\TalkFormatter;
 
 class Talk extends Eloquent
 {
@@ -55,55 +56,9 @@ class Talk extends Eloquent
      */
     public function createdFormattedOutput($talk, $admin_user_id, $userData = true)
     {
-        if ($talk->favorites) {
-            foreach ($talk->favorites as $favorite) {
-                if ($favorite->admin_user_id == $admin_user_id) {
-                    $talk->favorite = 1;
-                }
-            }
-        }
-        $meta = $talk->meta->where('admin_user_id', $admin_user_id)->first();
+        $format = new TalkFormatter();
+        $output = $format->createdFormattedOutput($talk, $admin_user_id, $userData);
 
-        $output = [
-            'id' => $talk->id,
-            'title' => $talk->title,
-            'type' => $talk->type,
-            'category' => $talk->category,
-            'created_at' => $talk->created_at,
-            'selected' => $talk->selected,
-            'favorite' => $talk->favorite,
-            'meta' => $meta ?: ['rating' => 0, 'viewed' => 0],
-            'description' => $talk->description,
-            'slides' => $talk->slides,
-            'other' => $talk->other,
-            'level' => $talk->level,
-            'desired' => $talk->desired,
-            'sponsor' => $talk->sponsor,
-        ];
-        if ($talk->speaker && $userData) {
-            $output['user'] = [
-                'id' => $talk->speaker->id,
-                'first_name' => $talk->speaker->first_name,
-                'last_name' => $talk->speaker->last_name,
-            ];
-            $output += [
-                'speaker_id' => $talk->speaker->id,
-                'speaker_first_name' => $talk->speaker->first_name,
-                'speaker_last_name' => $talk->speaker->last_name,
-                'speaker_email' => $talk->speaker->email,
-                'speaker_company' => $talk->speaker->company,
-                'speaker_twitter' => $talk->speaker->twitter,
-                'speaker_airport' => $talk->speaker->airport,
-                'speaker_hotel' => $talk->speaker->hotel,
-                'speaker_transportation' => $talk->speaker->transportation,
-                'speaker_info' => $talk->speaker->info,
-                'speaker_bio' => $talk->speaker->bio,
-            ];
-        }
-        if ($talk->total_rating) {
-            $output['total_rating'] = $talk->total_rating;
-            $output['review_count'] = $talk->review_count;
-        }
         return $output;
     }
 }

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -28,24 +28,18 @@ class Talk extends Eloquent
     }
 
     /**
-     * Return a collection of recent talks
+     * Returns the most recent talks
      *
      * @param Builder $query
-     * @param         $admin_id
-     * @param int     $limit
-     *
-     * @return array|Talk[]
+     * @param int $limit
+     * @return \Illuminate\Database\Query\Builder|static
      */
-    public function scopeRecent(Builder $query, $admin_id, $limit = 10)
+    public function scopeRecent(Builder $query, $limit = 10)
     {
         return $query
             ->orderBy('created_at')
             ->with(['favorites', 'meta'])
-            ->take($limit)
-            ->get()
-            ->map(function ($talk) use ($admin_id) {
-                return $this->createdFormattedOutput($talk, $admin_id);
-            });
+            ->take($limit);
     }
     /**
      * Iterates over DBAL objects and returns a formatted result set

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -29,11 +29,9 @@ class Talk extends Eloquent
     /**
      * Returns the most recent talks
      *
-     * @param Builder $query
-     * @param int $limit
-     * @return \Illuminate\Database\Query\Builder|static
+     * @param int $limit maximum ammount of entries to return.
      */
-    public function scopeRecent(Builder $query, $limit = 10)
+    public function scopeRecent(Builder $query, int $limit = 10) : Builder
     {
         return $query
             ->orderBy('created_at')

--- a/classes/Domain/Services/TalkFormat.php
+++ b/classes/Domain/Services/TalkFormat.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OpenCFP\Domain\Services;
+
+use Illuminate\Support\Collection;
+
+interface TalkFormat
+{
+    public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true) : Collection;
+
+    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true) : array;
+}

--- a/classes/Domain/Services/TalkFormatter.php
+++ b/classes/Domain/Services/TalkFormatter.php
@@ -2,29 +2,26 @@
 
 namespace OpenCFP\Domain\Services;
 
+use Illuminate\Database\Eloquent\Collection;
 use OpenCFP\Domain\Entity\Talk as TalkEntity;
 use OpenCFP\Domain\Model\Talk as TalkModel;
 use OpenCFP\Domain\Model\TalkMeta;
 
 class TalkFormatter
 {
-
     /**
-     * Grabs the related meta information of the talk, or 0's when there is none
+     * @param Collection $talkCollection Collection of Talks
+     * @param integer $admin_user_id
+     * @param bool $userData
      *
-     * @param TalkModel|TalkEntity $talk Talk that we want the meta information off
-     * @param int $admin_user_id user di
-     * @return array|TalkMeta
+     * @return array|Collection
      */
-    protected function getTalkMeta($talk, $admin_user_id)
+    public function formatList($talkCollection, $admin_user_id, $userData = true)
     {
-        $meta = TalkMeta::where('talk_id', $talk->id)->where('admin_user_id', $admin_user_id)->first();
-
-        if ($meta instanceof TalkMeta) {
-            return $meta;
-        }
-
-        return ['rating' => 0, 'viewed' => 0];
+        return $talkCollection
+            ->map(function ($talk) use ($admin_user_id,$userData) {
+                return $this->createdFormattedOutput($talk, $admin_user_id, $userData);
+            });
     }
 
     /**
@@ -91,5 +88,23 @@ class TalkFormatter
         }
 
         return $output;
+    }
+
+    /**
+     * Grabs the related meta information of the talk, or 0's when there is none
+     *
+     * @param TalkModel|TalkEntity $talk Talk that we want the meta information off
+     * @param int $admin_user_id user di
+     * @return array|TalkMeta
+     */
+    protected function getTalkMeta($talk, $admin_user_id)
+    {
+        $meta = TalkMeta::where('talk_id', $talk->id)->where('admin_user_id', $admin_user_id)->first();
+
+        if ($meta instanceof TalkMeta) {
+            return $meta;
+        }
+
+        return ['rating' => 0, 'viewed' => 0];
     }
 }

--- a/classes/Domain/Services/TalkFormatter.php
+++ b/classes/Domain/Services/TalkFormatter.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace OpenCFP\Domain\Services;
+
+use OpenCFP\Domain\Entity\Talk as TalkEntity;
+use OpenCFP\Domain\Model\Talk as TalkModel;
+use OpenCFP\Domain\Model\TalkMeta;
+
+class TalkFormatter
+{
+
+    /**
+     * Grabs the related meta information of the talk, or 0's when there is none
+     *
+     * @param TalkModel|TalkEntity $talk Talk that we want the meta information off
+     * @param int $admin_user_id user di
+     * @return array|TalkMeta
+     */
+    protected function getTalkMeta($talk, $admin_user_id)
+    {
+        $meta = TalkMeta::where('talk_id', $talk->id)->where('admin_user_id', $admin_user_id)->first();
+
+        if ($meta instanceof TalkMeta) {
+            return $meta;
+        }
+
+        return ['rating' => 0, 'viewed' => 0];
+    }
+
+    /**
+     * Iterates over DBAL objects and returns a formatted result set
+     *
+     * @param  mixed $talk
+     * @param  integer $admin_user_id
+     * @param bool $userData grab the speaker data or not
+     * @return array
+     */
+    public function createdFormattedOutput($talk, $admin_user_id, $userData = true)
+    {
+        if ($talk->favorites) {
+            foreach ($talk->favorites as $favorite) {
+                if ($favorite->admin_user_id == $admin_user_id) {
+                    $talk->favorite = 1;
+                }
+            }
+        }
+        $meta = $this->getTalkMeta($talk, $admin_user_id);
+
+        $output = [
+            'id' => $talk->id,
+            'title' => $talk->title,
+            'type' => $talk->type,
+            'category' => $talk->category,
+            'created_at' => $talk->created_at,
+            'selected' => $talk->selected,
+            'favorite' => $talk->favorite,
+            'meta' => $meta,
+            'description' => $talk->description,
+            'slides' => $talk->slides,
+            'other' => $talk->other,
+            'level' => $talk->level,
+            'desired' => $talk->desired,
+            'sponsor' => $talk->sponsor,
+        ];
+
+        if ($talk->speaker && $userData) {
+            $output['user'] = [
+                'id' => $talk->speaker->id,
+                'first_name' => $talk->speaker->first_name,
+                'last_name' => $talk->speaker->last_name,
+            ];
+
+            $output += [
+                'speaker_id' => $talk->speaker->id,
+                'speaker_first_name' => $talk->speaker->first_name,
+                'speaker_last_name' => $talk->speaker->last_name,
+                'speaker_email' => $talk->speaker->email,
+                'speaker_company' => $talk->speaker->company,
+                'speaker_twitter' => $talk->speaker->twitter,
+                'speaker_airport' => $talk->speaker->airport,
+                'speaker_hotel' => $talk->speaker->hotel,
+                'speaker_transportation' => $talk->speaker->transportation,
+                'speaker_info' => $talk->speaker->info,
+                'speaker_bio' => $talk->speaker->bio,
+            ];
+        }
+
+        if ($talk->total_rating) {
+            $output['total_rating'] = $talk->total_rating;
+            $output['review_count'] = $talk->review_count;
+        }
+
+        return $output;
+    }
+}

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -1,25 +1,25 @@
 <?php
 
-namespace OpenCFP\Domain\Services;
+namespace OpenCFP\Domain\Talk;
 
-use Illuminate\Database\Eloquent\Collection;
-use OpenCFP\Domain\Entity\Talk as TalkEntity;
-use OpenCFP\Domain\Model\Talk as TalkModel;
+use Illuminate\Support\Collection;
 use OpenCFP\Domain\Model\TalkMeta;
+use OpenCFP\Domain\Services\TalkFormat;
 
-class TalkFormatter
+class TalkFormatter implements TalkFormat
 {
     /**
+     * Iterates over a collection of DBAL objects and returns a formatted result set
+     *
      * @param Collection $talkCollection Collection of Talks
      * @param integer $admin_user_id
      * @param bool $userData
-     *
-     * @return array|Collection
+     * @return Collection
      */
-    public function formatList($talkCollection, $admin_user_id, $userData = true)
+    public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true) : Collection
     {
         return $talkCollection
-            ->map(function ($talk) use ($admin_user_id,$userData) {
+            ->map(function ($talk) use ($admin_user_id, $userData) {
                 return $this->createdFormattedOutput($talk, $admin_user_id, $userData);
             });
     }
@@ -27,12 +27,12 @@ class TalkFormatter
     /**
      * Iterates over DBAL objects and returns a formatted result set
      *
-     * @param  mixed $talk
-     * @param  integer $admin_user_id
+     * @param mixed $talk
+     * @param integer $admin_user_id
      * @param bool $userData grab the speaker data or not
      * @return array
      */
-    public function createdFormattedOutput($talk, $admin_user_id, $userData = true)
+    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true) : array
     {
         if ($talk->favorites) {
             foreach ($talk->favorites as $favorite) {
@@ -93,11 +93,12 @@ class TalkFormatter
     /**
      * Grabs the related meta information of the talk, or 0's when there is none
      *
-     * @param TalkModel|TalkEntity $talk Talk that we want the meta information off
-     * @param int $admin_user_id user di
-     * @return array|TalkMeta
+     * @param mixed $talk Talk we want to get the meta of, both entity and model work.
+     * @param int $admin_user_id user ID of the admin
+     *
+     * @return TalkMeta
      */
-    protected function getTalkMeta($talk, $admin_user_id)
+    protected function getTalkMeta($talk, int $admin_user_id) : TalkMeta
     {
         $meta = TalkMeta::where('talk_id', $talk->id)->where('admin_user_id', $admin_user_id)->first();
 
@@ -105,6 +106,6 @@ class TalkFormatter
             return $meta;
         }
 
-        return ['rating' => 0, 'viewed' => 0];
+        return new TalkMeta(['rating' => 0, 'viewed' => 0]);
     }
 }

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -2,10 +2,12 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use Illuminate\Database\Eloquent\Collection;
 use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\TalkFormatter;
 use OpenCFP\Http\Controller\BaseController;
 
 class DashboardController extends BaseController
@@ -18,8 +20,12 @@ class DashboardController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $user = $this->service(Authentication::class)->user();
-        $recent_talks = Talk::recent($user->getId());
+        $userId = $this->service(Authentication::class)->userId();
+        $talkFormatter = new TalkFormatter();
+
+        /** @var Collection $recent_talks */
+        $recent_talks = Talk::recent()->get();
+        $recent_talks = $talkFormatter->formatList($recent_talks, $userId);
 
         $templateData = [
             'speakerTotal' => User::count(),

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -7,7 +7,7 @@ use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Authentication;
-use OpenCFP\Domain\Services\TalkFormatter;
+use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Http\Controller\BaseController;
 
 class DashboardController extends BaseController

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -3,8 +3,6 @@
 namespace OpenCFP\Test\Domain\Model;
 
 use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Domain\Model\TalkMeta;
-use OpenCFP\Domain\Services\TalkFormatter;
 use OpenCFP\Test\DatabaseTestCase;
 
 /**
@@ -20,119 +18,5 @@ class TalkTest extends DatabaseTestCase
 
         $this->assertCount(10, Talk::recent()->get());
         $this->assertCount(3, Talk::recent(3)->get());
-    }
-
-    /**
-     * @test
-     */
-    public function createFormattedOutputWorksWithNoMeta()
-    {
-        $this->generateOneTalk();
-        $talk = new Talk;
-        $formatter = new TalkFormatter();
-
-        $format =$formatter->createdFormattedOutput($talk->first(), 1);
-
-        $this->assertEquals('One talk to rule them all', $format['title']);
-        $this->assertEquals('api', $format['category']);
-        $this->assertEquals(['rating' => 0, 'viewed' => 0], $format['meta']);
-        $this->assertTrue(!isset($format['user']));
-    }
-
-    /**
-     * @test
-     */
-    public function createFormattedOutputWorksWithMeta()
-    {
-        $this->generateOneTalk();
-        $formatter = new TalkFormatter();
-        $talk = new Talk;
-
-        // Now to see if the meta gets put in correctly
-        $secondFormat =$formatter->createdFormattedOutput($talk->first(), 2);
-
-        $this->assertEquals(1, $secondFormat['meta']->rating);
-        $this->assertEquals(1, $secondFormat['meta']->viewed);
-    }
-
-
-    private function generateOneTalk()
-    {
-        $talk = new Talk();
-
-        $talk->create(
-            [
-                'user_id' => 1,
-                'title' => 'One talk to rule them all',
-                'description' => 'Two is fine too',
-                'type' => 'regular',
-                'level' => 'entry',
-                'category' => 'api',
-            ]
-        );
-
-        $meta = new TalkMeta();
-        $meta->create(
-            [
-                'admin_user_id' => 2,
-                'rating' => 1,
-                'viewed' => 1,
-                'talk_id' => $talk->first()->id,
-                'created' => new \DateTime(),
-            ]
-        );
-    }
-
-
-    /**
-     * Helper function that generates some talks for us
-     */
-    private function generateTalks()
-    {
-        $talk = new Talk();
-
-        $talk->create(
-            [
-                'user_id' => 1,
-                'title' => 'One talk to rule them all',
-                'description' => 'Two is fine too',
-                'type' => 'regular',
-                'level' => 'entry',
-                'category' => 'api',
-            ]
-        );
-
-        $talk->create(
-            [
-                'user_id' => 1,
-                'title' => 'My second talk',
-                'description' => 'I told you two is fine',
-                'type' => 'regular',
-                'level' => 'entry',
-                'category' => 'api',
-            ]
-        );
-
-        $talk->create(
-            [
-                'user_id' => 1,
-                'title' => 'Third times a charm',
-                'description' => 'But you cant be too sure ',
-                'type' => 'regular',
-                'level' => 'entry',
-                'category' => 'api',
-            ]
-        );
-
-        $talk->create(
-            [
-                'user_id' => 1,
-                'title' => 'Lets do one more',
-                'description' => 'You know, just in case',
-                'type' => 'regular',
-                'level' => 'entry',
-                'category' => 'api',
-            ]
-        );
     }
 }

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -4,7 +4,7 @@ namespace OpenCFP\Test\Domain\Model;
 
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
-use OpenCFP\Domain\Model\User;
+use OpenCFP\Domain\Services\TalkFormatter;
 use OpenCFP\Test\DatabaseTestCase;
 
 /**
@@ -29,7 +29,9 @@ class TalkTest extends DatabaseTestCase
     {
         $this->generateOneTalk();
         $talk = new Talk;
-        $format =$talk->createdFormattedOutput($talk->first(), 1);
+        $formatter = new TalkFormatter();
+
+        $format =$formatter->createdFormattedOutput($talk->first(), 1);
 
         $this->assertEquals('One talk to rule them all', $format['title']);
         $this->assertEquals('api', $format['category']);
@@ -43,10 +45,11 @@ class TalkTest extends DatabaseTestCase
     public function createFormattedOutputWorksWithMeta()
     {
         $this->generateOneTalk();
+        $formatter = new TalkFormatter();
         $talk = new Talk;
 
         // Now to see if the meta gets put in correctly
-        $secondFormat =$talk->createdFormattedOutput($talk->first(), 2);
+        $secondFormat =$formatter->createdFormattedOutput($talk->first(), 2);
 
         $this->assertEquals(1, $secondFormat['meta']->rating);
         $this->assertEquals(1, $secondFormat['meta']->viewed);

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -18,8 +18,8 @@ class TalkTest extends DatabaseTestCase
     {
         factory(Talk::class, 10)->create();
 
-        $this->assertCount(10, Talk::recent(1));
-        $this->assertCount(3, Talk::recent(1, 3));
+        $this->assertCount(10, Talk::recent()->get());
+        $this->assertCount(3, Talk::recent(3)->get());
     }
 
     /**

--- a/tests/Domain/Services/TalkFormatterTest.php
+++ b/tests/Domain/Services/TalkFormatterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace OpenCFP\Test\Domain\Services;
+
+use Illuminate\Support\Collection;
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\TalkMeta;
+use OpenCFP\Domain\Talk\TalkFormatter;
+use OpenCFP\Test\DatabaseTestCase;
+
+/**
+ * @group db
+ */
+class TalkFormatterTest extends DatabaseTestCase
+{
+    /**
+     * @test
+     */
+    public function createFormattedOutputWorksWithNoMeta()
+    {
+        $this->generateOneTalk();
+        $talk = new Talk;
+        $formatter = new TalkFormatter();
+
+        $format =$formatter->createdFormattedOutput($talk->first(), 1);
+
+        $this->assertEquals('One talk to rule them all', $format['title']);
+        $this->assertEquals('api', $format['category']);
+        $this->assertEquals(0, $format['meta']->rating);
+        $this->assertEquals(0, $format['meta']->viewed);
+        $this->assertTrue(!isset($format['user']));
+    }
+
+    /**
+     * @test
+     */
+    public function createFormattedOutputWorksWithMeta()
+    {
+        $this->generateOneTalk();
+        $formatter = new TalkFormatter();
+        $talk = new Talk;
+
+        // Now to see if the meta gets put in correctly
+        $secondFormat =$formatter->createdFormattedOutput($talk->first(), 2);
+
+        $this->assertEquals(1, $secondFormat['meta']->rating);
+        $this->assertEquals(1, $secondFormat['meta']->viewed);
+    }
+
+    /**
+     * @test
+     */
+    public function formatListReturnsAllTalksAsCollection()
+    {
+        factory(Talk::class, 10)->create();
+
+        $formatter = new TalkFormatter();
+        $talks = Talk::all();
+        $formatted = $formatter->formatList($talks, 2);
+        $this->assertEquals(count($talks), count($formatted));
+        $this->assertInstanceOf(Collection::class, $formatted);
+    }
+
+
+    private function generateOneTalk()
+    {
+        $talk = new Talk();
+
+        $talk->create(
+            [
+                'user_id' => 1,
+                'title' => 'One talk to rule them all',
+                'description' => 'Two is fine too',
+                'type' => 'regular',
+                'level' => 'entry',
+                'category' => 'api',
+            ]
+        );
+
+        $meta = new TalkMeta();
+        $meta->create(
+            [
+                'admin_user_id' => 2,
+                'rating' => 1,
+                'viewed' => 1,
+                'talk_id' => $talk->first()->id,
+                'created' => new \DateTime(),
+            ]
+        );
+    }
+}

--- a/tests/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Http/Controller/Admin/DashboardControllerTest.php
@@ -32,6 +32,7 @@ class DashboardControllerTest extends TestCase
         $auth = m::mock(Authentication::class);
         $auth->shouldReceive('check')->andReturn(true);
         $auth->shouldReceive('user')->andReturn($user);
+        $auth->shouldReceive('userId')->andReturn(1);
         $this->swap(Authentication::class, $auth);
 
         /**
@@ -45,7 +46,6 @@ class DashboardControllerTest extends TestCase
 
         $favoriteMock = m::mock('overload:' . \OpenCFP\Domain\Model\Favorite::class);
         $favoriteMock->shouldReceive('count')->andReturn('1');
-        $this->swap(\OpenCFP\Domain\Model\User::class, $favoriteMock);
         $this->swap(\OpenCFP\Domain\Model\Favorite::class, $favoriteMock);
 
         $this->talkListMock();
@@ -66,7 +66,10 @@ class DashboardControllerTest extends TestCase
         $talk = m::mock('overload:' . \OpenCFP\Domain\Model\Talk::class);
         $talk->shouldReceive('count')->andReturn(10);
         $talk->shouldReceive('where')->andReturn($talk);
-        $talk->shouldReceive('recent')->andReturn([
+        $talk->shouldReceive('recent->get');
+
+        $formatted = m::mock('overload:' . \OpenCFP\Domain\Services\TalkFormatter::class);
+        $formatted->shouldReceive('formatList')->andReturn([
             [
                 'id' => 1,
                 'title' => 'First Talk',
@@ -102,6 +105,8 @@ class DashboardControllerTest extends TestCase
                 'selected' => 1,
             ],
         ]);
+        $this->swap(\OpenCFP\Domain\Services\TalkFormatter::class, $formatted);
+
         $this->swap(\OpenCFP\Domain\Model\Talk::class, $talk);
     }
 }

--- a/tests/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Http/Controller/Admin/DashboardControllerTest.php
@@ -68,7 +68,7 @@ class DashboardControllerTest extends TestCase
         $talk->shouldReceive('where')->andReturn($talk);
         $talk->shouldReceive('recent->get');
 
-        $formatted = m::mock('overload:' . \OpenCFP\Domain\Services\TalkFormatter::class);
+        $formatted = m::mock('overload:' . \OpenCFP\Domain\Talk\TalkFormatter::class);
         $formatted->shouldReceive('formatList')->andReturn([
             [
                 'id' => 1,
@@ -105,7 +105,7 @@ class DashboardControllerTest extends TestCase
                 'selected' => 1,
             ],
         ]);
-        $this->swap(\OpenCFP\Domain\Services\TalkFormatter::class, $formatted);
+        $this->swap(\OpenCFP\Domain\Talk\TalkFormatter::class, $formatted);
 
         $this->swap(\OpenCFP\Domain\Model\Talk::class, $talk);
     }


### PR DESCRIPTION
This PR moves the createdFormattedOutput function of the model to another class. The version in the talk mapper still exists, but is just used to point to the new function.

I moved the function to a new location in order to keep the models clean, and a bit of separation of concerns. I'm not 100% sure on the names of the class and interface, so feedback is welcome.

I also changed the scopeRecent a little bit to now just return a builder object instead of the formatted array. This is in line with how scopes are intended, and would allow us to chain multiple scopes if so desired.

Related to #506 .