### PR TITLE
Enhancement: Enable phpdoc_separation fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,6 +16,7 @@ $config = PhpCsFixer\Config::create()
         'no_extra_consecutive_blank_lines' => true,
         'no_unused_imports' => true,
         'ordered_imports' => true,
+        'phpdoc_separation' => true,
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,
         'psr0' => false,

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -184,6 +184,7 @@ class Application extends SilexApplication
 
     /**
      * Get the base path for the application.
+     *
      * @return string
      */
     public function basePath()
@@ -193,6 +194,7 @@ class Application extends SilexApplication
 
     /**
      * Get the configuration path.
+     *
      * @return string
      */
     public function configPath()
@@ -202,6 +204,7 @@ class Application extends SilexApplication
 
     /**
      * Get the uploads path.
+     *
      * @return string
      */
     public function uploadPath()
@@ -211,6 +214,7 @@ class Application extends SilexApplication
 
     /**
      * Get the templates path.
+     *
      * @return string
      */
     public function templatesPath()
@@ -220,6 +224,7 @@ class Application extends SilexApplication
 
     /**
      * Get the public path.
+     *
      * @return string
      */
     public function publicPath()
@@ -229,6 +234,7 @@ class Application extends SilexApplication
 
     /**
      * Get the assets path.
+     *
      * @return string
      */
     public function assetsPath()
@@ -238,6 +244,7 @@ class Application extends SilexApplication
 
     /**
      * Get the Twig cache path.
+     *
      * @return string
      */
     public function cacheTwigPath()
@@ -247,6 +254,7 @@ class Application extends SilexApplication
 
     /**
      * Get the HTML Purifier cache path.
+     *
      * @return string
      */
     public function cachePurifierPath()
@@ -256,6 +264,7 @@ class Application extends SilexApplication
 
     /**
      * Tells if application is in production environment.
+     *
      * @return boolean
      */
     public function isProduction()
@@ -265,6 +274,7 @@ class Application extends SilexApplication
 
     /**
      * Tells if application is in development environment.
+     *
      * @return boolean
      */
     public function isDevelopment()
@@ -274,6 +284,7 @@ class Application extends SilexApplication
 
     /**
      * Tells if application is in testing environment.
+     *
      * @return boolean
      */
     public function isTesting()

--- a/classes/Application/Speakers.php
+++ b/classes/Application/Speakers.php
@@ -61,6 +61,7 @@ class Speakers
      * @param int $talkId
      *
      * @return Talk
+     *
      * @throws NotAuthorizedException
      */
     public function getTalk(int $talkId)
@@ -94,6 +95,7 @@ class Speakers
      * @param TalkSubmission $submission
      *
      * @return Talk
+     *
      * @throws \Exception
      */
     public function submitTalk(TalkSubmission $submission): Talk

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -21,6 +21,7 @@ class Application extends ConsoleApplication
 
     /**
      * Application constructor.
+     *
      * @param ApplicationContainer $app
      */
     public function __construct(ApplicationContainer $app)

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -9,6 +9,7 @@ class Talk extends Mapper
 {
     /**
      * Column Sort By White List
+     *
      * @var array
      */
     protected $order_by_whitelist = [
@@ -25,7 +26,9 @@ class Talk extends Mapper
      *
      * @param integer $admin_user_id
      * @param array $options
+     *
      * @return array If order by is not in white list
+     *
      * @internal param string $order_by
      * @internal param string $sort Sort Direction
      */
@@ -64,6 +67,7 @@ class Talk extends Mapper
      *
      * @param integer $admin_user_id
      * @param array $options Ordery By and Sorting Options
+     *
      * @return array
      */
     public function getSelected($admin_user_id, $options = [])
@@ -94,7 +98,9 @@ class Talk extends Mapper
      *
      * @param  integer $admin_user_id
      * @param int $limit
+     *
      * @return array
+     *
      * @internal param int $limt
      */
     public function getRecent($admin_user_id, $limit = 10)
@@ -117,6 +123,7 @@ class Talk extends Mapper
      *
      * @param integer $admin_user_id
      * @param array $options Ordery By and Sorting Options
+     *
      * @return array
      */
     public function getFavoritesByUserId($admin_user_id, $options = [])
@@ -152,6 +159,7 @@ class Talk extends Mapper
      *
      * @param integer $admin_user_id
      * @param array $options Ordery By and Sorting Options
+     *
      * @return array
      */
     public function getTopRatedByUserId($admin_user_id, $options = [])
@@ -186,6 +194,7 @@ class Talk extends Mapper
      *
      * @param integer $admin_user_id
      * @param array $options Ordery By and Sorting Options
+     *
      * @return array
      */
     public function getNotViewedByUserId($admin_user_id, $options = [])
@@ -220,6 +229,7 @@ class Talk extends Mapper
      *
      * @param integer $admin_user_id
      * @param array $options Ordery By and Sorting Options
+     *
      * @return array
      */
     public function getViewedByUserId($admin_user_id, $options = [])
@@ -254,6 +264,7 @@ class Talk extends Mapper
      *
      * @param integer $admin_user_id
      * @param array $options Ordery By and Sorting Options
+     *
      * @return array
      */
     public function getRatedByUserId($admin_user_id, $options = [])
@@ -288,6 +299,7 @@ class Talk extends Mapper
      *
      * @param integer $admin_user_id
      * @param array $options Ordery By and Sorting Options
+     *
      * @return array
      */
     public function getPlusOneByUserId($admin_user_id, $options = [])
@@ -321,6 +333,7 @@ class Talk extends Mapper
      *
      * @param integer $admin_user_id
      * @param array $options Ordery By and Sorting Options
+     *
      * @return array
      */
     public function getNotRatedByUserId($admin_user_id, $options = [])
@@ -357,7 +370,9 @@ class Talk extends Mapper
      * @param mixed $value Column value
      * @param integer $admin_user_id
      * @param array $options Ordery By and Sorting Options
+     *
      * @return array column is not in the column white list
+     *
      * @throws InvalidArgumentException
      */
     public function getTalksFilteredBy($column, $value, $admin_user_id, $options = [])
@@ -399,6 +414,7 @@ class Talk extends Mapper
      * specific user
      *
      * @param  integer $user_id
+     *
      * @return array
      */
     public function getByUser($user_id)
@@ -411,6 +427,7 @@ class Talk extends Mapper
      *
      * @param  mixed   $talk
      * @param  integer $admin_user_id
+     *
      * @return array
      */
     public function createdFormattedOutput($talk, $admin_user_id, $userData = true)
@@ -425,6 +442,7 @@ class Talk extends Mapper
      *
      * @param array $options Sorting Options to Apply
      * @param array $defaultOptions Default Sorting Options
+     *
      * @return array
      */
     protected function getSortOptions(array $options, array $defaultOptions)

--- a/classes/Domain/Entity/Mapper/User.php
+++ b/classes/Domain/Entity/Mapper/User.php
@@ -10,6 +10,7 @@ class User extends Mapper
      * Return an array that grabs info from the User and Speaker entities
      *
      * @param  integer $user_id
+     *
      * @return array
      */
     public function getDetails($user_id)

--- a/classes/Domain/Entity/User.php
+++ b/classes/Domain/Entity/User.php
@@ -50,6 +50,7 @@ class User extends Entity
 
     /**
      * Getter for permissions property
+     *
      * @return array
      */
     protected function getPermissions()
@@ -59,7 +60,9 @@ class User extends Entity
 
     /**
      * Setter for permissions property
+     *
      * @param  string|array $permissions JSON string or an array of permissions
+     *
      * @return string       JSON
      */
     protected function setPermissions($permissions)

--- a/classes/Domain/Model/Airport.php
+++ b/classes/Domain/Model/Airport.php
@@ -13,6 +13,7 @@ class Airport extends Eloquent implements AirportInformationDatabase
      * @param string $code the IATA Airport Code to get information for
      *
      * @return self
+     *
      * @throws \Exception
      */
     public function withCode($code): self

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -31,6 +31,7 @@ class User extends Eloquent
      * If called with no parameters returns all talks of that user.
      *
      * @param int $talkId
+     *
      * @return Collection|Talk[]
      */
     public function getOtherTalks($talkId = 0): Collection

--- a/classes/Domain/Services/AirportInformationDatabase.php
+++ b/classes/Domain/Services/AirportInformationDatabase.php
@@ -8,6 +8,7 @@ interface AirportInformationDatabase
 {
     /**
      * @param string $code the IATA Airport Code to get information for
+     *
      * @see https://en.wikipedia.org/wiki/International_Air_Transport_Association_airport_code
      *
      * @return Airport

--- a/classes/Domain/Services/Authentication.php
+++ b/classes/Domain/Services/Authentication.php
@@ -20,6 +20,7 @@ interface Authentication
      * Returns current authenticated User account.
      *
      * @return UserInterface
+     *
      * @throws NotAuthenticatedException
      */
     public function user(): UserInterface;
@@ -28,6 +29,7 @@ interface Authentication
      * Returns current authenticated User Id.
      *
      * @return int
+     *
      * @throws NotAuthenticatedException
      */
     public function userId(): int;

--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  * Handle taking an image file uplaoded via a form and resizing/cropping/resaving.
  *
  * Class ProfileImageProcessor
+ *
  * @author Michael Williams <themrwilliams@gmail.com>
  */
 class ProfileImageProcessor

--- a/classes/Domain/Services/ResetEmailer.php
+++ b/classes/Domain/Services/ResetEmailer.php
@@ -42,6 +42,7 @@ class ResetEmailer
      * @param string $userId
      * @param string $email
      * @param string $resetCode
+     *
      * @return int
      */
     public function send($userId, $email, $resetCode)
@@ -60,6 +61,7 @@ class ResetEmailer
     /**
      * @param string $userId
      * @param string $resetCode
+     *
      * @return array
      */
     private function parameters($userId, $resetCode)
@@ -78,6 +80,7 @@ class ResetEmailer
     /**
      * @param string $email
      * @param array $parameters
+     *
      * @return \Swift_Message
      */
     private function preparedMessage($email, $parameters)

--- a/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
@@ -9,6 +9,7 @@ interface TalkRatingStrategy
     /**
      * @param int $talkId
      * @param $rating
+     *
      * @throws TalkRatingException
      *
      */

--- a/classes/Domain/Services/UserAccess.php
+++ b/classes/Domain/Services/UserAccess.php
@@ -11,6 +11,7 @@ interface UserAccess
      * If a user doesn't have access to a page they get redirected, otherwise nothing happens
      *
      * @param Application $app
+     *
      * @return RedirectResponse|void
      */
     public static function userHasAccess(Application $app);

--- a/classes/Domain/Speaker/SpeakerRepository.php
+++ b/classes/Domain/Speaker/SpeakerRepository.php
@@ -11,7 +11,9 @@ interface SpeakerRepository
      * Retrieves a speaker with associated talks.
      *
      * @param  string                  $speakerId
+     *
      * @throws EntityNotFoundException
+     *
      * @return User                    the speaker that matches given identifier.
      */
     public function findById($speakerId);
@@ -20,6 +22,7 @@ interface SpeakerRepository
      * Saves a speaker and their talks.
      *
      * @param  User  $speaker
+     *
      * @return mixed
      */
     public function persist(User $speaker);

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -14,6 +14,7 @@ class TalkFormatter implements TalkFormat
      * @param Collection $talkCollection Collection of Talks
      * @param integer $admin_user_id
      * @param bool $userData
+     *
      * @return Collection
      */
     public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true): Collection
@@ -30,6 +31,7 @@ class TalkFormatter implements TalkFormat
      * @param mixed $talk
      * @param integer $admin_user_id
      * @param bool $userData grab the speaker data or not
+     *
      * @return array
      */
     public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true): array

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -6,6 +6,7 @@ class Environment
 {
     /**
      * The specified environment.
+     *
      * @var string
      */
     protected $slug;
@@ -65,6 +66,7 @@ class Environment
 
     /**
      * @param  Environment $environment
+     *
      * @return bool
      */
     public function equals(Environment $environment)

--- a/classes/Http/API/TalkController.php
+++ b/classes/Http/API/TalkController.php
@@ -26,6 +26,7 @@ class TalkController extends ApiController
      * @param Request $request
      *
      * @return JsonResponse
+     *
      * @throws Exception
      */
     public function handleSubmitTalk(Request $request)

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -71,6 +71,7 @@ class ExportsController extends BaseController
      * This stops the cell from being executed as a formula in excel/google sheets etc.
      *
      * @param string $info
+     *
      * @return string
      */
     private function csvFormat($info)

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -183,6 +183,7 @@ class TalksController extends BaseController
      * Set Favorited Talk [POST]
      *
      * @param  Request $req Request Object
+     *
      * @return bool
      */
     public function favoriteAction(Request $req)
@@ -232,6 +233,7 @@ class TalksController extends BaseController
      * Set Selected Talk [POST]
      *
      * @param  Request $req Request Object
+     *
      * @return bool
      */
     public function selectAction(Request $req)

--- a/classes/Http/Controller/FlashableTrait.php
+++ b/classes/Http/Controller/FlashableTrait.php
@@ -10,6 +10,7 @@ trait FlashableTrait
      * Get Session Flash Message
      *
      * @param  Application $app OpenCFP Application
+     *
      * @return array
      */
     public function getFlash(Application $app)

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -226,6 +226,7 @@ class ProfileController extends BaseController
      *
      * @param  Application $app
      * @param  array       $sanitized_data
+     *
      * @return boolean
      */
     protected function saveUser($app, $sanitized_data)

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -18,6 +18,7 @@ class TalkController extends BaseController
 
     /**
      * @param $request_data
+     *
      * @return TalkForm
      */
     private function getTalkForm($request_data)
@@ -88,6 +89,7 @@ class TalkController extends BaseController
      * Controller action for viewing a specific talk
      *
      * @param  Request $req
+     *
      * @return mixed
      */
     public function viewAction(Request $req)
@@ -109,6 +111,7 @@ class TalkController extends BaseController
      * Controller action for displaying the form to edit an existing talk
      *
      * @param  Request $req
+     *
      * @return mixed
      */
     public function editAction(Request $req)
@@ -171,6 +174,7 @@ class TalkController extends BaseController
      * Action for displaying the form to create a new talk
      *
      * @param  Request $req
+     *
      * @return mixed
      */
     public function createAction(Request $req)
@@ -213,6 +217,7 @@ class TalkController extends BaseController
      * a new talk
      *
      * @param  Request $req
+     *
      * @return mixed
      */
     public function processCreateAction(Request $req)
@@ -446,6 +451,7 @@ class TalkController extends BaseController
      * @param  Application $app
      * @param  string      $email
      * @param  integer     $talk_id
+     *
      * @return mixed
      */
     protected function sendSubmitEmail(Application $app, $email, $talk_id)

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -70,7 +70,9 @@ abstract class Form
      * Returns the clean data.
      *
      * @array array $keys The wanted data
+     *
      * @param  array $keys
+     *
      * @return array The cleaned data
      */
     public function getCleanData(array $keys = [])
@@ -94,6 +96,7 @@ abstract class Form
      *
      * @param  string     $name    The tainted value name
      * @param  mixed      $default The default value to return if not set
+     *
      * @return mixed|null
      */
     public function getTaintedField($name, $default = null)
@@ -116,6 +119,7 @@ abstract class Form
      *
      * @param  string     $name    The option name
      * @param  mixed|null $default The default value
+     *
      * @return mixed      The option value
      */
     public function getOption($name, $default = null)
@@ -174,6 +178,7 @@ abstract class Form
      * Sanitizes all fields that were submitted.
      *
      * @param  array $taintedData The tainted data
+     *
      * @return array Sanitized data
      */
     protected function internalSanitize(array $taintedData): array

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -28,6 +28,7 @@ class SignupForm extends Form
      * Validate all methods by calling all our validation methods
      *
      * @param  string  $action
+     *
      * @return boolean
      */
     public function validateAll($action = 'create')
@@ -115,6 +116,7 @@ class SignupForm extends Form
      * Method that applies validation rules to email
      *
      * @return bool
+     *
      * @internal param string $email
      */
     public function validateEmail(): bool

--- a/classes/Http/View/TalkHelper.php
+++ b/classes/Http/View/TalkHelper.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Http\View;
 
 /**
  * Class TalkHelper
+ *
  * @package OpenCFP\Http\View
  */
 class TalkHelper
@@ -25,6 +26,7 @@ class TalkHelper
 
     /**
      * TalkHelper constructor.
+     *
      * @param $categories
      * @param $levels
      * @param $types
@@ -38,6 +40,7 @@ class TalkHelper
 
     /**
      * @param $category
+     *
      * @return mixed
      */
     public function getCategoryDisplayName($category)
@@ -51,6 +54,7 @@ class TalkHelper
 
     /**
      * @param $type
+     *
      * @return mixed
      */
     public function getTypeDisplayName($type)
@@ -64,6 +68,7 @@ class TalkHelper
 
     /**
      * @param $level
+     *
      * @return mixed
      */
     public function getLevelDisplayName($level)

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -40,7 +40,9 @@ class SentryAuthentication implements Authentication
 
     /**
      * Returns current authenticated User account.
+     *
      * @return UserInterface
+     *
      * @throws NotAuthenticatedException
      */
     public function user(): UserInterface

--- a/classes/Infrastructure/Auth/SpeakerAccess.php
+++ b/classes/Infrastructure/Auth/SpeakerAccess.php
@@ -14,6 +14,7 @@ class SpeakerAccess implements UserAccess
      * If a user doesn't have access to a page they get redirected, otherwise nothing happens
      *
      * @param Application $app
+     *
      * @return RedirectResponse|void
      */
     public static function userHasAccess(Application $app)

--- a/classes/Provider/CiconiaEngine.php
+++ b/classes/Provider/CiconiaEngine.php
@@ -9,12 +9,14 @@ class CiconiaEngine implements MarkdownEngineInterface
 {
     /**
      * Ciconia Markdown Engine
+     *
      * @var Ciconia
      */
     protected $engine;
 
     /**
      * Set engine to internal property
+     *
      * @param Ciconia $engine Markdown Parser Engine
      */
     public function __construct(Ciconia $engine)

--- a/classes/Provider/ControllerResolver.php
+++ b/classes/Provider/ControllerResolver.php
@@ -11,6 +11,7 @@ class ControllerResolver extends \Silex\ControllerResolver
      * into our controllers.
      *
      * @param  string      $controller
+     *
      * @return array|mixed
      */
     protected function createController($controller)

--- a/classes/Provider/Gateways/RequestCleaner.php
+++ b/classes/Provider/Gateways/RequestCleaner.php
@@ -15,6 +15,7 @@ class RequestCleaner
 
     /**
      * RequestCleaner constructor.
+     *
      * @param HTMLPurifier $purifier
      */
     public function __construct(HTMLPurifier $purifier)

--- a/tests/Console/AdminPromoteCommandTest.php
+++ b/tests/Console/AdminPromoteCommandTest.php
@@ -9,6 +9,7 @@ use OpenCFP\Environment;
 
 /**
  * Class AdminPromoteTest
+ *
  * @package OpenCFP\Test\Console
  * @group db
  */

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console;
 
 /**
  * Class ApplicationTest
+ *
  * @package OpenCFP\Test\Console
  * @group db
  */

--- a/tests/ContainerAwareFake.php
+++ b/tests/ContainerAwareFake.php
@@ -10,6 +10,7 @@ class ContainerAwareFake
 
     /**
      * @param string $slug
+     *
      * @return mixed
      */
     public function getService($slug)

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 
 /**
  * Class SpeakersControllerTest
+ *
  * @package OpenCFP\Test\Http\Controller\Admin
  * @group db
  */

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -11,6 +11,7 @@ use OpenCFP\Test\WebTestCase;
 
 /**
  * Class DashboardControllerTest
+ *
  * @package OpenCFP\Test\Http\Controller
  * @group db
  */

--- a/tests/Http/Controller/FlashableTraitTest.php
+++ b/tests/Http/Controller/FlashableTraitTest.php
@@ -66,6 +66,7 @@ class FlashableTraitTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param array $items
+     *
      * @return Application|\PHPUnit_Framework_MockObject_MockObject
      */
     private function getApplicationMock(array $items = [])

--- a/tests/Http/Controller/ForgotControllerTest.php
+++ b/tests/Http/Controller/ForgotControllerTest.php
@@ -10,6 +10,7 @@ use OpenCFP\Environment;
 
 /**
  * Class ForgotControllerTest
+ *
  * @package OpenCFP\Test\Http\Controller
  * @group db
  */

--- a/tests/Http/Controller/ProfileControllerTest.php
+++ b/tests/Http/Controller/ProfileControllerTest.php
@@ -12,6 +12,7 @@ use Spot\Locator;
 
 /**
  * Class ProfileControllerTest
+ *
  * @package OpenCFP\Test\Http\Controller
  * @group db
  */

--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 
 /**
  * Class SignupControllerTest
+ *
  * @package OpenCFP\Test\Http\Controller
  * @group db
  */

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -13,6 +13,7 @@ use OpenCFP\Http\Controller\TalkController;
 
 /**
  * Class TalkControllerTest
+ *
  * @package OpenCFP\Test\Http\Controller
  * @group db
  */
@@ -125,6 +126,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
      * action
      *
      * @param  mixed $data
+     *
      * @return void
      */
     protected function setPost($data)

--- a/tests/Http/Form/SignupFormTest.php
+++ b/tests/Http/Form/SignupFormTest.php
@@ -53,6 +53,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      * Verify that emails are being validated correctly
      *
      * @test
+     *
      * @param string  $email
      * @param boolean $expectedResponse
      * @dataProvider emailProvider
@@ -120,6 +121,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      * and sanitization
      *
      * @test
+     *
      * @param string $passwd
      * @dataProvider properPasswordValidator
      */
@@ -142,6 +144,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      * Test that bad passwords are being correctly matched and sanitized
      *
      * @test
+     *
      * @param string  $passwd
      * @param string  $passwd2
      * @param string  $expectedMessage
@@ -186,6 +189,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      * Test that the firstName is being validated correctly
      *
      * @test
+     *
      * @param string  $firstName
      * @param boolean $expectedResponse
      * @dataProvider firstNameProvider
@@ -229,6 +233,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      * Test that the lastName is being validated correctly
      *
      * @test
+     *
      * @param string  $lastName
      * @param boolean $expectedResponse
      * @dataProvider lastNameProvider
@@ -273,6 +278,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      * fields works correctly
      *
      * @test
+     *
      * @param array   $data
      * @param boolean $expectedResponse
      * @dataProvider validateAllProvider
@@ -315,6 +321,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      * Test that speaker info is validated correctly
      *
      * @test
+     *
      * @param string  $speakerInfo
      * @param boolean $expectedResponse
      * @dataProvider speakerTextProvider
@@ -336,6 +343,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      * Test that speaker info is validated correctly
      *
      * @test
+     *
      * @param string  $speakerBio
      * @param boolean $expectedResponse
      * @dataProvider speakerTextProvider
@@ -369,6 +377,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      * Test that we get back some sanitized data
      *
      * @test
+     *
      * @param array $inputData
      * @param array $expectedData
      * @dataProvider sanitizationProvider

--- a/tests/Http/Form/TalkFormTest.php
+++ b/tests/Http/Form/TalkFormTest.php
@@ -21,6 +21,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @dataProvider hasRequiredProvider
+     *
      * @param array   $rawData  serialized user-submitted data
      * @param boolean $response
      */
@@ -78,6 +79,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @dataProvider hasNoDesiredOrSponsorProvider
+     *
      * @param array   $rawData  serialized user-submitted data
      * @param boolean $response
      */
@@ -123,6 +125,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @dataProvider titleValidatesProvider
+     *
      * @param string  $title
      * @param boolean $expectedResponse
      */
@@ -164,6 +167,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @dataProvider descriptionValidatesProvider
+     *
      * @param string  $description
      * @param boolean $expectedResponse
      */
@@ -204,6 +208,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @dataProvider typeProvider
+     *
      * @param string  $type
      * @param boolean $expectedResponse
      */
@@ -250,6 +255,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @dataProvider categoryProvider
+     *
      * @param string  $category
      * @param boolean $expectedResponse
      */
@@ -314,6 +320,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @dataProvider levelProvider
+     *
      * @param string $level
      * @param boolean $expectedResponse
      */

--- a/tests/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -7,6 +7,7 @@ use OpenCFP\Test\DatabaseTransaction;
 
 /**
  * Class SentryAccountManagementTest
+ *
  * @package OpenCFP\Test\Infrastructure\Auth
  * @group db
  */

--- a/tests/Infrastructure/Auth/SentryAuthenticationTest.php
+++ b/tests/Infrastructure/Auth/SentryAuthenticationTest.php
@@ -8,6 +8,7 @@ use OpenCFP\Test\DatabaseTransaction;
 
 /**
  * Class SentryAuthenticationTest
+ *
  * @package OpenCFP\Test\Infrastructure\Auth
  * @group db
  */

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -66,6 +66,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param string $service
      * @param object $instance
+     *
      * @return object
      */
     protected function swap($service, $instance)
@@ -78,6 +79,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
      * Define additional headers to be sent with the request.
      *
      * @param array $headers
+     *
      * @return $this
      */
     public function withHeaders(array $headers): self

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -7,6 +7,7 @@ if (! function_exists('factory')) {
      * Create a model factory builder for a given class, name, and amount.
      *
      * @param  dynamic  class|class,name|class,amount|class,name,amount
+     *
      * @return \Illuminate\Database\Eloquent\FactoryBuilder
      */
     function factory()


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_separation` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**phpdoc_separation** [`@Symfony`]
>
>Annotations in phpdocs should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.