### PR TITLE
Enhancement: Enable phpdoc_scalar fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -17,6 +17,7 @@ $config = PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'ordered_imports' => true,
         'phpdoc_align' => true,
+        'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -265,7 +265,7 @@ class Application extends SilexApplication
     /**
      * Tells if application is in production environment.
      *
-     * @return boolean
+     * @return bool
      */
     public function isProduction()
     {
@@ -275,7 +275,7 @@ class Application extends SilexApplication
     /**
      * Tells if application is in development environment.
      *
-     * @return boolean
+     * @return bool
      */
     public function isDevelopment()
     {
@@ -285,7 +285,7 @@ class Application extends SilexApplication
     /**
      * Tells if application is in testing environment.
      *
-     * @return boolean
+     * @return bool
      */
     public function isTesting()
     {

--- a/classes/Domain/CallForProposal.php
+++ b/classes/Domain/CallForProposal.php
@@ -26,7 +26,7 @@ class CallForProposal
     /**
      * @param \DateTimeInterface $currentTime
      *
-     * @return boolean true if CFP is open, false otherwise.
+     * @return bool true if CFP is open, false otherwise.
      */
     public function isOpen(\DateTimeInterface $currentTime = null): bool
     {

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -24,8 +24,8 @@ class Talk extends Mapper
      * value in the favorite based on whether or not the current admin
      * user has favourited this talk
      *
-     * @param integer $admin_user_id
-     * @param array   $options
+     * @param int   $admin_user_id
+     * @param array $options
      *
      * @return array If order by is not in white list
      *
@@ -65,8 +65,8 @@ class Talk extends Mapper
     /**
      * Return a collection of talks that have been selected
      *
-     * @param integer $admin_user_id
-     * @param array   $options       Ordery By and Sorting Options
+     * @param int   $admin_user_id
+     * @param array $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -96,8 +96,8 @@ class Talk extends Mapper
     /**
      * Return an array of recent talks
      *
-     * @param integer $admin_user_id
-     * @param int     $limit
+     * @param int $admin_user_id
+     * @param int $limit
      *
      * @return array
      *
@@ -121,8 +121,8 @@ class Talk extends Mapper
     /**
      * Return a collection of talks that a majority of the admins have liked
      *
-     * @param integer $admin_user_id
-     * @param array   $options       Ordery By and Sorting Options
+     * @param int   $admin_user_id
+     * @param array $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -157,8 +157,8 @@ class Talk extends Mapper
      * Return a collection of top rated talks ordered by rating
      * the talk rating must be above 0 to show on list
      *
-     * @param integer $admin_user_id
-     * @param array   $options       Ordery By and Sorting Options
+     * @param int   $admin_user_id
+     * @param array $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -192,8 +192,8 @@ class Talk extends Mapper
     /**
      * Return a collection of talks not viewed by admin
      *
-     * @param integer $admin_user_id
-     * @param array   $options       Ordery By and Sorting Options
+     * @param int   $admin_user_id
+     * @param array $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -227,8 +227,8 @@ class Talk extends Mapper
     /**
      * Return a collection of talks viewed by admin
      *
-     * @param integer $admin_user_id
-     * @param array   $options       Ordery By and Sorting Options
+     * @param int   $admin_user_id
+     * @param array $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -262,8 +262,8 @@ class Talk extends Mapper
     /**
      * Return a collection of talks rated by admin
      *
-     * @param integer $admin_user_id
-     * @param array   $options       Ordery By and Sorting Options
+     * @param int   $admin_user_id
+     * @param array $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -297,8 +297,8 @@ class Talk extends Mapper
     /**
      * Return a collection of talks rated +1 by admin
      *
-     * @param integer $admin_user_id
-     * @param array   $options       Ordery By and Sorting Options
+     * @param int   $admin_user_id
+     * @param array $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -331,8 +331,8 @@ class Talk extends Mapper
     /**
      * Return a collection of talks not rated by admin
      *
-     * @param integer $admin_user_id
-     * @param array   $options       Ordery By and Sorting Options
+     * @param int   $admin_user_id
+     * @param array $options       Ordery By and Sorting Options
      *
      * @return array
      */
@@ -366,10 +366,10 @@ class Talk extends Mapper
     /**
      * Get a collection of talks filtered by a specific column
      *
-     * @param string  $column        Column to filter results with
-     * @param mixed   $value         Column value
-     * @param integer $admin_user_id
-     * @param array   $options       Ordery By and Sorting Options
+     * @param string $column        Column to filter results with
+     * @param mixed  $value         Column value
+     * @param int    $admin_user_id
+     * @param array  $options       Ordery By and Sorting Options
      *
      * @return array column is not in the column white list
      *
@@ -413,7 +413,7 @@ class Talk extends Mapper
      * Return a collection of entities representing talks that belong to a
      * specific user
      *
-     * @param integer $user_id
+     * @param int $user_id
      *
      * @return array
      */
@@ -425,8 +425,8 @@ class Talk extends Mapper
     /**
      * Iterates over DBAL objects and returns a formatted result set
      *
-     * @param mixed   $talk
-     * @param integer $admin_user_id
+     * @param mixed $talk
+     * @param int   $admin_user_id
      *
      * @return array
      */

--- a/classes/Domain/Entity/Mapper/User.php
+++ b/classes/Domain/Entity/Mapper/User.php
@@ -9,7 +9,7 @@ class User extends Mapper
     /**
      * Return an array that grabs info from the User and Speaker entities
      *
-     * @param integer $user_id
+     * @param int $user_id
      *
      * @return array
      */

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -12,7 +12,7 @@ class TalkFormatter implements TalkFormat
      * Iterates over a collection of DBAL objects and returns a formatted result set
      *
      * @param Collection $talkCollection Collection of Talks
-     * @param integer    $admin_user_id
+     * @param int        $admin_user_id
      * @param bool       $userData
      *
      * @return Collection
@@ -28,9 +28,9 @@ class TalkFormatter implements TalkFormat
     /**
      * Iterates over DBAL objects and returns a formatted result set
      *
-     * @param mixed   $talk
-     * @param integer $admin_user_id
-     * @param bool    $userData      grab the speaker data or not
+     * @param mixed $talk
+     * @param int   $admin_user_id
+     * @param bool  $userData      grab the speaker data or not
      *
      * @return array
      */

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -450,7 +450,7 @@ class TalkController extends BaseController
      *
      * @param Application $app
      * @param string      $email
-     * @param integer     $talk_id
+     * @param int         $talk_id
      *
      * @return mixed
      */

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -56,7 +56,7 @@ abstract class Form
      * Method that validates that we have all required
      * fields in our submitted data
      *
-     * @return boolean
+     * @return bool
      */
     public function hasRequiredFields(): bool
     {
@@ -145,7 +145,7 @@ abstract class Form
     /**
      * Returns whether or not the form has error messages.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasErrors(): bool
     {

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -29,7 +29,7 @@ class SignupForm extends Form
      *
      * @param string $action
      *
-     * @return boolean
+     * @return bool
      */
     public function validateAll($action = 'create')
     {
@@ -178,7 +178,7 @@ class SignupForm extends Form
     /**
      * Method that applies vaidation rules to user-submitted first names
      *
-     * @return boolean
+     * @return bool
      */
     public function validateFirstName(): bool
     {
@@ -206,7 +206,7 @@ class SignupForm extends Form
     /**
      * Method that applies vaidation rules to user-submitted first names
      *
-     * @return boolean
+     * @return bool
      */
     public function validateLastName(): bool
     {
@@ -259,7 +259,7 @@ class SignupForm extends Form
     /**
      * Method that applies validation rules to user-submitted speaker info
      *
-     * @return boolean
+     * @return bool
      */
     public function validateSpeakerInfo(): bool
     {
@@ -282,7 +282,7 @@ class SignupForm extends Form
     /**
      * Method that applies validation rules to user-submitted speaker bio
      *
-     * @return boolean
+     * @return bool
      */
     public function validateSpeakerBio(): bool
     {

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -51,7 +51,7 @@ class TalkForm extends Form
     /**
      * Validate everything
      *
-     * @return boolean
+     * @return bool
      */
     public function validateAll($action = 'create')
     {
@@ -70,7 +70,7 @@ class TalkForm extends Form
     /**
      * Method that validates title data
      *
-     * @return boolean
+     * @return bool
      */
     public function validateTitle(): bool
     {
@@ -94,7 +94,7 @@ class TalkForm extends Form
     /**
      * Method that validates description data
      *
-     * @return boolean
+     * @return bool
      */
     public function validateDescription(): bool
     {
@@ -110,7 +110,7 @@ class TalkForm extends Form
     /**
      * Method that validates talk types
      *
-     * @return boolean
+     * @return bool
      */
     public function validateType(): bool
     {

--- a/tests/Http/Form/SignupFormTest.php
+++ b/tests/Http/Form/SignupFormTest.php
@@ -54,8 +54,8 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      *
-     * @param string  $email
-     * @param boolean $expectedResponse
+     * @param string $email
+     * @param bool   $expectedResponse
      * @dataProvider emailProvider
      */
     public function emailsAreBeingValidatedCorrectly($email, $expectedResponse)
@@ -145,10 +145,10 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      *
-     * @param string  $passwd
-     * @param string  $passwd2
-     * @param string  $expectedMessage
-     * @param boolean $expectedResponse
+     * @param string $passwd
+     * @param string $passwd2
+     * @param string $expectedMessage
+     * @param bool   $expectedResponse
      * @dataProvider badPasswordProvider
      */
     public function badPasswordsAreBeingCorrectlyDetected($passwd, $passwd2, $expectedMessage, $expectedResponse)
@@ -190,8 +190,8 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      *
-     * @param string  $firstName
-     * @param boolean $expectedResponse
+     * @param string $firstName
+     * @param bool   $expectedResponse
      * @dataProvider firstNameProvider
      */
     public function firstNameIsValidatedCorrectly($firstName, $expectedResponse)
@@ -234,8 +234,8 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      *
-     * @param string  $lastName
-     * @param boolean $expectedResponse
+     * @param string $lastName
+     * @param bool   $expectedResponse
      * @dataProvider lastNameProvider
      */
     public function lastNameIsValidatedCorrectly($lastName, $expectedResponse)
@@ -279,8 +279,8 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      *
-     * @param array   $data
-     * @param boolean $expectedResponse
+     * @param array $data
+     * @param bool  $expectedResponse
      * @dataProvider validateAllProvider
      */
     public function validateAllWorksCorrectly($data, $expectedResponse)
@@ -322,8 +322,8 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      *
-     * @param string  $speakerInfo
-     * @param boolean $expectedResponse
+     * @param string $speakerInfo
+     * @param bool   $expectedResponse
      * @dataProvider speakerTextProvider
      */
     public function speakerInfoValidatedCorrectly($speakerInfo, $expectedResponse)
@@ -344,8 +344,8 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      *
-     * @param string  $speakerBio
-     * @param boolean $expectedResponse
+     * @param string $speakerBio
+     * @param bool   $expectedResponse
      * @dataProvider speakerTextProvider
      */
     public function speakerBioValidatedCorrectly($speakerBio, $expectedResponse)

--- a/tests/Http/Form/TalkFormTest.php
+++ b/tests/Http/Form/TalkFormTest.php
@@ -22,8 +22,8 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider hasRequiredProvider
      *
-     * @param array   $rawData  serialized user-submitted data
-     * @param boolean $response
+     * @param array $rawData  serialized user-submitted data
+     * @param bool  $response
      */
     public function correctlyDetectsRequiredFields($rawData, $response)
     {
@@ -80,8 +80,8 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider hasNoDesiredOrSponsorProvider
      *
-     * @param array   $rawData  serialized user-submitted data
-     * @param boolean $response
+     * @param array $rawData  serialized user-submitted data
+     * @param bool  $response
      */
     public function submitsTalkWhenNoDesiredOrSponrosIncluded($rawData, $response)
     {
@@ -126,8 +126,8 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider titleValidatesProvider
      *
-     * @param string  $title
-     * @param boolean $expectedResponse
+     * @param string $title
+     * @param bool   $expectedResponse
      */
     public function titleValidatesCorrectly($title, $expectedResponse)
     {
@@ -168,8 +168,8 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider descriptionValidatesProvider
      *
-     * @param string  $description
-     * @param boolean $expectedResponse
+     * @param string $description
+     * @param bool   $expectedResponse
      */
     public function descriptionValidatesCorrectly($description, $expectedResponse)
     {
@@ -209,8 +209,8 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider typeProvider
      *
-     * @param string  $type
-     * @param boolean $expectedResponse
+     * @param string $type
+     * @param bool   $expectedResponse
      */
     public function typeValidatesCorrectly($type, $expectedResponse)
     {
@@ -235,7 +235,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
     /**
      * Data provider for typeValidatesCorrectly
      *
-     * @return boolean
+     * @return bool
      */
     public function typeProvider()
     {
@@ -256,8 +256,8 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider categoryProvider
      *
-     * @param string  $category
-     * @param boolean $expectedResponse
+     * @param string $category
+     * @param bool   $expectedResponse
      */
     public function categoryValidatesCorrectly($category, $expectedResponse)
     {
@@ -278,7 +278,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
     /**
      * Data provider for typeValidatesCorrectly
      *
-     * @return boolean
+     * @return bool
      */
     public function categoryProvider()
     {
@@ -321,8 +321,8 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider levelProvider
      *
-     * @param string  $level
-     * @param boolean $expectedResponse
+     * @param string $level
+     * @param bool   $expectedResponse
      */
     public function levelValidatesCorrectly($level, $expectedResponse)
     {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_scalar` fixer
* [ ] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**phpdoc_scalar** [`@Symfony`]
>
>Scalar types should always be written in the same form. `int` not `integer`, `bool` not `boolean`, `float` not `real` or `double`.