### PR TITLE
Enhancement: Enable phpdoc_align fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,6 +16,7 @@ $config = PhpCsFixer\Config::create()
         'no_extra_consecutive_blank_lines' => true,
         'no_unused_imports' => true,
         'ordered_imports' => true,
+        'phpdoc_align' => true,
         'phpdoc_separation' => true,
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -25,7 +25,7 @@ class Talk extends Mapper
      * user has favourited this talk
      *
      * @param integer $admin_user_id
-     * @param array $options
+     * @param array   $options
      *
      * @return array If order by is not in white list
      *
@@ -66,7 +66,7 @@ class Talk extends Mapper
      * Return a collection of talks that have been selected
      *
      * @param integer $admin_user_id
-     * @param array $options Ordery By and Sorting Options
+     * @param array   $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -96,8 +96,8 @@ class Talk extends Mapper
     /**
      * Return an array of recent talks
      *
-     * @param  integer $admin_user_id
-     * @param int $limit
+     * @param integer $admin_user_id
+     * @param int     $limit
      *
      * @return array
      *
@@ -122,7 +122,7 @@ class Talk extends Mapper
      * Return a collection of talks that a majority of the admins have liked
      *
      * @param integer $admin_user_id
-     * @param array $options Ordery By and Sorting Options
+     * @param array   $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -158,7 +158,7 @@ class Talk extends Mapper
      * the talk rating must be above 0 to show on list
      *
      * @param integer $admin_user_id
-     * @param array $options Ordery By and Sorting Options
+     * @param array   $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -193,7 +193,7 @@ class Talk extends Mapper
      * Return a collection of talks not viewed by admin
      *
      * @param integer $admin_user_id
-     * @param array $options Ordery By and Sorting Options
+     * @param array   $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -228,7 +228,7 @@ class Talk extends Mapper
      * Return a collection of talks viewed by admin
      *
      * @param integer $admin_user_id
-     * @param array $options Ordery By and Sorting Options
+     * @param array   $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -263,7 +263,7 @@ class Talk extends Mapper
      * Return a collection of talks rated by admin
      *
      * @param integer $admin_user_id
-     * @param array $options Ordery By and Sorting Options
+     * @param array   $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -298,7 +298,7 @@ class Talk extends Mapper
      * Return a collection of talks rated +1 by admin
      *
      * @param integer $admin_user_id
-     * @param array $options Ordery By and Sorting Options
+     * @param array   $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -332,7 +332,7 @@ class Talk extends Mapper
      * Return a collection of talks not rated by admin
      *
      * @param integer $admin_user_id
-     * @param array $options Ordery By and Sorting Options
+     * @param array   $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -366,10 +366,10 @@ class Talk extends Mapper
     /**
      * Get a collection of talks filtered by a specific column
      *
-     * @param string $column Column to filter results with
-     * @param mixed $value Column value
+     * @param string  $column        Column to filter results with
+     * @param mixed   $value         Column value
      * @param integer $admin_user_id
-     * @param array $options Ordery By and Sorting Options
+     * @param array   $options       Ordery By and Sorting Options
      *
      * @return array column is not in the column white list
      *
@@ -413,7 +413,7 @@ class Talk extends Mapper
      * Return a collection of entities representing talks that belong to a
      * specific user
      *
-     * @param  integer $user_id
+     * @param integer $user_id
      *
      * @return array
      */
@@ -425,8 +425,8 @@ class Talk extends Mapper
     /**
      * Iterates over DBAL objects and returns a formatted result set
      *
-     * @param  mixed   $talk
-     * @param  integer $admin_user_id
+     * @param mixed   $talk
+     * @param integer $admin_user_id
      *
      * @return array
      */
@@ -440,7 +440,7 @@ class Talk extends Mapper
     /**
      * Get sorting options, order_by and sort direction
      *
-     * @param array $options Sorting Options to Apply
+     * @param array $options        Sorting Options to Apply
      * @param array $defaultOptions Default Sorting Options
      *
      * @return array

--- a/classes/Domain/Entity/Mapper/User.php
+++ b/classes/Domain/Entity/Mapper/User.php
@@ -9,7 +9,7 @@ class User extends Mapper
     /**
      * Return an array that grabs info from the User and Speaker entities
      *
-     * @param  integer $user_id
+     * @param integer $user_id
      *
      * @return array
      */

--- a/classes/Domain/Entity/User.php
+++ b/classes/Domain/Entity/User.php
@@ -61,9 +61,9 @@ class User extends Entity
     /**
      * Setter for permissions property
      *
-     * @param  string|array $permissions JSON string or an array of permissions
+     * @param string|array $permissions JSON string or an array of permissions
      *
-     * @return string       JSON
+     * @return string JSON
      */
     protected function setPermissions($permissions)
     {

--- a/classes/Domain/Services/ResetEmailer.php
+++ b/classes/Domain/Services/ResetEmailer.php
@@ -25,10 +25,10 @@ class ResetEmailer
     private $config_title;
 
     /**
-     * @param \Swift_Mailer $swiftMailer
+     * @param \Swift_Mailer  $swiftMailer
      * @param \Twig_Template $template
-     * @param string $configEmail
-     * @param string $configTitle
+     * @param string         $configEmail
+     * @param string         $configTitle
      */
     public function __construct(\Swift_Mailer $swiftMailer, \Twig_Template $template, $configEmail, $configTitle)
     {
@@ -79,7 +79,7 @@ class ResetEmailer
 
     /**
      * @param string $email
-     * @param array $parameters
+     * @param array  $parameters
      *
      * @return \Swift_Message
      */

--- a/classes/Domain/Speaker/SpeakerRepository.php
+++ b/classes/Domain/Speaker/SpeakerRepository.php
@@ -10,18 +10,18 @@ interface SpeakerRepository
     /**
      * Retrieves a speaker with associated talks.
      *
-     * @param  string                  $speakerId
+     * @param string $speakerId
      *
      * @throws EntityNotFoundException
      *
-     * @return User                    the speaker that matches given identifier.
+     * @return User the speaker that matches given identifier.
      */
     public function findById($speakerId);
 
     /**
      * Saves a speaker and their talks.
      *
-     * @param  User  $speaker
+     * @param User $speaker
      *
      * @return mixed
      */

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -12,8 +12,8 @@ class TalkFormatter implements TalkFormat
      * Iterates over a collection of DBAL objects and returns a formatted result set
      *
      * @param Collection $talkCollection Collection of Talks
-     * @param integer $admin_user_id
-     * @param bool $userData
+     * @param integer    $admin_user_id
+     * @param bool       $userData
      *
      * @return Collection
      */
@@ -28,9 +28,9 @@ class TalkFormatter implements TalkFormat
     /**
      * Iterates over DBAL objects and returns a formatted result set
      *
-     * @param mixed $talk
+     * @param mixed   $talk
      * @param integer $admin_user_id
-     * @param bool $userData grab the speaker data or not
+     * @param bool    $userData      grab the speaker data or not
      *
      * @return array
      */
@@ -95,8 +95,8 @@ class TalkFormatter implements TalkFormat
     /**
      * Grabs the related meta information of the talk, or 0's when there is none
      *
-     * @param mixed $talk Talk we want to get the meta of, both entity and model work.
-     * @param int $admin_user_id user ID of the admin
+     * @param mixed $talk          Talk we want to get the meta of, both entity and model work.
+     * @param int   $admin_user_id user ID of the admin
      *
      * @return TalkMeta
      */

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -65,7 +65,7 @@ class Environment
     }
 
     /**
-     * @param  Environment $environment
+     * @param Environment $environment
      *
      * @return bool
      */

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -183,7 +183,7 @@ class TalksController extends BaseController
     /**
      * Set Favorited Talk [POST]
      *
-     * @param  Request $req Request Object
+     * @param Request $req Request Object
      *
      * @return bool
      */
@@ -211,7 +211,7 @@ class TalksController extends BaseController
     /**
      * Set Selected Talk [POST]
      *
-     * @param  Request $req Request Object
+     * @param Request $req Request Object
      *
      * @return bool
      */

--- a/classes/Http/Controller/FlashableTrait.php
+++ b/classes/Http/Controller/FlashableTrait.php
@@ -9,7 +9,7 @@ trait FlashableTrait
     /**
      * Get Session Flash Message
      *
-     * @param  Application $app OpenCFP Application
+     * @param Application $app OpenCFP Application
      *
      * @return array
      */

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -224,8 +224,8 @@ class ProfileController extends BaseController
     /**
      * Method that saves user info using sanitized data and an Entity mapper
      *
-     * @param  Application $app
-     * @param  array       $sanitized_data
+     * @param Application $app
+     * @param array       $sanitized_data
      *
      * @return boolean
      */

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -88,7 +88,7 @@ class TalkController extends BaseController
     /**
      * Controller action for viewing a specific talk
      *
-     * @param  Request $req
+     * @param Request $req
      *
      * @return mixed
      */
@@ -110,7 +110,7 @@ class TalkController extends BaseController
     /**
      * Controller action for displaying the form to edit an existing talk
      *
-     * @param  Request $req
+     * @param Request $req
      *
      * @return mixed
      */
@@ -173,7 +173,7 @@ class TalkController extends BaseController
     /**
      * Action for displaying the form to create a new talk
      *
-     * @param  Request $req
+     * @param Request $req
      *
      * @return mixed
      */
@@ -216,7 +216,7 @@ class TalkController extends BaseController
      * Controller action the processes the POST request to try and create
      * a new talk
      *
-     * @param  Request $req
+     * @param Request $req
      *
      * @return mixed
      */
@@ -448,9 +448,9 @@ class TalkController extends BaseController
     /**
      * Method that sends an email when a talk is created
      *
-     * @param  Application $app
-     * @param  string      $email
-     * @param  integer     $talk_id
+     * @param Application $app
+     * @param string      $email
+     * @param integer     $talk_id
      *
      * @return mixed
      */

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -71,7 +71,7 @@ abstract class Form
      *
      * @array array $keys The wanted data
      *
-     * @param  array $keys
+     * @param array $keys
      *
      * @return array The cleaned data
      */
@@ -94,8 +94,8 @@ abstract class Form
     /**
      * Returns the value of a tainted data by its name.
      *
-     * @param  string     $name    The tainted value name
-     * @param  mixed      $default The default value to return if not set
+     * @param string $name    The tainted value name
+     * @param mixed  $default The default value to return if not set
      *
      * @return mixed|null
      */
@@ -117,10 +117,10 @@ abstract class Form
     /**
      * Returns the value of a form's option if set.
      *
-     * @param  string     $name    The option name
-     * @param  mixed|null $default The default value
+     * @param string     $name    The option name
+     * @param mixed|null $default The default value
      *
-     * @return mixed      The option value
+     * @return mixed The option value
      */
     public function getOption($name, $default = null)
     {
@@ -177,7 +177,7 @@ abstract class Form
     /**
      * Sanitizes all fields that were submitted.
      *
-     * @param  array $taintedData The tainted data
+     * @param array $taintedData The tainted data
      *
      * @return array Sanitized data
      */

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -27,7 +27,7 @@ class SignupForm extends Form
     /**
      * Validate all methods by calling all our validation methods
      *
-     * @param  string  $action
+     * @param string $action
      *
      * @return boolean
      */

--- a/classes/Provider/ControllerResolver.php
+++ b/classes/Provider/ControllerResolver.php
@@ -10,7 +10,7 @@ class ControllerResolver extends \Silex\ControllerResolver
      * We're overriding this protected method to auto-inject the application container
      * into our controllers.
      *
-     * @param  string      $controller
+     * @param string $controller
      *
      * @return array|mixed
      */

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -125,7 +125,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
      * Method for setting the values that would be posted to a controller
      * action
      *
-     * @param  mixed $data
+     * @param mixed $data
      *
      * @return void
      */

--- a/tests/Http/Form/TalkFormTest.php
+++ b/tests/Http/Form/TalkFormTest.php
@@ -321,7 +321,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider levelProvider
      *
-     * @param string $level
+     * @param string  $level
      * @param boolean $expectedResponse
      */
     public function levelValidatesCorrectly($level, $expectedResponse)


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_align` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**phpdoc_align** [`@Symfony`]
>
>All items of the given phpdoc tags must be aligned vertically.
>
>Configuration options:
>
>* `tags` (`array`): the tags that should be aligned; defaults to `['param', 'return', 'throws', 'type', 'var']`