### PR TITLE
Fix: Remove codeclimate/php-test-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 env:
   global:
     - TRAVIS_DB=cfp_test
-    - CODECLIMATE_REPO_TOKEN=9deb249b01a414d979959cfd05a4c351b19a5959858653b20276454d4189edc3
     - CC_TEST_REPORTER_ID=9deb249b01a414d979959cfd05a4c351b19a5959858653b20276454d4189edc3
 
 # cache composer downloads so installing is quicker

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "vlucas/spot2": "dev-master"
     },
     "require-dev": {
-        "codeclimate/php-test-reporter": "0.2.0",
         "friendsofphp/php-cs-fixer": "^2.8.0",
         "fzaninotto/faker": "^1.5.0",
         "mockery/mockery": "1.0.*@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc5302627b28ab96cfbf988684c887ec",
+    "content-hash": "ce30ab80ccefc24fb0f61090e600050e",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -4152,64 +4152,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "codeclimate/php-test-reporter",
-            "version": "v0.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/codeclimate/php-test-reporter.git",
-                "reference": "85b5de950678a25f3e85adb6bc26de7f7f231d18"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/85b5de950678a25f3e85adb6bc26de7f7f231d18",
-                "reference": "85b5de950678a25f3e85adb6bc26de7f7f231d18",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "php": ">=5.3",
-                "satooshi/php-coveralls": "0.6.*",
-                "symfony/console": ">=2.0"
-            },
-            "require-dev": {
-                "ext-xdebug": "*",
-                "phpunit/phpunit": "3.7.*@stable"
-            },
-            "bin": [
-                "composer/bin/test-reporter"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "CodeClimate\\Component": "src/",
-                    "CodeClimate\\Bundle": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Code Climate",
-                    "email": "hello@codeclimate.com",
-                    "homepage": "https://codeclimate.com"
-                }
-            ],
-            "description": "PHP client for reporting test coverage to Code Climate",
-            "homepage": "https://github.com/codeclimate/php-test-reporter",
-            "keywords": [
-                "codeclimate",
-                "coverage"
-            ],
-            "time": "2015-09-08T14:22:33+00:00"
-        },
         {
             "name": "composer/semver",
             "version": "1.4.2",


### PR DESCRIPTION
This PR

* [x] removes `codeclimate/php-test-reporter`
* [x] removes the unused `CODECLIMATE_REPO_TOKEN` environment variable from `.travis.yml`

Follows #562.