### PR TITLE
Fix: Suggest to use yarn (rather than npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,20 +644,13 @@ $ script/test
 
 OpenCFP ships with a pre-compiled CSS file. However, we now include the Sass / PostCSS used to compile front-end assets. You are free to modify these source files to change brand colors or modify your instance however you see fit. Remember, you can do **nothing** and take advantage of the pre-compiled CSS we ship. You only need these instructions if you want to customize or contribute to the look and feel of OpenCFP. Let's take a look at this new workflow for OpenCFP. 
 
-Install Node dependencies using `npm` or `yarn`.
+Install Node dependencies using `yarn`.
 
 ```bash
-# If you have a recent version of Node.js + npm that doesn't suck...
-npm install
-
-# If you love Facebook and balls of string...
 yarn install
-
-# If you're really awesome, do both...
-don't do both
 ```
 
-Now dependencies are installed and we're ready to compile assets. Check out the `scripts` section of `package.json`. A normal development workflow is to run either `npm run watch` or `npm run watch-poll` (for OS that don't have `fs-events`) and begin work. When you make changes to Sass files, Webpack will recompile assets, but it doesn't compress the output. To do that, run `npm run prod` (an alias for `npm run production`). This will run the same compilation, but will compress the output.
+Now dependencies are installed and we're ready to compile assets. Check out the `scripts` section of `package.json`. A normal development workflow is to run either `yarn run watch` or `yarn run watch-poll` (for OS that don't have `fs-events`) and begin work. When you make changes to Sass files, Webpack will recompile assets, but it doesn't compress the output. To do that, run `yarn run prod` (an alias for `yarn run production`). This will run the same compilation, but will compress the output.
 
 The main `app.scss` file is at [`resources/assets/sass/app.scss`](resources/assets/sass/app.scss). We use [Laravel Mix](https://github.com/JeffreyWay/laravel-mix) to compile our Sass. Mix is configurable to run without Laravel, so we take advantage of that because it really makes dealing with Webpack a lot simpler. Our Mix configuration is at [`webpack.mix.js`](webpack.mix.js). In it, we run our `app.scss` through a Sass compilation step, we copy FontAwesome icons and finally run the compiled CSS through [Tailwind CSS](https://tailwindcss.com), a PostCSS plugin.
 


### PR DESCRIPTION
This PR

* [x] removes suggestions to use `npm` instead of `yarn`

💁‍♂️ It's painfully slow, and running `npm install` rather than running `yarn install` with a checked in `yarn.lock` will eventually produce different results (as `npm` doesn't take into account locked dependencies in `yarn.lock`).