### PR TITLE
Fix: Reference phpunit.xsd using relative path

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"


### PR DESCRIPTION
This PR

* [x] references the path to the `phpunit.xsd` schema relative to `phpunit.xml.dist`