### PR TITLE
Enhancement: Move auth checks to middleware

### DIFF
--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -15,14 +15,7 @@ class ProfileController extends BaseController
 
     public function editAction(Request $req)
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
-        $user = $auth->user();
+        $user = $this->service(Authentication::class)->user();
 
         if ((string) $user->getId() !== $req->get('id')) {
             $this->service('session')->set('flash', [
@@ -64,14 +57,7 @@ class ProfileController extends BaseController
 
     public function processAction(Request $req)
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
-        $user = $auth->user();
+        $user = $this->service(Authentication::class)->user();
 
         if ((string) $user->getId() !== $req->get('id')) {
             $this->service('session')->set('flash', [
@@ -180,28 +166,14 @@ class ProfileController extends BaseController
         return $this->render('user/edit.twig', $form_data);
     }
 
-    public function passwordAction(Request $req)
+    public function passwordAction()
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
         return $this->render('user/change_password.twig');
     }
 
     public function passwordProcessAction(Request $req)
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
-        $user = $auth->user();
+        $user = $this->service(Authentication::class)->user();
 
         /**
          * Okay, the logic is kind of weird but we can use the SignupForm

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -95,13 +95,6 @@ class TalkController extends BaseController
         /* @var Speakers $speakers */
         $speakers = $this->service('application.speakers');
 
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
         try {
             $id = filter_var($req->get('id'), FILTER_VALIDATE_INT);
             $talk = $speakers->getTalk($id);
@@ -120,13 +113,6 @@ class TalkController extends BaseController
      */
     public function editAction(Request $req)
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
         $id = $req->get('id');
         $talk_id = filter_var($id, FILTER_VALIDATE_INT);
 
@@ -148,7 +134,7 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $user = $auth->user();
+        $user = $this->service(Authentication::class)->user();
 
         /* @var Locator $spot */
         $spot = $this->service('spot');
@@ -189,13 +175,6 @@ class TalkController extends BaseController
      */
     public function createAction(Request $req)
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
         // You can only create talks while the CfP is open
         if (! $this->service('callforproposal')->isOpen()) {
             $this->service('session')->set(
@@ -238,13 +217,6 @@ class TalkController extends BaseController
      */
     public function processCreateAction(Request $req)
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
         // You can only create talks while the CfP is open
         if (! $this->service('callforproposal')->isOpen()) {
             $this->service('session')->set(
@@ -258,7 +230,7 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $user = $auth->user();
+        $user = $this->service(Authentication::class)->user();
 
         $request_data = [
             'title' => $req->get('title'),
@@ -353,14 +325,7 @@ class TalkController extends BaseController
 
     public function updateAction(Request $req)
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
-        $user = $auth->user();
+        $user = $this->service(Authentication::class)->user();
 
         $request_data = [
             'id' => $req->get('id'),
@@ -457,19 +422,12 @@ class TalkController extends BaseController
 
     public function deleteAction(Request $req, Application $app)
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
-        if (!$auth->check()) {
-            return $this->redirectTo('login');
-        }
-
         // You can only delete talks while the CfP is open
         if (! $this->service('callforproposal')->isOpen()) {
             return $app->json(['delete' => 'no']);
         }
 
-        $user = $auth->user();
+        $user = $this->service(Authentication::class)->user();
         $talk_mapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
         $talk = $talk_mapper->get($req->get('tid'));
 

--- a/classes/Infrastructure/Auth/SpeakerAccess.php
+++ b/classes/Infrastructure/Auth/SpeakerAccess.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OpenCFP\Infrastructure\Auth;
+
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\UserAccess;
+use Silex\Application;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class SpeakerAccess implements UserAccess
+{
+
+    /**
+     * If a user doesn't have access to a page they get redirected, otherwise nothing happens
+     *
+     * @param Application $app
+     * @return RedirectResponse|void
+     */
+    public static function userHasAccess(Application $app)
+    {
+        /** @var Authentication $auth */
+        $auth = $app[Authentication::class];
+
+        if (!$auth->check()) {
+            return $app->redirect('/login');
+        }
+    }
+}

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Provider\Gateways;
 
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Infrastructure\Auth\AdminAccess;
+use OpenCFP\Infrastructure\Auth\SpeakerAccess;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Silex\Api\BootableProviderInterface;
@@ -53,6 +54,10 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
             $app->requireHttps();
         }
 
+        $asSpeaker = function () use ($app) {
+            return SpeakerAccess::userHasAccess($app);
+        };
+
         $web->get('/', 'OpenCFP\Http\Controller\PagesController::showHomepage')->bind('homepage');
         $web->get('/package', 'OpenCFP\Http\Controller\PagesController::showSpeakerPackage')->bind('speaker_package');
         $web->get('/ideas', 'OpenCFP\Http\Controller\PagesController::showTalkIdeas')->bind('talk_ideas');
@@ -61,12 +66,12 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         $web->get('/dashboard', 'OpenCFP\Http\Controller\DashboardController::showSpeakerProfile')->bind('dashboard');
 
         // Talks
-        $web->get('/talk/edit/{id}', 'OpenCFP\Http\Controller\TalkController::editAction')->bind('talk_edit');
-        $web->get('/talk/create', 'OpenCFP\Http\Controller\TalkController::createAction')->bind('talk_new');
-        $web->post('/talk/create', 'OpenCFP\Http\Controller\TalkController::processCreateAction')->bind('talk_create');
-        $web->post('/talk/update', 'OpenCFP\Http\Controller\TalkController::updateAction')->bind('talk_update');
-        $web->post('/talk/delete', 'OpenCFP\Http\Controller\TalkController::deleteAction')->bind('talk_delete');
-        $web->get('/talk/{id}', 'OpenCFP\Http\Controller\TalkController::viewAction')->bind('talk_view');
+        $web->get('/talk/edit/{id}', 'OpenCFP\Http\Controller\TalkController::editAction')->bind('talk_edit')->before($asSpeaker);
+        $web->get('/talk/create', 'OpenCFP\Http\Controller\TalkController::createAction')->bind('talk_new')->before($asSpeaker);
+        $web->post('/talk/create', 'OpenCFP\Http\Controller\TalkController::processCreateAction')->bind('talk_create')->before($asSpeaker);
+        $web->post('/talk/update', 'OpenCFP\Http\Controller\TalkController::updateAction')->bind('talk_update')->before($asSpeaker);
+        $web->post('/talk/delete', 'OpenCFP\Http\Controller\TalkController::deleteAction')->bind('talk_delete')->before($asSpeaker);
+        $web->get('/talk/{id}', 'OpenCFP\Http\Controller\TalkController::viewAction')->bind('talk_view')->before($asSpeaker);
 
         // Login/Logout
         $web->get('/login', 'OpenCFP\Http\Controller\SecurityController::indexAction')->bind('login');
@@ -79,12 +84,12 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         $web->get('/signup/success', 'OpenCFP\Http\Controller\SignupController::successAction')->bind('user_success');
 
         // Edit Profile/Account
-        $web->get('/profile/edit/{id}', 'OpenCFP\Http\Controller\ProfileController::editAction')->bind('user_edit');
-        $web->post('/profile/edit', 'OpenCFP\Http\Controller\ProfileController::processAction')->bind('user_update');
+        $web->get('/profile/edit/{id}', 'OpenCFP\Http\Controller\ProfileController::editAction')->bind('user_edit')->before($asSpeaker);
+        $web->post('/profile/edit', 'OpenCFP\Http\Controller\ProfileController::processAction')->bind('user_update')->before($asSpeaker);
 
         // Change/forgot Password
-        $web->get('/profile/change_password', 'OpenCFP\Http\Controller\ProfileController::passwordAction')->bind('password_edit');
-        $web->post('/profile/change_password', 'OpenCFP\Http\Controller\ProfileController::passwordProcessAction')->bind('password_change');
+        $web->get('/profile/change_password', 'OpenCFP\Http\Controller\ProfileController::passwordAction')->bind('password_edit')->before($asSpeaker);
+        $web->post('/profile/change_password', 'OpenCFP\Http\Controller\ProfileController::passwordProcessAction')->bind('password_change')->before($asSpeaker);
         $web->get('/forgot', 'OpenCFP\Http\Controller\ForgotController::indexAction')->bind('forgot_password');
         $web->post('/forgot', 'OpenCFP\Http\Controller\ForgotController::sendResetAction')->bind('forgot_password_create');
         $web->get('/forgot_success', 'OpenCFP\Http\Controller\ForgotController::successAction')->bind('forgot_password_success');

--- a/tests/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Infrastructure/Auth/SpeakerAccessTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OpenCFP\Test\Http\Controller\Admin;
+
+use Mockery;
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Infrastructure\Auth\SpeakerAccess;
+use OpenCFP\Test\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class SpeakerAccessTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testReturnsRedirectIfCheckFailed()
+    {
+        $auth = Mockery::mock(Authentication::class);
+        $auth->shouldReceive('check')->andReturn(false);
+        $this->swap(Authentication::class, $auth);
+        $this->assertInstanceOf(RedirectResponse::class, SpeakerAccess::userHasAccess($this->app));
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsNothingIfUserIsLoggedIn()
+    {
+        $auth = Mockery::mock(Authentication::class);
+        $auth->shouldReceive('check')->andReturn(true);
+        $this->swap(Authentication::class, $auth);
+        $this->assertNull(SpeakerAccess::userHasAccess($this->app));
+    }
+
+    /**
+     * @test
+     */
+    public function testAnAdminHasAccessToSpeakerPages()
+    {
+        $this->asAdmin();
+        $this->assertNull(SpeakerAccess::userHasAccess($this->app));
+    }
+}


### PR DESCRIPTION
This PR moves some standard auth checks to middleware

In a lot of the speaker controllers, the first thing every functions did was the following check:

```php
if (!$auth->check()) {		
    return $this->redirectTo('login');		
}
```
This moves all the those checks to one central point, the ```SpeakerAccess```  Class, which gets called before the controller is executed.

I didn't add this to all the speaker controllers, since some of them keep the check in other places, and i didn't want to mess with that logic for now.