### PR TITLE
Fix: Do not import native PHP classes

### DIFF
--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Console\Command;
 
-use Exception;
 use OpenCFP\Console\BaseCommand;
 use OpenCFP\Domain\Services\AccountManagement;
 use Symfony\Component\Console\Input\InputArgument;
@@ -51,7 +50,7 @@ EOF
 
         try {
             $user = $accounts->findByLogin($email);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $io->error(sprintf(
                 'Could not find account with email %s.',
                 $email

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Console\Command;
 
-use Exception;
 use OpenCFP\Console\BaseCommand;
 use OpenCFP\Domain\Services\AccountManagement;
 use Symfony\Component\Console\Input\InputArgument;
@@ -51,7 +50,7 @@ EOF
 
         try {
             $user = $accounts->findByLogin($email);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $io->error(sprintf(
                 'Could not find account with email %s.',
                 $email

--- a/classes/Domain/CallForProposal.php
+++ b/classes/Domain/CallForProposal.php
@@ -2,10 +2,6 @@
 
 namespace OpenCFP\Domain;
 
-use DateInterval;
-use DateTimeImmutable;
-use DateTimeInterface;
-
 /**
  * This object is responsible for representing behaviour around the call
  * for proposal process. Today it is only responsible for reporting whether or not the
@@ -19,23 +15,23 @@ class CallForProposal
      */
     private $endDate;
 
-    public function __construct(DateTimeInterface $end)
+    public function __construct(\DateTimeInterface $end)
     {
         if ($end->format('H:i:s') === '00:00:00') {
-            $end = $end->add(new DateInterval('P1D'));
+            $end = $end->add(new \DateInterval('P1D'));
         }
         $this->endDate = $end;
     }
 
     /**
-     * @param DateTimeInterface $currentTime
+     * @param \DateTimeInterface $currentTime
      *
      * @return boolean true if CFP is open, false otherwise.
      */
-    public function isOpen(DateTimeInterface $currentTime = null)
+    public function isOpen(\DateTimeInterface $currentTime = null)
     {
         if (! $currentTime) {
-            $currentTime = new DateTimeImmutable('now');
+            $currentTime = new \DateTimeImmutable('now');
         }
 
         return $currentTime < $this->endDate;

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -1,7 +1,5 @@
 <?php namespace OpenCFP;
 
-use InvalidArgumentException;
-
 class Environment
 {
     /**
@@ -13,7 +11,7 @@ class Environment
     private function __construct($slug)
     {
         if (! in_array($slug, ['production', 'development', 'testing'])) {
-            throw new InvalidArgumentException('Invalid environment specified.');
+            throw new \InvalidArgumentException('Invalid environment specified.');
         }
 
         $this->slug = (string) $slug;

--- a/classes/Http/API/ProfileController.php
+++ b/classes/Http/API/ProfileController.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Http\API;
 
-use Exception;
 use OpenCFP\Application\Speakers;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -33,7 +32,7 @@ class ProfileController extends ApiController
             return $this->respond($profile->toArrayForApi());
         } catch (NotAuthenticatedException $e) {
             return $this->respondUnauthorized();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->respondInternalError($e->getMessage());
         }
     }

--- a/classes/Http/API/TalkController.php
+++ b/classes/Http/API/TalkController.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Http\API;
 
-use Exception;
 use OpenCFP\Application\Speakers;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
 use OpenCFP\Domain\Talk\InvalidTalkSubmissionException;
@@ -43,7 +42,7 @@ class TalkController extends ApiController
             return $this->setStatusCode(Response::HTTP_BAD_REQUEST)->respondWithError($e->getMessage());
         } catch (NotAuthenticatedException $e) {
             return $this->respondUnauthorized();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->respondInternalError($e->getMessage());
         }
     }

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -3,7 +3,6 @@
 namespace OpenCFP\Http\Controller;
 
 use Cartalyst\Sentry\Users\UserNotFoundException;
-use Exception;
 use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Http\Form\ForgotForm;
 use OpenCFP\Http\Form\ResetForm;
@@ -74,7 +73,7 @@ class ForgotController extends BaseController
     public function resetAction(Request $req)
     {
         if (empty($req->get('reset_code'))) {
-            throw new Exception();
+            throw new \Exception();
         }
 
         $errorMessage = 'The reset you have requested appears to be invalid, please try again.';
@@ -119,7 +118,7 @@ class ForgotController extends BaseController
         $reset_code = $req->get('reset_code');
 
         if (empty($reset_code)) {
-            throw new Exception();
+            throw new \Exception();
         }
 
         $form = $this->service('form.factory')->createBuilder(ResetForm::class)->getForm();
@@ -173,7 +172,7 @@ class ForgotController extends BaseController
         $password = $data['password'];
 
         if (empty($reset_code)) {
-            throw new Exception();
+            throw new \Exception();
         }
 
         try {

--- a/tests/Domain/CallForProposalTest.php
+++ b/tests/Domain/CallForProposalTest.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Test\Domain;
 
-use DateTime;
 use OpenCFP\Domain\CallForProposal;
 
 class CallForProposalTest extends \PHPUnit\Framework\TestCase
@@ -13,7 +12,7 @@ class CallForProposalTest extends \PHPUnit\Framework\TestCase
      */
     public function it_should_tell_whether_or_not_the_cfp_is_open($endDate)
     {
-        $cfp = new CallForProposal(new DateTime($endDate));
+        $cfp = new CallForProposal(new \DateTime($endDate));
         $this->assertTrue($cfp->isOpen());
     }
 
@@ -28,7 +27,7 @@ class CallForProposalTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_should_say_cfp_is_closed_after_end_date_has_passed()
     {
-        $cfp = new CallForProposal(new DateTime('-1 day'));
+        $cfp = new CallForProposal(new \DateTime('-1 day'));
         $this->assertFalse($cfp->isOpen());
     }
 }

--- a/tests/Http/API/ProfileApiControllerTest.php
+++ b/tests/Http/API/ProfileApiControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Test\Http\API;
 
-use Exception;
 use Mockery as m;
 use Mockery\MockInterface;
 use OpenCFP\Application\Speakers;
@@ -57,7 +56,7 @@ class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
     public function it_responds_internal_error_when_something_bad_happens()
     {
         $this->speakers->shouldReceive('findProfile')
-            ->andThrow(new Exception('Zomgz it blew up somehow.'));
+            ->andThrow(new \Exception('Zomgz it blew up somehow.'));
 
         $response = $this->sut->handleShowSpeakerProfile($this->getRequest());
 

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -4,7 +4,6 @@ namespace OpenCFP\Test\Http\Controller;
 
 use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users\UserInterface;
-use DateTime;
 use Mockery as m;
 use OpenCFP\Application;
 use OpenCFP\Domain\CallForProposal;
@@ -166,9 +165,9 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         // Set CFP end to today (whenever test is run)
         // Previously, this fails because it checked midnight
         // for the current date. `isCfpOpen` now uses 11:59pm current date.
-        $now = new DateTime();
+        $now = new \DateTime();
 
-        $this->app['callforproposal'] = new CallForProposal(new DateTime($now->format('M. jS, Y')));
+        $this->app['callforproposal'] = new CallForProposal(new \DateTime($now->format('M. jS, Y')));
 
         /*
          * This should not have a flash message. The fact that this
@@ -184,9 +183,9 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
          * However, if I update application configuration to make
          * the CFP end date to be "yesterday" then we get flash as expected.
          */
-        $yesterday = new DateTime('yesterday');
+        $yesterday = new \DateTime('yesterday');
 
-        $this->app['callforproposal'] = new CallForProposal(new DateTime($yesterday->format('M. jS, Y')));
+        $this->app['callforproposal'] = new CallForProposal(new \DateTime($yesterday->format('M. jS, Y')));
 
         $controller->createAction($this->req);
 


### PR DESCRIPTION
This PR

* [x] removes imports for native PHP classes

💁‍♂️ It might be a matter of personal taste, but by never importing native PHP classes (and instead referencing them from relative to the root namespace), a) the list of imports is reduced and b) it's immediately clear by looking at a line of code whether it is referencing a class from the root namespace or not.