### PR TITLE
Enhancement: Enable no_empty_phpdoc fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,6 +13,7 @@ $config = PhpCsFixer\Config::create()
             'syntax' => 'short'
         ],
         'blank_line_after_opening_tag' => true,
+        'no_empty_phpdoc' => true,
         'no_extra_consecutive_blank_lines' => true,
         'no_unused_imports' => true,
         'ordered_imports' => true,

--- a/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -28,8 +28,7 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(IdentityProvider::class, $provider);
     }
 
-    /**
-     */
+    
     public function testGetCurrentUserThrowsNotAuthenticatedExceptionWhenNotAuthenticated()
     {
         $sentry = $this->getSentryMock();


### PR DESCRIPTION
This PR

* [x] enables the `no_empty_phpdoc` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**no_empty_phpdoc** [`@Symfony`]
>
>There should not be empty PHPDoc blocks.
