### PR TITLE
Refactor: profile process action

### DIFF
--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -49,10 +49,15 @@ class ProfileImageProcessor
      * @param UploadedFile $file
      * @param string       $publishFilename
      *
+     * @return string
+     *
      * @throws \Exception
      */
-    public function process(UploadedFile $file, $publishFilename)
+    public function process(UploadedFile $file, $publishFilename = null): string
     {
+        if ($publishFilename === null) {
+            $publishFilename = $this->generator->generate(50). '.'. $file->guessExtension();
+        }
         // Temporary filename to work with.
         $tempFilename = $this->generator->generate(40);
 
@@ -76,6 +81,7 @@ class ProfileImageProcessor
             if ($speakerPhoto->save($this->publishDir . '/' . $publishFilename)) {
                 unlink($this->publishDir . '/' . $tempFilename);
             }
+            return $publishFilename;
         } catch (\Exception $e) {
             unlink($this->publishDir . '/' . $tempFilename);
             throw $e;

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -5,14 +5,11 @@ namespace OpenCFP\Http\Controller;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Http\Form\SignupForm;
-use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
 use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class ProfileController extends BaseController
 {
-    use FlashableTrait;
-
     public function editAction(Request $req)
     {
         $user = $this->service(Authentication::class)->user();
@@ -97,7 +94,7 @@ class ProfileController extends BaseController
         $form_data['formAction'] = $this->url('user_update');
         $form_data['buttonInfo'] = 'Update Profile';
         $form_data['id'] = $userId;
-        $form_data['flash'] = $this->getFlash($this->app);
+        $form_data['flash'] = $this->service('session')->get('flash');
 
         return $this->render('user/edit.twig', $form_data);
     }

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -81,7 +81,7 @@ class ProfileController extends BaseController
 
         if ($isValid) {
             $sanitized_data = $this->transformSanitizedData($form->getCleanData());
-            $sanitized_data['photo_path'] = $this->handlePhoto($form_data['speaker_photo'] ?? null);
+            $sanitized_data['photo_path'] = isset($form_data['speaker_photo']) ? $this->handlePhoto($form_data['speaker_photo']) : null;
 
             User::find($userId)->update($sanitized_data);
             return $this->redirectTo('dashboard');
@@ -205,19 +205,14 @@ class ProfileController extends BaseController
     private function handlePhoto($photo)
     {
         if ($photo !== null && $photo !== '') {
-            /** @var \Symfony\Component\HttpFoundation\File\UploadedFile $file */
-            $file = $photo;
             /** @var \OpenCFP\Domain\Services\ProfileImageProcessor $processor */
             $processor = $this->service('profile_image_processor');
             /** @var PseudoRandomStringGenerator $generator */
             $generator = $this->service('security.random');
 
-            /**
-             * The extension technically is not required. We guess the extension using a trusted method.
-             */
-            $path = $generator->generate(40) . '.' . $file->guessExtension();
+            $path = $generator->generate(40) . '.' . $photo->guessExtension();
+            $processor->process($photo, $path);
 
-            $processor->process($file, $path);
             return $path;
         }
         return null;

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -93,9 +93,9 @@ class ProfileController extends BaseController
                 /**
                  * The extension technically is not required. We guess the extension using a trusted method.
                  */
-                $sanitized_data['speaker_photo'] = $generator->generate(40) . '.' . $file->guessExtension();
+                $sanitized_data['photo_path'] = $generator->generate(40) . '.' . $file->guessExtension();
 
-                $processor->process($file, $sanitized_data['speaker_photo']);
+                $processor->process($file, $sanitized_data['photo_path']);
             }
 
             User::find($userId)->update($sanitized_data);

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -77,11 +77,11 @@ class ProfileController extends BaseController
 
         if ($isValid) {
             $sanitized_data = $this->transformSanitizedData($form->getCleanData());
-            $sanitized_data['photo_path'] =
-                isset($form_data['speaker_photo'])
-                    ? $this->service('profile_image_processor')->process($form_data['speaker_photo'])
-                    : null;
-
+            if (isset($form_data['speaker_photo'])) {
+                $sanitized_data['photo_path'] = $this->service('profile_image_processor')
+                    ->process($form_data['speaker_photo']);
+            }
+            unset($sanitized_data['speaker_photo']);
             User::find($userId)->update($sanitized_data);
             return $this->redirectTo('dashboard');
         }

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -80,10 +80,7 @@ class ProfileController extends BaseController
         $isValid = $form->validateAll('update');
 
         if ($isValid) {
-            $sanitized_data = $form->getCleanData();
-
-            // Remove leading @ for twitter
-            $sanitized_data['twitter'] = preg_replace('/^@/', '', $sanitized_data['twitter']);
+            $sanitized_data = $this->transformSanitizedData($form->getCleanData());
 
             if (isset($form_data['speaker_photo'])) {
                 /** @var \Symfony\Component\HttpFoundation\File\UploadedFile $file */
@@ -101,7 +98,7 @@ class ProfileController extends BaseController
                 $processor->process($file, $sanitized_data['speaker_photo']);
             }
 
-            User::find($userId)->update($this->transformSanitizedData($sanitized_data));
+            User::find($userId)->update($sanitized_data);
             return $this->redirectTo('dashboard');
         }
         $this->service('session')->set('flash', [
@@ -198,8 +195,18 @@ class ProfileController extends BaseController
         return $form_data;
     }
 
+    /**
+     * Transforms the sanitized data array to be used by our User Model for updates
+     *
+     * @param array $sanitizedData
+     *
+     * @return array
+     */
     private function transformSanitizedData(array $sanitizedData): array
     {
+        // Remove leading @ for twitter
+        $sanitizedData['twitter'] = preg_replace('/^@/', '', $sanitizedData['twitter']);
+
         $sanitizedData['bio'] = $sanitizedData['speaker_bio'];
         unset($sanitizedData['speaker_bio']);
         $sanitizedData['info'] = $sanitizedData['speaker_info'];

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -180,6 +180,24 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
         return $this;
     }
 
+    public function asLoggedInSpeaker(int $id = 1): self
+    {
+        $user = Mockery::mock(UserInterface::class);
+        $user->shouldReceive('id')->andReturn($id);
+        $user->shouldReceive('getId')->andReturn($id);
+        $user->shouldReceive('hasAccess')->with('admin')->andReturn(false);
+        $user->shouldReceive('hasPermission')->with('admin')->andReturn(false);
+        $user->shouldReceive('getLogin')->andReturn('my@email.com');
+
+        // Create a test double for Sentry
+        $auth = Mockery::mock(Authentication::class);
+        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('user')->andReturn($user);
+        $auth->shouldReceive('userId')->andReturn($id);
+        $this->swap(Authentication::class, $auth);
+        return $this;
+    }
+
     public function asAdmin(int $id = 1): self
     {
         // Set things up so Sentry believes we're logged in


### PR DESCRIPTION
This PR refactors the profile process action, and its tests.

* The tests are now based on the WebTestCase, and are a lot more readable.
* Added an asLoggedInSpeaker function to WebTestCase
* Some functionality got extracted to new functions
* Put the profile image processor in charge of naming the new file.
* Use illuminate instead of spot