### PR TITLE
Enhancement: Enable phpdoc_no_empty_return fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -17,6 +17,7 @@ $config = PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'ordered_imports' => true,
         'phpdoc_align' => true,
+        'phpdoc_no_empty_return' => true,
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
         'php_unit_expectation' => true,

--- a/classes/Domain/Services/Authentication.php
+++ b/classes/Domain/Services/Authentication.php
@@ -51,7 +51,6 @@ interface Authentication
     /**
      * Destroys the user's active authenticated session.
      *
-     * @return void
      */
     public function logout();
 }

--- a/classes/Domain/Services/Authentication.php
+++ b/classes/Domain/Services/Authentication.php
@@ -50,7 +50,6 @@ interface Authentication
 
     /**
      * Destroys the user's active authenticated session.
-     *
      */
     public function logout();
 }

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -85,7 +85,6 @@ class SentryAuthentication implements Authentication
     /**
      * Destroys the user's active authenticated session.
      *
-     *
      * @throws NotAuthenticatedException
      */
     public function logout()

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -85,7 +85,6 @@ class SentryAuthentication implements Authentication
     /**
      * Destroys the user's active authenticated session.
      *
-     * @return void
      *
      * @throws NotAuthenticatedException
      */

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -126,7 +126,6 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
      * action
      *
      * @param mixed $data
-     *
      */
     protected function setPost($data)
     {

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -127,7 +127,6 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
      *
      * @param mixed $data
      *
-     * @return void
      */
     protected function setPost($data)
     {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_no_empty_return` fixer
* [x] runs `make cs`
* [x] removes extra empty lines

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**phpdoc_no_empty_return** [`@Symfony`]
>
>@return void and @return null annotations should be omitted from phpdocs.