### PR TITLE
Fix twig errors on non existent route

### DIFF
--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -24,7 +24,7 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         $web = $app['controllers_factory'];
 
         $web->before(new RequestCleaner($app['purifier']));
-        $web->before(function (Request $request, Container $app) {
+        $app->before(function (Request $request, Container $app) {
             /* @var Twig_Environment $twig */
             $twig = $app['twig'];
 
@@ -45,7 +45,7 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
                 $twig->addGlobal('flash', $app['session']->get('flash'));
                 $app['session']->set('flash', null);
             }
-        });
+        }, Application::EARLY_EVENT);
 
         if ($app->config('application.secure_ssl')) {
             $web->requireHttps();


### PR DESCRIPTION
Before this, if the route the user requested wasn't defined, it would
cause an error in the 404 page, as it didn't go through the before
functions.

This commit fixes that by first of all binding it to app, instead of web
so it checks in all routes, even if it doesn't match the web, or any
route we know. It also makes it an Early event, which means that it will
fire off, even if its a 404.

**Old version**
![image](https://user-images.githubusercontent.com/14289961/32369437-7009d2b2-c089-11e7-8ab7-277ea4f3bd1a.png)

