### PR TITLE
Fix: Use constants for HTTP response status codes

### DIFF
--- a/tests/Http/API/ApiControllerTest.php
+++ b/tests/Http/API/ApiControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace OpenCFP\Test\Http\API;
 
+use Symfony\Component\HttpFoundation;
+
 class ApiControllerTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -17,18 +19,18 @@ class ApiControllerTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_allows_developer_to_specify_a_status_code_for_response()
     {
-        $this->sut->setStatusCode(200);
-        $this->assertEquals(200, $this->sut->getStatusCode());
+        $this->sut->setStatusCode(HttpFoundation\Response::HTTP_OK);
+        $this->assertEquals(HttpFoundation\Response::HTTP_OK, $this->sut->getStatusCode());
     }
 
     /** @test */
     public function it_can_send_a_simple_json_response()
     {
-        $response = $this->sut->setStatusCode(200)->respond(['message' => 'Huzzah']);
+        $response = $this->sut->setStatusCode(HttpFoundation\Response::HTTP_OK)->respond(['message' => 'Huzzah']);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
         $this->assertJson($response->getContent());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
         $this->assertContains('Huzzah', $response->getContent());
     }
 
@@ -38,18 +40,18 @@ class ApiControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function it_warns_when_successful_status_code_is_used_for_error()
     {
-        $this->sut->setStatusCode(200)
+        $this->sut->setStatusCode(HttpFoundation\Response::HTTP_OK)
             ->respondWithError('Error with success status code');
     }
 
     /** @test */
     public function it_responds_with_error_message_given_appropriate_status_code()
     {
-        $response = $this->sut->setStatusCode(400)
+        $response = $this->sut->setStatusCode(HttpFoundation\Response::HTTP_BAD_REQUEST)
             ->respondWithError('Some kind of bad request.');
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_BAD_REQUEST, $response->getStatusCode());
         $this->assertContains('bad request', $response->getContent());
     }
 
@@ -70,11 +72,11 @@ class ApiControllerTest extends \PHPUnit\Framework\TestCase
     public function specializedResponseExamples()
     {
         return [
-            ['BadRequest', 400, 'Bad request'],
-            ['Unauthorized', 401, 'Unauthorized'],
-            ['Forbidden', 403, 'Forbidden'],
-            ['NotFound', 404, 'Resource not found'],
-            ['InternalError', 500, 'Internal server error'],
+            ['BadRequest', HttpFoundation\Response::HTTP_BAD_REQUEST, 'Bad request'],
+            ['Unauthorized', HttpFoundation\Response::HTTP_UNAUTHORIZED, 'Unauthorized'],
+            ['Forbidden', HttpFoundation\Response::HTTP_FORBIDDEN, 'Forbidden'],
+            ['NotFound', HttpFoundation\Response::HTTP_NOT_FOUND, 'Resource not found'],
+            ['InternalError', HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR, 'Internal server error'],
         ];
     }
 }

--- a/tests/Http/API/ProfileApiControllerTest.php
+++ b/tests/Http/API/ProfileApiControllerTest.php
@@ -9,6 +9,7 @@ use OpenCFP\Application\Speakers;
 use OpenCFP\Domain\Entity\User;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Http\API\ProfileController;
+use Symfony\Component\HttpFoundation;
 use Symfony\Component\HttpFoundation\Request;
 
 class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
@@ -37,7 +38,7 @@ class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleShowSpeakerProfile($this->getRequest());
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
         $this->assertContains('Hamburglar', $response->getContent());
     }
 
@@ -49,7 +50,7 @@ class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleShowSpeakerProfile($this->getRequest());
 
-        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
         $this->assertContains('Unauthorized', $response->getContent());
     }
 
@@ -61,7 +62,7 @@ class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleShowSpeakerProfile($this->getRequest());
 
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
         $this->assertContains('Zomgz it blew up somehow', $response->getContent());
     }
 

--- a/tests/Http/API/TalkApiControllerTest.php
+++ b/tests/Http/API/TalkApiControllerTest.php
@@ -8,6 +8,7 @@ use OpenCFP\Application\Speakers;
 use OpenCFP\Domain\Entity\Talk;
 use OpenCFP\Domain\Talk\TalkSubmission;
 use OpenCFP\Http\API\TalkController;
+use Symfony\Component\HttpFoundation;
 use Symfony\Component\HttpFoundation\Request;
 
 class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
@@ -46,7 +47,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleSubmitTalk($request);
 
-        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_CREATED, $response->getStatusCode());
         $this->assertContains('Happy Path Submission', $response->getContent());
     }
 
@@ -57,7 +58,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleSubmitTalk($request);
 
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_BAD_REQUEST, $response->getStatusCode());
         $this->assertContains('The description of the talk must be included', $response->getContent());
     }
 
@@ -71,7 +72,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleSubmitTalk($request);
 
-        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
     }
 
     /** @test */
@@ -83,7 +84,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleViewTalk($this->getValidRequest(), 1);
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
         $this->assertContains('Testy Talk', $response->getContent());
     }
 
@@ -95,7 +96,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleViewTalk($this->getValidRequest(), 1);
 
-        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
         $this->assertContains('Unauthorized', $response->getContent());
     }
 
@@ -110,7 +111,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleViewAllTalks($this->getValidRequest());
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
         $this->assertContains('Testy Talk', $response->getContent());
         $this->assertContains('Another Talk', $response->getContent());
         $this->assertContains('Yet Another Talk', $response->getContent());
@@ -124,7 +125,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->sut->handleViewAllTalks($this->getValidRequest());
 
-        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals(HttpFoundation\Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
         $this->assertContains('Unauthorized', $response->getContent());
     }
 


### PR DESCRIPTION
This PR

* [x] uses constants for HTTP response status codes (instead of magic numbers)