### PR TITLE
Fix: Extend from WebTestCase

### DIFF
--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -8,7 +8,7 @@ use HTMLPurifier_Config;
 use Mockery as m;
 use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Domain\Services\Authentication;
-use OpenCFP\Test\TestCase;
+use OpenCFP\Test\WebTestCase;
 use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
  * @package OpenCFP\Test\Http\Controller
  * @group db
  */
-class SignupControllerTest extends TestCase
+class SignupControllerTest extends WebTestCase
 {
     /**
      * @test

--- a/tests/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Infrastructure/Auth/SpeakerAccessTest.php
@@ -5,10 +5,10 @@ namespace OpenCFP\Test\Http\Controller\Admin;
 use Mockery;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Infrastructure\Auth\SpeakerAccess;
-use OpenCFP\Test\TestCase;
+use OpenCFP\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
-class SpeakerAccessTest extends TestCase
+class SpeakerAccessTest extends WebTestCase
 {
     /**
      * @test


### PR DESCRIPTION
This PR

* [x] fixes the failing build by extending from `WebTestCase`

Follows #545.