### PR TITLE
Refactor: Talks controller to use Illuminate

### DIFF
--- a/classes/Domain/Model/Favorite.php
+++ b/classes/Domain/Model/Favorite.php
@@ -5,10 +5,20 @@ namespace OpenCFP\Domain\Model;
 class Favorite extends Eloquent
 {
     protected $table = 'favorites';
-    public $timestamps = false;
+
+    const CREATED_AT = 'created';
+    const UPDATED_AT = null;
 
     public function talk()
     {
         $this->belongsTo(Talk::class, 'talk_id');
+    }
+
+    public function setUpdatedAt($value)
+    {
+        /**
+         * This is the dirty way to tell Illuminate that we don't have an updated at field
+         * while still having a created_at field.
+         */
     }
 }

--- a/classes/Domain/Model/TalkComment.php
+++ b/classes/Domain/Model/TalkComment.php
@@ -5,7 +5,9 @@ namespace OpenCFP\Domain\Model;
 class TalkComment extends Eloquent
 {
     protected $table = 'talk_comments';
-    public $timestamps = false;
+
+    const CREATED_AT = 'created';
+    const UPDATED_AT = null;
 
     public function user()
     {
@@ -15,5 +17,13 @@ class TalkComment extends Eloquent
     public function talk()
     {
         return $this->belongsTo(Talk::class);
+    }
+
+    public function setUpdatedAt($value)
+    {
+        /**
+         * This is the dirty way to tell Illuminate that we don't have an updated at field
+         * while still having a created_at field.
+         */
     }
 }

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\TalkComment;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
@@ -165,21 +166,12 @@ class TalksController extends BaseController
     public function commentCreateAction(Request $req)
     {
         $talk_id = (int)$req->get('id');
-
-        $user = $this->service(Authentication::class)->user();
-        $admin_user_id = (int) $user->getId();
-
-        /* @var Locator $spot */
-        $spot = $this->service('spot');
-
-        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\TalkComment::class);
-        $comment = $mapper->get();
-
-        $comment->talk_id = $talk_id;
-        $comment->user_id = $admin_user_id;
-        $comment->message = $req->get('comment');
-
-        $mapper->save($comment);
+        
+        TalkComment::create([
+            'talk_id' => $talk_id,
+            'user_id' => $this->service(Authentication::class)->userId(),
+            'message' => $req->get('comment'),
+        ]);
 
         $this->service('session')->set('flash', [
                 'type' => 'success',

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
-use OpenCFP\Domain\Entity\Talk as TalkEntity;
 use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Services\Authentication;
@@ -13,7 +12,6 @@ use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Domain\Talk\TalkFilter;
 use OpenCFP\Http\Controller\BaseController;
 use OpenCFP\Http\Controller\FlashableTrait;
-use Spot\Locator;
 use Symfony\Component\HttpFoundation\Request;
 
 class TalksController extends BaseController
@@ -154,28 +152,14 @@ class TalksController extends BaseController
      */
     public function selectAction(Request $req)
     {
-        $status = true;
-
-        if ($req->get('delete') !== null) {
-            $status = false;
+        $talk = Talk::find($req->get('id'));
+        if ($talk instanceof Talk) {
+            $talk->selected = $req->get('delete') !== null ? 1 :0;
+            $talk->save();
+            return true;
         }
 
-        /* @var Locator $spot */
-        $spot = $this->service('spot');
-
-        $mapper = $spot->mapper(TalkEntity::class);
-        $talk = $mapper->get($req->get('id'));
-
-        $selected = 1;
-
-        if ($status == false) {
-            $selected = 0;
-        }
-
-        $talk->selected = $selected;
-        $mapper->save($talk);
-
-        return true;
+        return false;
     }
 
     public function commentCreateAction(Request $req)

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -159,7 +159,7 @@ class TalksController extends BaseController
     {
         $talk = Talk::find($req->get('id'));
         if ($talk instanceof Talk) {
-            $talk->selected = $req->get('delete') !== null ? 1 :0;
+            $talk->selected = $req->get('delete') == true ? 0 :1;
             $talk->save();
             return true;
         }

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -130,10 +130,14 @@ class TalksController extends BaseController
 
         if ($req->get('delete') !== null) {
             // Delete the record that matches
-            return Favorite::where('admin_user_id', $admin_user_id)
+            $favorite = Favorite::where('admin_user_id', $admin_user_id)
                 ->where('talk_id', $talkId)
-                ->first()
-                ->delete();
+                ->first();
+            if ($favorite instanceof  Favorite) {
+                $favorite->delete();
+                return true;
+            }
+            return false;
         }
 
         Favorite::firstOrCreate([

--- a/tests/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Http/Controller/Admin/TalksControllerTest.php
@@ -191,4 +191,30 @@ class TalksControllerTest extends WebTestCase
             ->assertNotSee('1')
             ->assertSuccessful();
     }
+
+    /**
+     * @test
+     */
+    public function rateActionWorksCorrectly()
+    {
+        $talk = factory(Talk::class, 1)->create()->first();
+
+        $this->asAdmin()
+            ->post('/admin/talks/'.$talk->id. '/rate', ['rating' => 1])
+            ->assertSee('1')
+            ->assertSuccessful();
+    }
+
+    /**
+     * @test
+     */
+    public function rateActionRetunsFalseOnWrongRate()
+    {
+        $talk = factory(Talk::class, 1)->create()->first();
+
+        $this->asAdmin()
+            ->post('/admin/talks/'.$talk->id. '/rate', ['rating' => 12])
+            ->assertNotSee('1')
+            ->assertSuccessful();
+    }
 }

--- a/tests/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Http/Controller/Admin/TalksControllerTest.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Test\Http\Controller\Admin;
 
 use Mockery as m;
+use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Services\Authentication;
@@ -123,7 +124,7 @@ class TalksControllerTest extends WebTestCase
      */
     public function talkIsCorrectlyCommentedOn()
     {
-        $talk = factory(Talk::class,1)->create()->first();
+        $talk = factory(Talk::class, 1)->create()->first();
 
         $this->asAdmin()
             ->post(
@@ -206,5 +207,44 @@ class TalksControllerTest extends WebTestCase
             ->assertSuccessful();
     }
 
+    /**
+     * @test
+     */
+    public function favoriteActionWorksCorrectly()
+    {
+        $talk = factory(Talk::class, 1)->create()->first();
 
+        $this->asAdmin()
+            ->post('/admin/talks/'. $talk->id . '/favorite')
+            ->assertSee('1')
+            ->assertSuccessful();
+    }
+
+    /**
+     * @test
+     */
+    public function favoriteActionDeletesCorrectly()
+    {
+        $talk = factory(Talk::class, 1)->create()->first();
+        Favorite::create([
+            'admin_user_id' => 1,
+            'talk_id' => $talk->id,
+        ]);
+
+        $this->asAdmin()
+            ->post('/admin/talks/'. $talk->id . '/favorite', ['delete' =>1])
+            ->assertSee('1')
+            ->assertSuccessful();
+    }
+
+    /**
+     * @test
+     */
+    public function favoriteActionDoesNotErrorWhenTryingToDeleteFavoriteThatDoesNoExist()
+    {
+        $this->asAdmin()
+            ->post('/admin/talks/255/favorite', ['delete' => 1])
+            ->assertNotSee('1')
+            ->assertSuccessful();
+    }
 }


### PR DESCRIPTION
This PR updates the admins talk controller to use Illuminate.

It also updates some of the models that have a created field for the created at timestamp, but no updated_at field.

It also adds a few tests for the favorite, select, and rate actions which weren't properly tested yet, and updated other tests for that controller to make proper use of the WebTestCase where possible.

Related to: #506.