### PR TITLE
Fix: Class name does not match file name

### DIFF
--- a/tests/Console/AdminPromoteCommandTest.php
+++ b/tests/Console/AdminPromoteCommandTest.php
@@ -12,7 +12,7 @@ use OpenCFP\Environment;
  * @package OpenCFP\Test\Console
  * @group db
  */
-class AdminPromoteTest extends \PHPUnit\Framework\TestCase
+class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {


### PR DESCRIPTION
This PR

* [x] fixes an issue where a class name does not match the name of the containing file