### PR TITLE
Fix: Remove useless annotation

### DIFF
--- a/tests/Infrastructure/Auth/AdminAccessTest.php
+++ b/tests/Infrastructure/Auth/AdminAccessTest.php
@@ -11,10 +11,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class AdminAccessTest extends WebTestCase
 {
-
-    /**
-     * @test
-     */
     public function testReturnsRedirectIfCheckFailed()
     {
         $auth = Mockery::mock(Authentication::class);
@@ -24,9 +20,6 @@ class AdminAccessTest extends WebTestCase
         $this->assertInstanceOf(RedirectResponse::class, AdminAccess::userHasAccess($this->app));
     }
 
-    /**
-     * @test
-     */
     public function testReturnsFalseIfCheckSucceededButUserHasNoAdminPermission()
     {
         $user = Mockery::mock(UserInterface::class);
@@ -40,9 +33,6 @@ class AdminAccessTest extends WebTestCase
         $this->assertInstanceOf(RedirectResponse::class, AdminAccess::userHasAccess($this->app));
     }
 
-    /**
-     * @test
-     */
     public function testReturnsNothingIfCheckSucceededAndUserHasAdminPermission()
     {
         $user = Mockery::mock(UserInterface::class);

--- a/tests/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Infrastructure/Auth/SpeakerAccessTest.php
@@ -10,9 +10,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class SpeakerAccessTest extends WebTestCase
 {
-    /**
-     * @test
-     */
     public function testReturnsRedirectIfCheckFailed()
     {
         $auth = Mockery::mock(Authentication::class);
@@ -21,9 +18,6 @@ class SpeakerAccessTest extends WebTestCase
         $this->assertInstanceOf(RedirectResponse::class, SpeakerAccess::userHasAccess($this->app));
     }
 
-    /**
-     * @test
-     */
     public function testReturnsNothingIfUserIsLoggedIn()
     {
         $auth = Mockery::mock(Authentication::class);
@@ -32,9 +26,6 @@ class SpeakerAccessTest extends WebTestCase
         $this->assertNull(SpeakerAccess::userHasAccess($this->app));
     }
 
-    /**
-     * @test
-     */
     public function testAnAdminHasAccessToSpeakerPages()
     {
         $this->asAdmin();


### PR DESCRIPTION
This PR

* [x] removes useless `@test` annotations

💁‍♂️ Test methods are already prefixed with `test`.
