### PR TITLE
Fix: Remove duplicate key from php-cs-fixer configuration

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -19,7 +19,6 @@ $config = PhpCsFixer\Config::create()
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,
         'psr0' => false,
-        'single_blank_line_before_namespace' => true,
         'return_type_declaration' => true,
         'single_blank_line_before_namespace' => true,
         'single_quote' => true,


### PR DESCRIPTION
This PR

* [x] removes a duplicate key from the configuration for `php-cs-fixer`