### PR TITLE
Enhancement: Enable return_type_declaration fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -15,6 +15,7 @@ $config = PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'ordered_imports' => true,
         'psr0' => false,
+        'return_type_declaration' => true,
         'single_quote' => true,
         'trailing_comma_in_multiline_array' => true,
         'yoda_style' => [

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -31,7 +31,7 @@ class Talk extends Eloquent
      *
      * @param int $limit maximum ammount of entries to return.
      */
-    public function scopeRecent(Builder $query, int $limit = 10) : Builder
+    public function scopeRecent(Builder $query, int $limit = 10): Builder
     {
         return $query
             ->orderBy('created_at')

--- a/classes/Domain/Services/TalkFormat.php
+++ b/classes/Domain/Services/TalkFormat.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Collection;
 
 interface TalkFormat
 {
-    public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true) : Collection;
+    public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true): Collection;
 
-    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true) : array;
+    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true): array;
 }

--- a/classes/Domain/Services/TalkRating/TalkRatingContext.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingContext.php
@@ -7,7 +7,7 @@ use OpenCFP\Domain\Services\Authentication;
 
 class TalkRatingContext
 {
-    public static function getTalkStrategy(string $strategy, Authentication $auth) : TalkRatingStrategy
+    public static function getTalkStrategy(string $strategy, Authentication $auth): TalkRatingStrategy
     {
         $strategy = strtolower($strategy);
         switch ($strategy) {

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -16,7 +16,7 @@ class TalkFormatter implements TalkFormat
      * @param bool $userData
      * @return Collection
      */
-    public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true) : Collection
+    public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true): Collection
     {
         return $talkCollection
             ->map(function ($talk) use ($admin_user_id, $userData) {
@@ -32,7 +32,7 @@ class TalkFormatter implements TalkFormat
      * @param bool $userData grab the speaker data or not
      * @return array
      */
-    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true) : array
+    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true): array
     {
         if ($talk->favorites) {
             foreach ($talk->favorites as $favorite) {
@@ -98,7 +98,7 @@ class TalkFormatter implements TalkFormat
      *
      * @return TalkMeta
      */
-    protected function getTalkMeta($talk, int $admin_user_id) : TalkMeta
+    protected function getTalkMeta($talk, int $admin_user_id): TalkMeta
     {
         $meta = TalkMeta::where('talk_id', $talk->id)->where('admin_user_id', $admin_user_id)->first();
 


### PR DESCRIPTION
This PR

* [x] enables the `return_type_declaration` fixer
* [x] runs `make cs`

Somewhat related to https://github.com/opencfp/opencfp/pull/523.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.7.1#usage:

>**return_type_declaration** [`@Symfony`]
>
>There should be one or no space before colon, and one space after it in return type declarations, according to configuration.
>
>Configuration options:
>
>* `space_before` (`'none'`, `'one'`): spacing to apply before colon; defaults to `'none'`

💡 Note that [`PSR-12`](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md#44-methods-and-functions), which has some ideas about spacing around the `:`, is a work in progress. Nonetheless, by enabling the fixer here, we default to no space before the `:`, as suggested by PSR-12 as well.