### PR TITLE
Refactor of Talk Rating

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -15,6 +15,7 @@ use OpenCFP\Provider\ImageProcessorProvider;
 use OpenCFP\Provider\ResetEmailerServiceProvider;
 use OpenCFP\Provider\SentryServiceProvider;
 use OpenCFP\Provider\SpotServiceProvider;
+use OpenCFP\Provider\TalkRatingProvider;
 use OpenCFP\Provider\TwigServiceProvider;
 use OpenCFP\Provider\YamlConfigDriver;
 use Silex\Application as SilexApplication;
@@ -93,6 +94,7 @@ class Application extends SilexApplication
         $this->register(new SpotServiceProvider);
         $this->register(new ImageProcessorProvider);
         $this->register(new ResetEmailerServiceProvider());
+        $this->register(new TalkRatingProvider());
 
         // Application Services...
         $this->register(new ApplicationServiceProvider);

--- a/classes/Domain/Model/TalkMeta.php
+++ b/classes/Domain/Model/TalkMeta.php
@@ -5,7 +5,9 @@ namespace OpenCFP\Domain\Model;
 class TalkMeta extends Eloquent
 {
     protected $table = 'talk_meta';
-    public $timestamps = false;
+    const CREATED_AT = 'created';
+    const UPDATED_AT = null;
+
     /**
      * The attributes that aren't mass assignable.
      *
@@ -21,5 +23,13 @@ class TalkMeta extends Eloquent
     public function user()
     {
         return $this->belongsTo(User::class, 'admin_user_id');
+    }
+
+    public function setUpdatedAt($value)
+    {
+        /**
+         * This is the dirty way to tell Illuminate that we don't have an updated at field
+         * while still having a created_at field.
+         */
     }
 }

--- a/classes/Domain/Services/TalkRating/TalkRating.php
+++ b/classes/Domain/Services/TalkRating/TalkRating.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace OpenCFP\Domain\Services\TalkRating;
+
+use Illuminate\Database\Eloquent\Model;
+use OpenCFP\Domain\Model\TalkMeta;
+use OpenCFP\Domain\Services\Authentication;
+
+abstract class TalkRating implements TalkRatingStrategy
+{
+    protected $adminId;
+    protected $meta;
+
+    public function __construct(TalkMeta $meta, Authentication $auth)
+    {
+        $this->adminId = $auth->userId();
+        $this->meta = $meta;
+    }
+
+    /**
+     * @param int $talkId
+     * @param $rating
+     */
+    protected function saveRating(int $talkId, $rating)
+    {
+        $meta = $this->fetchMetaInfo($talkId);
+        $meta->rating = $rating;
+        $meta->save();
+    }
+
+    private function fetchMetaInfo(int $talkId): Model
+    {
+        return $this->meta->firstOrCreate([
+            'admin_user_id' => $this->adminId,
+            'talk_id' => $talkId,
+        ]);
+    }
+}

--- a/classes/Domain/Services/TalkRating/TalkRatingContext.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingContext.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace OpenCFP\Domain\Services\TalkRating;
+
+use OpenCFP\Domain\Model\TalkMeta;
+use OpenCFP\Domain\Services\Authentication;
+
+class TalkRatingContext
+{
+    public static function getTalkStrategy(string $strategy, Authentication $auth) : TalkRatingStrategy
+    {
+        $strategy = strtolower($strategy);
+        switch ($strategy) {
+            case 'yesno':
+                return new YesNoRating(new TalkMeta, $auth);
+            default:
+                return new YesNoRating(new TalkMeta, $auth);
+        }
+    }
+}

--- a/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
@@ -1,11 +1,16 @@
 <?php
 
-
 namespace OpenCFP\Domain\Services\TalkRating;
 
 interface TalkRatingStrategy
 {
     public function isValidRating($rating): bool;
 
+    /**
+     * @param int $talkId
+     * @param $rating
+     * @throws TalkRatingException
+     *
+     */
     public function rate(int $talkId, $rating);
 }

--- a/classes/Domain/Services/TalkRating/YesNoRating.php
+++ b/classes/Domain/Services/TalkRating/YesNoRating.php
@@ -2,21 +2,8 @@
 
 namespace OpenCFP\Domain\Services\TalkRating;
 
-use OpenCFP\Domain\Entity\TalkMeta;
-use OpenCFP\Domain\Services\Authentication;
-use Spot\MapperInterface;
-
-class YesNoRating implements TalkRatingStrategy
+class YesNoRating extends TalkRating
 {
-    private $mapper;
-    private $auth;
-
-    public function __construct(MapperInterface $mapper, Authentication $auth)
-    {
-        $this->mapper = $mapper;
-        $this->auth = $auth;
-    }
-
     public function isValidRating($rating): bool
     {
         if ($rating < -1 || $rating > 1) {
@@ -31,27 +18,6 @@ class YesNoRating implements TalkRatingStrategy
         if (!$this->isValidRating($rating)) {
             throw TalkRatingException::invalidRating($rating);
         }
-
-        $meta = $this->fetchMetaInfo($talkId);
-        $meta->rating = $rating;
-        $this->mapper->save($meta);
-    }
-
-    private function fetchMetaInfo(int $talkId): TalkMeta
-    {
-        $adminUserId = $this->auth->userId();
-        $talkMeta = $this->mapper->where([
-            'admin_user_id' => $adminUserId,
-            'talk_id' => $talkId,
-        ])
-            ->first();
-
-        if (!$talkMeta) {
-            $talkMeta = $this->mapper->get();
-            $talkMeta->admin_user_id = $adminUserId;
-            $talkMeta->talk_id = $talkId;
-        }
-
-        return $talkMeta;
+        $this->saveRating($talkId, $rating);
     }
 }

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -5,7 +5,7 @@ namespace OpenCFP\Http\Controller\Admin;
 use OpenCFP\Domain\Entity\Talk;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
-use OpenCFP\Domain\Services\TalkRating\YesNoRating;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingStrategy;
 use OpenCFP\Http\Controller\BaseController;
 use OpenCFP\Http\Controller\FlashableTrait;
 use Pagerfanta\View\TwitterBootstrap3View;
@@ -202,12 +202,8 @@ class TalksController extends BaseController
         if (!$this->userHasAccess()) {
             return false;
         }
-
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-        $mapper = $this->service('spot')->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
-
-        $talkRatingStrategy = new YesNoRating($mapper, $auth);
+        /** @var TalkRatingStrategy $talkRatingStrategy */
+        $talkRatingStrategy = $this->service(TalkRatingStrategy::class);
 
         try {
             $talk_rating = (int) $req->get('rating');

--- a/classes/Provider/TalkRatingProvider.php
+++ b/classes/Provider/TalkRatingProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenCFP\Provider;
+
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingContext;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingStrategy;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class TalkRatingProvider implements ServiceProviderInterface
+{
+    public function register(Container $app)
+    {
+        $app[TalkRatingStrategy::class] = function ($app) {
+            return TalkRatingContext::getTalkStrategy('YesNo', $app[Authentication::class]);
+        };
+    }
+}

--- a/tests/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -1,24 +1,23 @@
 <?php
 
-
 namespace OpenCFP\Test\Domain\Services\TalkRating;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery as m;
-use OpenCFP\Domain\Entity\TalkMeta;
+use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
 use OpenCFP\Domain\Services\TalkRating\YesNoRating;
-use Spot\MapperInterface;
 
 class YesNoRatingTest extends MockeryTestCase
 {
     public function testRateThrowsExceptionOnInvalidRating()
     {
         $mockAuth = m::mock(Authentication::class);
-        $mockMapper = m::mock(MapperInterface::class);
+        $metaMock = m::mock(TalkMeta::class);
+        $mockAuth->shouldReceive('userId')->andReturn(1);
 
-        $sut = new YesNoRating($mockMapper, $mockAuth);
+        $sut = new YesNoRating($metaMock, $mockAuth);
 
         $this->expectException(TalkRatingException::class);
         $this->expectExceptionMessage('Invalid talk rating: 9001');
@@ -28,41 +27,17 @@ class YesNoRatingTest extends MockeryTestCase
 
     public function testRate()
     {
-        $talkMeta = new TalkMeta();
-
         $mockAuth = m::mock(Authentication::class);
         $mockAuth->shouldReceive('userId')->andReturn(1);
 
-        $mockMapper = m::mock(MapperInterface::class);
-        $mockMapper->shouldReceive('where->first')->andReturn(false);
-        $mockMapper->shouldReceive('get')->andReturn($talkMeta);
-        $mockMapper->shouldReceive('save')->withArgs([$talkMeta]);
+        $metaMock = m::mock(TalkMeta::class)->makePartial();
+        $metaMock->shouldReceive('firstOrCreate')->andReturnSelf();
+        $metaMock->shouldReceive('save')->andReturnSelf();
 
-        $sut = new YesNoRating($mockMapper, $mockAuth);
-
-        $sut->rate(7, 1);
-
-        self::assertEquals(1, $talkMeta->admin_user_id);
-        self::assertEquals(7, $talkMeta->talk_id);
-        self::assertEquals(1, $talkMeta->rating);
-    }
-
-    public function testRerate()
-    {
-        $talkMeta = new TalkMeta();
-        $talkMeta->rating = 0;
-
-        $mockAuth = m::mock(Authentication::class);
-        $mockAuth->shouldReceive('userId')->andReturn(1);
-
-        $mockMapper = m::mock(MapperInterface::class);
-        $mockMapper->shouldReceive('where->first')->andReturn($talkMeta);
-        $mockMapper->shouldReceive('save')->withArgs([$talkMeta]);
-
-        $sut = new YesNoRating($mockMapper, $mockAuth);
+        $sut = new YesNoRating($metaMock, $mockAuth);
 
         $sut->rate(7, 1);
 
-        self::assertEquals(1, $talkMeta->rating);
+        $this->assertEquals(1, $metaMock->rating);
     }
 }


### PR DESCRIPTION
 This PR does a few things:

 1. Create a TalkRating base class which has some standard functionality like saving the new rating.
 2. Create a TalkRatingContext, which defines what strategy to use
 3. Create a Provider which calls the TalkRatingContext
 4. Override some standard Illuminate functionality in relation to created at and updated at functions.

Follows #503 .