### PR TITLE
Enhancement: Enable trim_array_spaces fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -27,6 +27,7 @@ $config = PhpCsFixer\Config::create()
         'single_blank_line_before_namespace' => true,
         'single_quote' => true,
         'trailing_comma_in_multiline_array' => true,
+        'trim_array_spaces' => true,
         'yoda_style' => [
             'equal' => false,
             'identical' => false,

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -46,7 +46,7 @@ class ExportsController extends BaseController
 
     private function talksExportAction($attributed, $where = null)
     {
-        $sort = [ 'created_at' => 'DESC' ];
+        $sort = ['created_at' => 'DESC'];
 
         $admin_user_id = $this->service(Authentication::class)->userId();
         $mapper = $this->service('spot')->mapper('OpenCFP\Domain\Entity\Talk');

--- a/classes/Http/Controller/PagesController.php
+++ b/classes/Http/Controller/PagesController.php
@@ -23,6 +23,6 @@ class PagesController extends BaseController
 
     private function getContextWithTalksCount()
     {
-        return [ 'number_of_talks' => Talk::count()];
+        return ['number_of_talks' => Talk::count()];
     }
 }


### PR DESCRIPTION
This PR

* [x] enables the `trim_array_spaces` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

> **trim_array_spaces** [`@Symfony`]
>
>Arrays should be formatted like function/method arguments, without leading or trailing single line space.