### PR TITLE
Enhancement: Enable php_unit_expectation and php_unit_no_expectation_annotation fixers

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -6,6 +6,7 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = PhpCsFixer\Config::create()
     ->setUsingCache(true)
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => [
@@ -15,6 +16,8 @@ $config = PhpCsFixer\Config::create()
         'no_extra_consecutive_blank_lines' => true,
         'no_unused_imports' => true,
         'ordered_imports' => true,
+        'php_unit_expectation' => true,
+        'php_unit_no_expectation_annotation' => true,
         'psr0' => false,
         'single_blank_line_before_namespace' => true,
         'return_type_declaration' => true,

--- a/tests/Application/SpeakersTest.php
+++ b/tests/Application/SpeakersTest.php
@@ -74,10 +74,10 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \OpenCFP\Domain\EntityNotFoundException
      */
     public function it_throws_an_exception_when_speaker_is_not_found()
     {
+        $this->expectException(\OpenCFP\Domain\EntityNotFoundException::class);
         $this->trainStudentRepositoryToThrowEntityNotFoundException();
         $this->sut->findProfile();
     }
@@ -96,10 +96,10 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \OpenCFP\Application\NotAuthorizedException
      */
     public function it_disallows_speakers_viewing_talks_other_than_their_own()
     {
+        $this->expectException(\OpenCFP\Application\NotAuthorizedException::class);
         // We use relation to grab speakers talks. So if they have none, someone is doing
         // something screwy attempting to get a talk they should be able to.
         $this->trainIdentityProviderToReturnSampleSpeaker($this->getSpeakerWithNoTalks());
@@ -122,10 +122,10 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \OpenCFP\Application\NotAuthorizedException
      */
     public function it_guards_if_spot_relation_ever_returns_talks_that_arent_owned_by_speaker()
     {
+        $this->expectException(\OpenCFP\Application\NotAuthorizedException::class);
         $this->trainIdentityProviderToReturnSampleSpeaker($this->getSpeakerFromMisbehavingSpot());
         $this->sut->getTalk(1);
     }
@@ -173,10 +173,10 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function it_doesnt_allow_talk_submissions_after_cfp_has_ended()
     {
+        $this->expectException(\Exception::class);
         $this->callForProposal->shouldReceive('isOpen')
             ->once()
             ->andReturn(false);

--- a/tests/Domain/Model/AirportTest.php
+++ b/tests/Domain/Model/AirportTest.php
@@ -37,11 +37,11 @@ class AirportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \Exception
-     * @expectedExceptionMessage not found
      */
     public function it_squawks_when_airport_is_not_found()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('not found');
         $this->airports->withCode('foobarbaz');
     }
 

--- a/tests/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/Domain/Talk/TalkSubmissionTest.php
@@ -36,11 +36,11 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      * @dataProvider invalidTalkTitles
-     * @expectedException \OpenCFP\Domain\Talk\InvalidTalkSubmissionException
-     * @expectedExceptionMessage title
      */
     public function it_guards_that_title_is_appropriate_length($title)
     {
+        $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
+        $this->expectExceptionMessage('title');
         TalkSubmission::fromNative(['title' => $title]);
     }
 
@@ -54,11 +54,11 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \OpenCFP\Domain\Talk\InvalidTalkSubmissionException
-     * @expectedExceptionMessage description
      */
     public function it_guards_that_description_is_provided()
     {
+        $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
+        $this->expectExceptionMessage('description');
         TalkSubmission::fromNative([
             'title' => 'Talk With No Description',
             'description' => '',
@@ -67,11 +67,11 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \OpenCFP\Domain\Talk\InvalidTalkSubmissionException
-     * @expectedExceptionMessage talk type
      */
     public function it_guards_that_invalid_talk_types_cannot_be_used()
     {
+        $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
+        $this->expectExceptionMessage('talk type');
         TalkSubmission::fromNative([
             'title' => 'Some off-the-wall Talk Type',
             'description' => 'I do not play by the rules.',
@@ -81,11 +81,11 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \OpenCFP\Domain\Talk\InvalidTalkSubmissionException
-     * @expectedExceptionMessage level
      */
     public function it_guards_that_invalid_level_cannot_be_used()
     {
+        $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
+        $this->expectExceptionMessage('level');
         TalkSubmission::fromNative([
             'title' => 'Invalid Skill Level Talk',
             'description' => 'I do not play by the rules.',
@@ -96,11 +96,11 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \OpenCFP\Domain\Talk\InvalidTalkSubmissionException
-     * @expectedExceptionMessage category
      */
     public function it_guards_that_invalid_categories_cannot_be_assigned()
     {
+        $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
+        $this->expectExceptionMessage('category');
         TalkSubmission::fromNative([
             'title' => 'Invalid Categorized Talk',
             'description' => 'I do not play by the rules.',

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -34,10 +34,10 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_fails_when_given_an_invalid_environment_string()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Environment::fromString('foo');
     }
 }

--- a/tests/Http/API/ApiControllerTest.php
+++ b/tests/Http/API/ApiControllerTest.php
@@ -36,10 +36,10 @@ class ApiControllerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \PHPUnit\Framework\Exception
      */
     public function it_warns_when_successful_status_code_is_used_for_error()
     {
+        $this->expectException(\PHPUnit\Framework\Exception::class);
         $this->sut->setStatusCode(HttpFoundation\Response::HTTP_OK)
             ->respondWithError('Error with success status code');
     }

--- a/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -29,10 +29,10 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \OpenCFP\Domain\Services\NotAuthenticatedException
      */
     public function testGetCurrentUserThrowsNotAuthenticatedExceptionWhenNotAuthenticated()
     {
+        $this->expectException(\OpenCFP\Domain\Services\NotAuthenticatedException::class);
         $sentry = $this->getSentryMock();
 
         $sentry

--- a/tests/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
@@ -23,10 +23,10 @@ class SpotSpeakerRepositoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \OpenCFP\Domain\EntityNotFoundException
      */
     public function testFindByThrowsEntityNotFoundException()
     {
+        $this->expectException(\OpenCFP\Domain\EntityNotFoundException::class);
         $id = $this->getFaker()->randomNumber();
 
         $mapper = $this->getMapperMock();


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_expectation` and `php_unit_no_expectation_annotation` fixers
* [ ] runs `make cs`
* [ ] moves expectations to desired location

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**php_unit_expectation** [@PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
>
>Usages of `->setExpectedException*` methods MUST be replaced by `->expectException* methods`.
>
>Risky rule: risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities.
>
>Configuration options:
>
>* `target` (`'5.2'`, `'5.6'`, `'newest'`): target version of PHPUnit; defaults to `'newest'`

and

>**php_unit_no_expectation_annotation** [@PHPUnit32Migration:risky, @PHPUnit35Migration:risky, `@PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
>
>Usages of `@expectedException*` annotations MUST be replaced by `->setExpectedException*` methods.
>
>Risky rule: risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities.
>
>Configuration options:
>
>* `target` (`'3.2'`, `'4.3'`, `'newest'`): target version of PHPUnit; defaults to `'newest'`
`use_class_const` (`bool`): use `::class` notation; defaults to `true`


Follows #535.