### PR TITLE
Fix: Move expectations in regard to exceptions

### DIFF
--- a/tests/Application/SpeakersTest.php
+++ b/tests/Application/SpeakersTest.php
@@ -77,8 +77,10 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
      */
     public function it_throws_an_exception_when_speaker_is_not_found()
     {
-        $this->expectException(\OpenCFP\Domain\EntityNotFoundException::class);
         $this->trainStudentRepositoryToThrowEntityNotFoundException();
+
+        $this->expectException(\OpenCFP\Domain\EntityNotFoundException::class);
+
         $this->sut->findProfile();
     }
 
@@ -99,10 +101,12 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
      */
     public function it_disallows_speakers_viewing_talks_other_than_their_own()
     {
-        $this->expectException(\OpenCFP\Application\NotAuthorizedException::class);
         // We use relation to grab speakers talks. So if they have none, someone is doing
         // something screwy attempting to get a talk they should be able to.
         $this->trainIdentityProviderToReturnSampleSpeaker($this->getSpeakerWithNoTalks());
+
+        $this->expectException(\OpenCFP\Application\NotAuthorizedException::class);
+
         $this->sut->getTalk(1);
     }
 
@@ -125,8 +129,10 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
      */
     public function it_guards_if_spot_relation_ever_returns_talks_that_arent_owned_by_speaker()
     {
-        $this->expectException(\OpenCFP\Application\NotAuthorizedException::class);
         $this->trainIdentityProviderToReturnSampleSpeaker($this->getSpeakerFromMisbehavingSpot());
+
+        $this->expectException(\OpenCFP\Application\NotAuthorizedException::class);
+
         $this->sut->getTalk(1);
     }
 
@@ -176,7 +182,6 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
      */
     public function it_doesnt_allow_talk_submissions_after_cfp_has_ended()
     {
-        $this->expectException(\Exception::class);
         $this->callForProposal->shouldReceive('isOpen')
             ->once()
             ->andReturn(false);
@@ -187,6 +192,8 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
             'category' => 'api',
             'level' => 'mid',
         ]);
+
+        $this->expectException(\Exception::class);
 
         $this->sut->submitTalk($submission);
     }

--- a/tests/Domain/Model/AirportTest.php
+++ b/tests/Domain/Model/AirportTest.php
@@ -42,6 +42,7 @@ class AirportTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('not found');
+
         $this->airports->withCode('foobarbaz');
     }
 

--- a/tests/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/Domain/Talk/TalkSubmissionTest.php
@@ -41,6 +41,7 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
         $this->expectExceptionMessage('title');
+
         TalkSubmission::fromNative(['title' => $title]);
     }
 
@@ -59,6 +60,7 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
         $this->expectExceptionMessage('description');
+
         TalkSubmission::fromNative([
             'title' => 'Talk With No Description',
             'description' => '',
@@ -72,6 +74,7 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
         $this->expectExceptionMessage('talk type');
+
         TalkSubmission::fromNative([
             'title' => 'Some off-the-wall Talk Type',
             'description' => 'I do not play by the rules.',
@@ -86,6 +89,7 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
         $this->expectExceptionMessage('level');
+
         TalkSubmission::fromNative([
             'title' => 'Invalid Skill Level Talk',
             'description' => 'I do not play by the rules.',
@@ -101,6 +105,7 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\OpenCFP\Domain\Talk\InvalidTalkSubmissionException::class);
         $this->expectExceptionMessage('category');
+
         TalkSubmission::fromNative([
             'title' => 'Invalid Categorized Talk',
             'description' => 'I do not play by the rules.',

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -38,6 +38,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
     public function it_fails_when_given_an_invalid_environment_string()
     {
         $this->expectException(\InvalidArgumentException::class);
+
         Environment::fromString('foo');
     }
 }

--- a/tests/Http/API/ApiControllerTest.php
+++ b/tests/Http/API/ApiControllerTest.php
@@ -39,9 +39,11 @@ class ApiControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function it_warns_when_successful_status_code_is_used_for_error()
     {
+        $this->sut->setStatusCode(HttpFoundation\Response::HTTP_OK);
+
         $this->expectException(\PHPUnit\Framework\Exception::class);
-        $this->sut->setStatusCode(HttpFoundation\Response::HTTP_OK)
-            ->respondWithError('Error with success status code');
+
+        $this->sut->respondWithError('Error with success status code');
     }
 
     /** @test */

--- a/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -32,7 +32,6 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetCurrentUserThrowsNotAuthenticatedExceptionWhenNotAuthenticated()
     {
-        $this->expectException(\OpenCFP\Domain\Services\NotAuthenticatedException::class);
         $sentry = $this->getSentryMock();
 
         $sentry
@@ -49,6 +48,8 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
             $sentry,
             $speakerRepository
         );
+
+        $this->expectException(\OpenCFP\Domain\Services\NotAuthenticatedException::class);
 
         $provider->getCurrentUser();
     }

--- a/tests/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/SpotSpeakerRepositoryTest.php
@@ -22,11 +22,8 @@ class SpotSpeakerRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(SpeakerRepository::class, $repository);
     }
 
-    /**
-     */
     public function testFindByThrowsEntityNotFoundException()
     {
-        $this->expectException(\OpenCFP\Domain\EntityNotFoundException::class);
         $id = $this->getFaker()->randomNumber();
 
         $mapper = $this->getMapperMock();
@@ -39,6 +36,8 @@ class SpotSpeakerRepositoryTest extends \PHPUnit\Framework\TestCase
         ;
 
         $repository = new SpotSpeakerRepository($mapper);
+
+        $this->expectException(\OpenCFP\Domain\EntityNotFoundException::class);
 
         $repository->findById($id);
     }


### PR DESCRIPTION
This PR

* [x] moves expectations in regard to exceptions right before the *act* phase

Follows #549.

💁‍♂️ For reference, see https://thephp.cc/news/2016/02/questioning-phpunit-best-practices.