### PR TITLE
Enhancement: Enable caching for yarn on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 
 # cache composer downloads so installing is quicker
 cache:
+  yarn: true
   directories:
     - $HOME/.composer/cache
     - $HOME/.php-cs-fixer


### PR DESCRIPTION
This PR

* [x] enables caching for yarn on Travis

Follows #518.

💁‍♂️ For reference, see https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn.