### PR TITLE
Enhancement: Enable no_extra_consecutive_blank_lines fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,6 +11,7 @@ $config = PhpCsFixer\Config::create()
         'array_syntax' => [
             'syntax' => 'short'
         ],
+        'no_extra_consecutive_blank_lines' => true,
         'no_unused_imports' => true,
         'ordered_imports' => true,
         'psr0' => false,

--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -89,7 +89,6 @@ class UserCreateCommand extends BaseCommand
                 $email
             ));
 
-
             return false;
         }
 

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -75,7 +75,6 @@ class SignupController extends BaseController
             $form_data['speaker_photo'] = $req->files->get('speaker_photo');
         }
 
-
         $form = new SignupForm(
             $form_data,
             $app['purifier'],

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -160,7 +160,6 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-
         $data = [
             'formAction' => $this->url('talk_update'),
             'talkCategories' => $this->getTalkCategories(),

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -52,7 +52,6 @@ class TalkTest extends DatabaseTestCase
         $this->assertEquals(1, $secondFormat['meta']->viewed);
     }
 
-
     private function generateOneTalk()
     {
         $talk = new Talk();
@@ -79,7 +78,6 @@ class TalkTest extends DatabaseTestCase
             ]
         );
     }
-
 
     /**
      * Helper function that generates some talks for us

--- a/tests/Http/Controller/ProfileControllerTest.php
+++ b/tests/Http/Controller/ProfileControllerTest.php
@@ -142,7 +142,6 @@ class ProfileControllerTest extends \PHPUnit\Framework\TestCase
     {
         $this->putUserInRequest(false);
 
-
         $controller = new ProfileController();
         $controller->setApplication($this->app);
         $response = $controller->processAction($this->req);
@@ -180,7 +179,6 @@ class ProfileControllerTest extends \PHPUnit\Framework\TestCase
         $response = $controller->processAction($this->req);
 
         $flash= $this->app['session']->get('flash');
-
 
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\RedirectResponse',

--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -42,7 +42,6 @@ class SignupControllerTest extends \PHPUnit\Framework\TestCase
         // Create a session
         $app->shouldReceive('offsetGet')->with('session')->andReturn(new Session(new MockFileSessionStorage()));
 
-
         // Create our URL generator
         $url = 'http://opencfp/signup';
         $url_generator = m::mock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
@@ -193,7 +192,6 @@ class SignupControllerTest extends \PHPUnit\Framework\TestCase
 
         $req = m::mock('Symfony\Component\HttpFoundation\Request');
 
-
         foreach ($form_data as $field => $value) {
             $req->shouldReceive('get')->with($field)->andReturn($value);
         }
@@ -279,7 +277,6 @@ class SignupControllerTest extends \PHPUnit\Framework\TestCase
 
         $req = m::mock('Symfony\Component\HttpFoundation\Request');
 
-
         foreach ($form_data as $field => $value) {
             $req->shouldReceive('get')->with($field)->andReturn($value);
         }
@@ -364,7 +361,6 @@ class SignupControllerTest extends \PHPUnit\Framework\TestCase
         $controller->setApplication($app);
 
         $req = m::mock('Symfony\Component\HttpFoundation\Request');
-
 
         foreach ($form_data as $field => $value) {
             $req->shouldReceive('get')->with($field)->andReturn($value);

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -136,7 +136,6 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-
     /**
      * @test
      */
@@ -304,7 +303,6 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         $this->app['spot']->shouldReceive('first')->andReturn($this->app['spot']);
         $this->app['spot']->shouldReceive('toArray')->andReturn(['user_id'=> (int)$this->app[Authentication::class]->user()->getId() + 2]);
 
-
         $response = $controller->editAction($this->req);
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\RedirectResponse',
@@ -375,7 +373,6 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         ];
 
         $this->setPost($talk_data);
-
 
         $response = $controller->updateAction($this->req);
 


### PR DESCRIPTION
This PR

* [x] enables the `no_extra_consecutive_blank_lines` fixer
* [x] runs `make cs`

Somewhat related to #514.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.7.1#usage:

>**no_extra_consecutive_blank_lines** [`@Symfony`]
>
>Removes extra blank lines and/or blank lines following configuration.
>
>Configuration options:
>
>* `tokens` (`array`): list of tokens to fix; defaults to `['extra']`
