### PR TITLE
Rename TestCase to WebTestCase

### DIFF
--- a/tests/Domain/Model/AirportTest.php
+++ b/tests/Domain/Model/AirportTest.php
@@ -4,12 +4,11 @@ namespace OpenCFP\Test\Domain\Model;
 
 use OpenCFP\Domain\Model\Airport;
 use OpenCFP\Test\DatabaseTransaction;
-use OpenCFP\Test\TestCase;
 
 /**
  * @group db
  */
-class AirportTest extends TestCase
+class AirportTest extends \PHPUnit\Framework\TestCase
 {
     use DatabaseTransaction;
 

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -6,12 +6,11 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Test\DatabaseTransaction;
-use OpenCFP\Test\TestCase;
 
 /**
  * @group db
  */
-class TalkTest extends TestCase
+class TalkTest extends \PHPUnit\Framework\TestCase
 {
     use DatabaseTransaction;
 

--- a/tests/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Http/Controller/Admin/DashboardControllerTest.php
@@ -5,7 +5,7 @@ namespace OpenCFP\Test\Http\Controller\Admin;
 use Cartalyst\Sentry\Users\UserInterface;
 use Mockery as m;
 use OpenCFP\Domain\Services\Authentication;
-use OpenCFP\Test\TestCase;
+use OpenCFP\Test\WebTestCase;
 
 /**
  * @runTestsInSeparateProcesses
@@ -13,7 +13,7 @@ use OpenCFP\Test\TestCase;
  *
  * These slow down the tests a bit, but it is required for our overrides to work.
  */
-class DashboardControllerTest extends TestCase
+class DashboardControllerTest extends WebTestCase
 {
 
     /**

--- a/tests/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Http/Controller/Admin/TalksControllerTest.php
@@ -7,9 +7,9 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Test\DatabaseTransaction;
-use OpenCFP\Test\TestCase;
+use OpenCFP\Test\WebTestCase;
 
-class TalksControllerTest extends TestCase
+class TalksControllerTest extends WebTestCase
 {
     use DatabaseTransaction;
 

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -8,15 +8,15 @@ use Mockery as m;
 use OpenCFP\Application;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
-use OpenCFP\Test\TestCase;
 use OpenCFP\Test\Util\Faker\GeneratorTrait;
+use OpenCFP\Test\WebTestCase;
 
 /**
  * Class DashboardControllerTest
  * @package OpenCFP\Test\Http\Controller
  * @group db
  */
-class DashboardControllerTest extends TestCase
+class DashboardControllerTest extends WebTestCase
 {
     use GeneratorTrait;
 

--- a/tests/Infrastructure/Auth/AdminAccessTest.php
+++ b/tests/Infrastructure/Auth/AdminAccessTest.php
@@ -6,15 +6,11 @@ use Cartalyst\Sentry\Users\UserInterface;
 use Mockery;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Infrastructure\Auth\AdminAccess;
-use OpenCFP\Test\TestCase;
+use OpenCFP\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
-class AdminAccessTest extends TestCase
+class AdminAccessTest extends WebTestCase
 {
-    public function tearDown()
-    {
-        Mockery::close();
-    }
 
     /**
      * @test

--- a/tests/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -4,14 +4,13 @@ namespace OpenCFP\Test\Infrastructure\Auth;
 
 use OpenCFP\Infrastructure\Auth\SentryAccountManagement;
 use OpenCFP\Test\DatabaseTransaction;
-use OpenCFP\Test\TestCase;
 
 /**
  * Class SentryAccountManagementTest
  * @package OpenCFP\Test\Infrastructure\Auth
  * @group db
  */
-class SentryAccountManagementTest extends TestCase
+class SentryAccountManagementTest extends \PHPUnit\Framework\TestCase
 {
     use DatabaseTransaction;
     use SentryTestHelpers;

--- a/tests/Infrastructure/Auth/SentryAuthenticationTest.php
+++ b/tests/Infrastructure/Auth/SentryAuthenticationTest.php
@@ -5,14 +5,13 @@ namespace OpenCFP\Test\Infrastructure\Auth;
 use OpenCFP\Infrastructure\Auth\SentryAccountManagement;
 use OpenCFP\Infrastructure\Auth\SentryAuthentication;
 use OpenCFP\Test\DatabaseTransaction;
-use OpenCFP\Test\TestCase;
 
 /**
  * Class SentryAuthenticationTest
  * @package OpenCFP\Test\Infrastructure\Auth
  * @group db
  */
-class SentryAuthenticationTest extends TestCase
+class SentryAuthenticationTest extends \PHPUnit\Framework\TestCase
 {
     use DatabaseTransaction;
     use SentryTestHelpers;

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -9,7 +9,7 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Environment;
 use Symfony\Component\HttpFoundation\Request;
 
-class TestCase extends \PHPUnit\Framework\TestCase
+class WebTestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Application


### PR DESCRIPTION
This PR renames TestCase to WebTestCase, so its more clear in meaning.

I also made a few tests go back to using the standard PHPUnit testcase as their base class, since they have no need for all the extras supplied by our own base test case class.