### PR TITLE
Enhancement: Enable blank_line_after_opening_tag fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,6 +11,7 @@ $config = PhpCsFixer\Config::create()
         'array_syntax' => [
             'syntax' => 'short'
         ],
+        'blank_line_after_opening_tag' => true,
         'no_extra_consecutive_blank_lines' => true,
         'no_unused_imports' => true,
         'ordered_imports' => true,

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Console;
+<?php
+
+namespace OpenCFP\Console;
 
 use OpenCFP\Application as ApplicationContainer;
 use OpenCFP\Console\Command\AdminDemoteCommand;

--- a/classes/Domain/Entity/Tag.php
+++ b/classes/Domain/Entity/Tag.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OpenCFP\Domain\Entity;
 
 use Spot\Entity;

--- a/classes/Domain/Entity/TalkTag.php
+++ b/classes/Domain/Entity/TalkTag.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OpenCFP\Domain\Entity;
 
 use Spot\Entity;

--- a/classes/Domain/Speaker/SpeakerRepository.php
+++ b/classes/Domain/Speaker/SpeakerRepository.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Domain\Speaker;
+<?php
+
+namespace OpenCFP\Domain\Speaker;
 
 use OpenCFP\Domain\Entity\User;
 use OpenCFP\Domain\EntityNotFoundException;

--- a/classes/Domain/Talk/TalkRepository.php
+++ b/classes/Domain/Talk/TalkRepository.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Domain\Talk;
+<?php
+
+namespace OpenCFP\Domain\Talk;
 
 use OpenCFP\Domain\Entity\Talk;
 

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP;
+<?php
+
+namespace OpenCFP;
 
 use InvalidArgumentException;
 

--- a/classes/Http/Form/ForgotForm.php
+++ b/classes/Http/Form/ForgotForm.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OpenCFP\Http\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OpenCFP\Http\Form;
 
 abstract class Form

--- a/classes/Http/Form/ResetForm.php
+++ b/classes/Http/Form/ResetForm.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OpenCFP\Http\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/classes/Provider/CallForProposalProvider.php
+++ b/classes/Provider/CallForProposalProvider.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Provider;
+<?php
+
+namespace OpenCFP\Provider;
 
 use OpenCFP\Domain\CallForProposal;
 use Pimple\Container;

--- a/classes/Provider/CiconiaEngine.php
+++ b/classes/Provider/CiconiaEngine.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OpenCFP\Provider;
 
 use Aptoma\Twig\Extension\MarkdownEngineInterface;

--- a/classes/Provider/ControllerResolver.php
+++ b/classes/Provider/ControllerResolver.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Provider;
+<?php
+
+namespace OpenCFP\Provider;
 
 use OpenCFP\Http\Controller\BaseController;
 

--- a/classes/Provider/ControllerResolverServiceProvider.php
+++ b/classes/Provider/ControllerResolverServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Provider;
+<?php
+
+namespace OpenCFP\Provider;
 
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;

--- a/classes/Provider/DatabaseServiceProvider.php
+++ b/classes/Provider/DatabaseServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Provider;
+<?php
+
+namespace OpenCFP\Provider;
 
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;

--- a/classes/Provider/HtmlPurifierServiceProvider.php
+++ b/classes/Provider/HtmlPurifierServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Provider;
+<?php
+
+namespace OpenCFP\Provider;
 
 use HTMLPurifier;
 use HTMLPurifier_Config;

--- a/classes/Provider/SentryServiceProvider.php
+++ b/classes/Provider/SentryServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Provider;
+<?php
+
+namespace OpenCFP\Provider;
 
 use Cartalyst\Sentry\Facades\Native\Sentry;
 use Pimple\Container;

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace OpenCFP\Provider;
+<?php
+
+namespace OpenCFP\Provider;
 
 use Aptoma\Twig\Extension\MarkdownEngine;
 use Aptoma\Twig\Extension\MarkdownExtension;


### PR DESCRIPTION
This PR

* [x] enables the `blank_line_after_opening_tag` fixer 
* [x] runs `make cs`

Related to https://github.com/opencfp/opencfp/pull/529#issuecomment-342521923.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.7.1#usage:

>**blank_line_after_opening_tag** [`@Symfony`]
>
>Ensure there is no code on the same line as the PHP open tag and it is followed by a blank line.