### PR TITLE
Enhancement: PHP Mess Detector for Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,6 +10,8 @@ engines:
     enabled: true
     config:
       standard: PSR2
+  phpmd:
+    enabled: true
 
 ratings:
   paths:


### PR DESCRIPTION
This PR adds the PHPMD option to code climate. 

This should be useful to give more insight into where faults within the code base are, and give better insight in what future PR's do to the complexity of the code base.

For more info see: https://docs.codeclimate.com/docs/phpmd, and the PHPMD documentation https://phpmd.org/