### PR TITLE
Enhancement: Enable phpdoc_indent fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -17,6 +17,7 @@ $config = PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'ordered_imports' => true,
         'phpdoc_align' => true,
+        'phpdoc_indent' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,

--- a/tests/Http/Form/SignupFormTest.php
+++ b/tests/Http/Form/SignupFormTest.php
@@ -361,10 +361,10 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-      * Data provider for speakerInfoValidatedCorrectly
-      *
-      * @return array
-      */
+     * Data provider for speakerInfoValidatedCorrectly
+     *
+     * @return array
+     */
     public function speakerTextProvider()
     {
         return [


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_indent` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**phpdoc_indent** [`@Symfony`]
>
>Docblocks should have the same indentation as the documented subject.