### PR TITLE
Fix: Configure preferred installation source in composer.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 it: cs test
 
 composer:
-	composer install --prefer-dist
+	composer install
 
 cs: composer
 	vendor/bin/php-cs-fixer fix --verbose --diff

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "opencfp/opencfp",
     "license": "MIT",
     "config": {
+        "preferred-install": "dist",
         "sort-packages": true
     },
     "require": {


### PR DESCRIPTION
This PR

* [x] configures the preferred installation source in `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#preferred-install.