### PR TITLE
Fix: Update composer itself once only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
   - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then COLLECT_COVERAGE=true; else COLLECT_COVERAGE=false; fi
   - if [[ "$COLLECT_COVERAGE" == "false" ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ "$WITH_CS" == "true" ]]; then mkdir -p "$HOME/.php-cs-fixer"; fi
-  - composer self-update
   - composer validate --no-check-publish
 
 install:


### PR DESCRIPTION
This PR

* [x] removes a run of `composer self-update` from `before_install` section

💁‍♂️ For reference, see

* https://travis-ci.org/opencfp/opencfp/builds/288589424#L459-L462
* https://travis-ci.org/opencfp/opencfp/builds/288589424#L493-L495

❗️ There were times when the run of `composer self-update` on Travis CI would **not** update to the latest stable version, but these times are over, hehe.