### PR TITLE
Refactor: Speakers controller to use Illuminate

### DIFF
--- a/classes/Domain/Model/Favorite.php
+++ b/classes/Domain/Model/Favorite.php
@@ -9,6 +9,6 @@ class Favorite extends Eloquent
 
     public function talk()
     {
-        $this->belongsTo(Talk::class, 'talk_id');
+        return $this->belongsTo(Talk::class, 'talk_id');
     }
 }

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -57,7 +57,7 @@ class Talk extends Eloquent
         $this->comments()
             ->get()
             ->each(function ($comment) {
-                if (!$comment->delete()){
+                if (!$comment->delete()) {
                     throw new \Exception('Unable to delete all comments');
                 }
             });
@@ -93,6 +93,5 @@ class Talk extends Eloquent
                     throw new \Exception('Unable to delete all meta info');
                 }
             });
-
     }
 }

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -38,4 +38,61 @@ class Talk extends Eloquent
             ->with(['favorites', 'meta'])
             ->take($limit);
     }
+
+    public function delete()
+    {
+        $this->deleteComments();
+        $this->deleteFavorites();
+        $this->deleteMeta();
+        return parent::delete();
+    }
+
+    /**
+     * Deletes all comments of the talk
+     *
+     * @throws \Exception
+     */
+    public function deleteComments()
+    {
+        $this->comments()
+            ->get()
+            ->each(function ($comment) {
+                if (!$comment->delete()){
+                    throw new \Exception('Unable to delete all comments');
+                }
+            });
+    }
+
+    /**
+     * Delets all favorites of the talk
+     *
+     * @throws \Exception
+     */
+    public function deleteFavorites()
+    {
+        $this->favorites()
+            ->get()
+            ->each(function ($favorite) {
+                if (!$favorite->delete()) {
+                    throw new \Exception('Unable to delete all favorites');
+                }
+            });
+    }
+
+    /**
+     * Deletes all meta info of the talk
+     *
+     * @throws \Exception
+     */
+    public function deleteMeta()
+    {
+        $this->meta()
+            ->get()
+            ->each(function ($meta) {
+                if (!$meta->delete()) {
+                    throw new \Exception('Unable to delete all meta info');
+                }
+            });
+
+    }
 }

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -77,13 +77,14 @@ class User extends Eloquent
      * Deletes user, all of their talks, and meta/favorites/comments
      *
      * @return bool
+     *
      * @throws \Exception
      */
     public function delete(): bool
     {
         $this->talks()
             ->get()
-            ->each(function($talk) {
+            ->each(function ($talk) {
                 if (! $talk->delete()) {
                     throw new \Exception('Unable to delete talks of user');
                 }

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -72,4 +72,26 @@ class User extends Eloquent
             ->orWhere('last_name', 'like', '%' . $search. '%')
             ->orderBy($orderByColumn, $orderByDirection);
     }
+
+    /**
+     * Deletes user, all of their talks, and meta/favorites/comments
+     *
+     * @return bool
+     * @throws \Exception
+     */
+    public function delete(): bool
+    {
+        $this->talks()
+            ->get()
+            ->each(function($talk) {
+                if (! $talk->delete()) {
+                    throw new \Exception('Unable to delete talks of user');
+                }
+            });
+        if (! parent::delete()) {
+            throw new \Exception('Unable to delete User');
+        }
+
+        return true;
+    }
 }

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -27,6 +27,7 @@ class SpeakersController extends BaseController
         $adminUserIds = array_column($adminUsers, 'id');
 
         $rawSpeakers = User::search($search)->get();
+
         $airports = $this->service(AirportInformationDatabase::class);
         $rawSpeakers = $rawSpeakers->map(function ($speaker) use ($airports, $adminUserIds) {
             try {
@@ -122,7 +123,8 @@ class SpeakersController extends BaseController
 
         $capsule->getConnection()->beginTransaction();
         try {
-            User::delete($req->get('id'));
+            $user = User::find($req->get('id'));
+            $user->delete($req->get('id'));
             $ext = 'Successfully deleted the requested user';
             $type = 'success';
             $short = 'Success';

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -71,14 +71,9 @@ class SpeakersController extends BaseController
 
     public function viewAction(Request $req)
     {
-        /* @var Locator $spot */
-        $spot = $this->service('spot');
+        $speaker_details = User::find($req->get('id'));
 
-        // Get info about the speaker
-        $user_mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
-        $speaker_details = $user_mapper->get($req->get('id'));
-
-        if (empty($speaker_details)) {
+        if (!$speaker_details instanceof User) {
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
@@ -106,9 +101,7 @@ class SpeakersController extends BaseController
             ];
         }
 
-        // Get info about the talks
-        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $talks = $talk_mapper->getByUser($req->get('id'))->toArray();
+        $talks = $speaker_details->talks()->get();
 
         // Build and render the template
         $templateData = [
@@ -168,7 +161,7 @@ class SpeakersController extends BaseController
     }
 
     /**
-     * @param User $speaker
+     * @param UserEntity $speaker
      */
     private function removeSpeakerTalks(UserEntity $speaker)
     {

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -127,7 +127,6 @@ class SpeakersController extends BaseController
             $type = 'success';
             $short = 'Success';
             $capsule->getConnection()->commit();
-
         } catch (\Exception $e) {
             $capsule->getConnection()->rollBack();
             $ext = 'Unable to delete the requested user';

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -123,7 +123,7 @@ class SpeakersController extends BaseController
 
         $capsule->getConnection()->beginTransaction();
         try {
-            $user = User::find($req->get('id'));
+            $user = User::findorFail($req->get('id'));
             $user->delete($req->get('id'));
             $ext = 'Successfully deleted the requested user';
             $type = 'success';

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -194,15 +194,10 @@ class SpeakersController extends BaseController
 
     public function demoteAction(Request $req)
     {
-        /** @var Authentication $auth */
-        $auth = $this->service(Authentication::class);
-
         /** @var AccountManagement $accounts */
         $accounts = $this->service(AccountManagement::class);
 
-        $admin = $auth->user();
-
-        if ($admin->getId() == $req->get('id')) {
+        if ($this->service(Authentication::class)->userId() == $req->get('id')) {
             $this->service('session')->set('flash', [
                 'type' => 'error',
                 'short' => 'Error',
@@ -212,12 +207,8 @@ class SpeakersController extends BaseController
             return $this->redirectTo('admin_speakers');
         }
 
-        /* @var Locator $spot */
-        $spot = $this->service('spot');
-
-        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
-        $user_data = $mapper->get($req->get('id'))->toArray();
-        $user = $accounts->findByLogin($user_data['email']);
+        $userEmail = User::find($req->get('id'))->email;
+        $user = $accounts->findByLogin($userEmail);
 
         try {
             $accounts->demoteFrom($user->getLogin());
@@ -243,12 +234,8 @@ class SpeakersController extends BaseController
         /* @var AccountManagement $accounts */
         $accounts = $this->service(AccountManagement::class);
 
-        /* @var Locator $spot */
-        $spot = $this->service('spot');
-
-        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
-        $user_data = $mapper->get($req->get('id'))->toArray();
-        $user = $accounts->findByLogin($user_data['email']);
+        $userEmail = User::find($req->get('id'))->email;
+        $user = $accounts->findByLogin($userEmail);
 
         if ($user->hasAccess('admin')) {
             $this->service('session')->set('flash', [

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -160,11 +160,8 @@ class SpeakersController extends BaseController
 
             return $this->redirectTo('admin_speakers');
         }
-
-        $userEmail = User::find($req->get('id'))->email;
-        $user = $accounts->findByLogin($userEmail);
-
         try {
+            $user = $accounts->findById($req->get('id'));
             $accounts->demoteFrom($user->getLogin());
 
             $this->service('session')->set('flash', [
@@ -187,21 +184,17 @@ class SpeakersController extends BaseController
     {
         /* @var AccountManagement $accounts */
         $accounts = $this->service(AccountManagement::class);
-
-        $userEmail = User::find($req->get('id'))->email;
-        $user = $accounts->findByLogin($userEmail);
-
-        if ($user->hasAccess('admin')) {
-            $this->service('session')->set('flash', [
-                'type' => 'error',
-                'short' => 'Error',
-                'ext' => 'User already is in the Admin group.',
-            ]);
-
-            return $this->redirectTo('admin_speakers');
-        }
-
         try {
+            $user = $accounts->findById($req->get('id'));
+            if ($user->hasAccess('admin')) {
+                $this->service('session')->set('flash', [
+                    'type' => 'error',
+                    'short' => 'Error',
+                    'ext' => 'User already is in the Admin group.',
+                ]);
+                return $this->redirectTo('admin_speakers');
+            }
+
             $accounts->promoteTo($user->getLogin());
 
             $this->service('session')->set('flash', [

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -118,9 +118,9 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         // Admin::Speakers
         $admin->get('/speakers', 'OpenCFP\Http\Controller\Admin\SpeakersController::indexAction')->bind('admin_speakers');
         $admin->get('/speakers/{id}', 'OpenCFP\Http\Controller\Admin\SpeakersController::viewAction')->bind('admin_speaker_view');
-        $admin->get('/admin/speakers/{id}/promote', 'OpenCFP\Http\Controller\Admin\SpeakersController::promoteAction')->bind('admin_speaker_promote');
-        $admin->get('/admin/speakers/{id}/demote', 'OpenCFP\Http\Controller\Admin\SpeakersController::demoteAction')->bind('admin_speaker_demote');
-        $admin->get('/admin/speakers/delete/{id}', 'OpenCFP\Http\Controller\Admin\SpeakersController::deleteAction')->bind('admin_speaker_delete');
+        $admin->get('/speakers/{id}/promote', 'OpenCFP\Http\Controller\Admin\SpeakersController::promoteAction')->bind('admin_speaker_promote');
+        $admin->get('/speakers/{id}/demote', 'OpenCFP\Http\Controller\Admin\SpeakersController::demoteAction')->bind('admin_speaker_demote');
+        $admin->get('/speakers/delete/{id}', 'OpenCFP\Http\Controller\Admin\SpeakersController::deleteAction')->bind('admin_speaker_delete');
 
         // CSV Exports
         $admin->get('/export/csv', 'OpenCFP\Http\Controller\Admin\ExportsController::attributedTalksExportAction')->bind('admin_export_csv');

--- a/factories/Common.php
+++ b/factories/Common.php
@@ -43,3 +43,20 @@ $factory->define(\OpenCFP\Domain\Model\TalkMeta::class, function (\Faker\Generat
         'created' => new \DateTime(),
     ];
 });
+
+$factory->define(\OpenCFP\Domain\Model\TalkComment::class, function (\Faker\Generator $faker) {
+    return [
+        'user_id' => factory(\OpenCFP\Domain\Model\User::class)->create()->id,
+        'talk_id' => factory(\OpenCFP\Domain\Model\Talk::class)->create()->id,
+        'message' => $faker->realText(),
+        'created' => new \DateTime(),
+    ];
+});
+
+$factory->define(\OpenCFP\Domain\Model\Favorite::class, function (\Faker\Generator $faker) {
+    return [
+        'admin_user_id' => factory(\OpenCFP\Domain\Model\User::class)->create()->id,
+        'talk_id' => factory(\OpenCFP\Domain\Model\Talk::class)->create()->id,
+        'created' => new \DateTime(),
+    ];
+});

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -2,7 +2,9 @@
 
 namespace OpenCFP\Test\Domain\Model;
 
+use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\TalkComment;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Test\DatabaseTransaction;
@@ -63,6 +65,94 @@ class TalkTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(1, $secondFormat['meta']->rating);
         $this->assertEquals(1, $secondFormat['meta']->viewed);
+    }
+
+    /**
+     * @test
+     */
+    public function deleteWorksWithMeta()
+    {
+        /** @var TalkMeta $meta */
+        $meta = factory(TalkMeta::class, 1)->create()->first();
+        $talk = $meta->talk()->first();
+
+        $talk->delete();
+        $this->assertCount(0, TalkMeta::all());
+    }
+    /**
+     * @test
+     */
+    public function deleteMetaButKeepTalkIsPossible()
+    {
+        /** @var TalkMeta $meta */
+        $meta = factory(TalkMeta::class, 1)->create()->first();
+        $talk = $meta->talk()->first();
+
+        $talk->deleteMeta();
+        $this->assertCount(0, TalkMeta::all());
+        $this->assertCount(1, Talk::all());
+    }
+
+    /**
+     * @test
+     */
+    public function deleteWorksWithComments()
+    {
+        /** @var TalkComment $meta */
+        $comment = factory(TalkComment::class, 1)->create()->first();
+        $talk = $comment->talk()->first();
+
+        $talk->delete();
+        $this->assertCount(0, TalkComment::all());
+    }
+    /**
+     * @test
+     */
+    public function deleteCommentsButKeepTalkIsPossible()
+    {
+        /** @var TalkComment $comment */
+        $comment = factory(TalkComment::class, 1)->create()->first();
+        $talk = $comment->talk()->first();
+
+        $talk->deleteComments();
+        $this->assertCount(0, TalkComment::all());
+        $this->assertCount(1, Talk::all());
+    }
+
+    /**
+     * @test
+     */
+    public function deleteWorksWithFavorites()
+    {
+        /** @var Favorite $favorite */
+        $favorite = factory(Favorite::class, 1)->create()->first();
+        $talk = $favorite->talk()->first();
+
+        $talk->delete();
+        $this->assertCount(0, Favorite::all());
+    }
+    /**
+     * @test
+     */
+    public function deleteFavoritesButKeepTalkIsPossible()
+    {
+        /** @var Favorite $favorite */
+        $favorite = factory(Favorite::class, 1)->create()->first();
+        $talk = $favorite->talk()->first();
+
+        $talk->deleteFavorites();
+        $this->assertCount(0, Favorite::all());
+        $this->assertCount(1, Talk::all());
+    }
+
+    /**
+     * @test
+     */
+    public function deleteWorksWithNoOtherItems()
+    {
+        $talk = factory(Talk::class, 1)->create()->first();
+
+        $this->assertTrue($talk->delete());
     }
 
     private function generateOneTalk()

--- a/tests/Domain/Model/UserTest.php
+++ b/tests/Domain/Model/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Test\Domain\Model;
 
+use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\DatabaseTransaction;
 
@@ -41,6 +42,31 @@ class UserTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(5, User::search()->get());
         $this->assertCount(3, User::search('Vries')->get());
         $this->assertCount(1, User::search('Hunter')->get());
+    }
+
+    /**
+     * @test
+     */
+    public function deleteDeletesTalksAsWellAsUser()
+    {
+        $talk = factory(Talk::class, 1)->create()->first();
+
+        $user = $talk->speaker;
+        $user->delete();
+
+        $this->assertCount(0, Talk::all());
+        $this->assertCount(0, User::all());
+    }
+
+    /**
+     * @test
+     */
+    public function deleteStillWorksNormally()
+    {
+        $user = factory(User::class, 1)->create()->first();
+
+        $this->assertTrue($user->delete());
+        $this->assertCount(0, User::all());
     }
 
     private function makeKnownUsers()

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -49,28 +49,7 @@ class SpeakersControllerTest extends WebTestCase
         $this->asAdmin()
             ->get('/admin/speakers/7679')
             ->assertNotSee('Other Information')
-            ->assertRedirect();
-    }
-
-    /**
-     * @test
-     */
-    public function deleteUserWorksCorrectly()
-    {
-        $user = factory(User::class, 1)->create()->first();
-
-        $this->asAdmin()
-            ->get('/admin/speakers/delete/'. $user->id)
-            ->assertRedirect();
-    }
-
-    /**
-     * @test
-     */
-    public function deleteRedirectsOnFailure()
-    {
-        $this->asAdmin()
-            ->get('/admin/speakers/delete/255')
-            ->assertRedirect();
+            ->assertRedirect()
+            ->assertFlashContains('Error');
     }
 }

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -52,4 +52,28 @@ class SpeakersControllerTest extends WebTestCase
             ->assertRedirect()
             ->assertFlashContains('Error');
     }
+
+    /**
+     * @test
+     */
+    public function promoteActionWorksNormally()
+    {
+        $user = factory(User::class, 1)->create()->first();
+
+        $this->asAdmin()
+            ->get('/admin/speakers/' . $user->id . '/promote')
+            ->assertFlashContains('Success')
+            ->assertRedirect();
+    }
+
+    /**
+     * @test
+     */
+    public function promoteActionGivesErrorWhenUserDoesntExist()
+    {
+        $this->asAdmin()
+            ->get('/admin/speakers/5678/promote')
+            ->assertFlashContains('Error')
+            ->assertRedirect();
+    }
 }

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -37,7 +37,7 @@ class SpeakersControllerTest extends WebTestCase
 
         $this->asAdmin()
             ->get('/admin/speakers/' . $user->id)
-            ->assertSee($user->first()->first_name)
+            ->assertSee($user->first_name)
             ->assertSuccessful();
     }
 
@@ -51,29 +51,5 @@ class SpeakersControllerTest extends WebTestCase
             ->assertNotSee('Other Information')
             ->assertRedirect()
             ->assertFlashContains('Error');
-    }
-
-    /**
-     * @test
-     */
-    public function promoteActionWorksNormally()
-    {
-        $user = factory(User::class, 1)->create()->first();
-
-        $this->asAdmin()
-            ->get('/admin/speakers/' . $user->id . '/promote')
-            ->assertFlashContains('Success')
-            ->assertRedirect();
-    }
-
-    /**
-     * @test
-     */
-    public function promoteActionGivesErrorWhenUserDoesntExist()
-    {
-        $this->asAdmin()
-            ->get('/admin/speakers/5678/promote')
-            ->assertFlashContains('Error')
-            ->assertRedirect();
     }
 }

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -2,15 +2,9 @@
 
 namespace OpenCFP\Test\Http\Controller\Admin;
 
-use Cartalyst\Sentry\Users\UserInterface;
-use Mockery as m;
-use OpenCFP\Application;
-use OpenCFP\Domain\Services\Authentication;
-use OpenCFP\Environment;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+use OpenCFP\Domain\Model\User;
+use OpenCFP\Test\DatabaseTransaction;
+use OpenCFP\Test\WebTestCase;
 
 /**
  * Class SpeakersControllerTest
@@ -18,146 +12,65 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
  * @package OpenCFP\Test\Http\Controller\Admin
  * @group db
  */
-class SpeakersControllerTest extends \PHPUnit\Framework\TestCase
+class SpeakersControllerTest extends WebTestCase
 {
-    private $app;
+    use DatabaseTransaction;
 
-    protected function setUp()
+    public function setUp()
     {
-        // Create our Application object
-        $this->app = new Application(BASE_PATH, Environment::testing());
-        $this->app['session.test'] = true;
-
-        // Create a test double for our User entity
-        $user = m::mock(UserInterface::class);
-        $user->shouldReceive('hasPermission')->with('admin')->andReturn(true);
-        $user->shouldReceive('getId')->andReturn(1);
-        $user->shouldReceive('hasAccess')->with('admin')->andReturn(true);
-
-        // Create a test double for our Sentry object
-        $auth = m::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(true);
-        $auth->shouldReceive('user')->andReturn($user);
-        $this->app[Authentication::class] = $auth;
-        $this->app['user'] = $user;
+        parent::setUp();
+        $this->setUpDatabase();
     }
 
-    /**
-     * Verify that not found speaker redirects and sets flash error message
-     *
-     * @test
-     */
-    public function speakerNotFoundHasFlashMessage()
+    public function tearDown()
     {
-        $speakerId = uniqid();
-
-        // Override our mapper with the double
-        $spot = m::mock(\Spot\Locator::class);
-        $mapper = m::mock(\OpenCFP\Domain\Entity\Mapper\User::class);
-        $mapper->shouldReceive('get')
-            ->andReturn([]);
-
-        $spot->shouldReceive('mapper')
-            ->with(\OpenCFP\Domain\Entity\User::class)
-            ->andReturn($mapper);
-        $this->app['spot'] = $spot;
-
-        // Use our pre-configured Application object
-        ob_start();
-        $this->app->run();
-        ob_end_clean();
-
-        // Create our Request object
-        $req = m::mock(\Symfony\Component\HttpFoundation\Request::class);
-        $req->shouldReceive('get')->with('id')->andReturn($speakerId);
-
-        // Execute the controller and capture the output
-        $controller = new \OpenCFP\Http\Controller\Admin\SpeakersController();
-        $controller->setApplication($this->app);
-        $response = $controller->viewAction($req);
-
-        $this->assertInstanceOf(
-            \Symfony\Component\HttpFoundation\RedirectResponse::class,
-            $response
-        );
-
-        $this->assertContains(
-            'Could not find requested speaker',
-            $this->app['session']->get('flash')
-        );
+        parent::tearDown();
+        $this->tearDownDatabase();
     }
 
     /**
      * @test
      */
-    public function speaker_talks_comments_and_meta_should_be_removed_when_speaker_is_deleted()
+    public function viewActionDisplaysCorrectly()
     {
-        $spot = m::mock(\Spot\Locator::class);
-        $speaker = m::mock(\OpenCFP\Domain\Entity\User::class);
-        $talk = m::mock(\OpenCFP\Domain\Entity\Talk::class);
-        $userMapper = m::mock(\Spot\Mapper::class);
-        $talkMapper = m::mock(\Spot\Mapper::class);
-        $talkCommentsMapper = m::mock(\Spot\Mapper::class);
-        $talkMetaMapper = m::mock(\Spot\Mapper::class);
+        $user = factory(User::class, 1)->create()->first();
 
-        // Create a session object
-        $this->app['session'] = new Session(new MockFileSessionStorage);
+        $this->asAdmin()
+            ->get('/admin/speakers/' . $user->id)
+            ->assertSee($user->first()->first_name)
+            ->assertSuccessful();
+    }
 
-        // Use our pre-configured Application object
-        ob_start();
-        $this->app->run();
-        ob_end_clean();
+    /**
+     * @test
+     */
+    public function viewActionRedirectsOnNonUser()
+    {
+        $this->asAdmin()
+            ->get('/admin/speakers/7679')
+            ->assertNotSee('Other Information')
+            ->assertRedirect();
+    }
 
-        // We're deleting speaker numero uno
-        $request = m::mock(Request::class);
-        $request->shouldReceive('get')->with('id')->atLeast()->once()->andReturn(1);
+    /**
+     * @test
+     */
+    public function deleteUserWorksCorrectly()
+    {
+        $user = factory(User::class, 1)->create()->first();
 
-        // We get the speaker from mapper
-        $userMapper->shouldReceive('get')->with(1)->once()->andReturn($speaker);
+        $this->asAdmin()
+            ->get('/admin/speakers/delete/'. $user->id)
+            ->assertRedirect();
+    }
 
-        // Speaker is handed off to `removeSpeakerTalks`
-        // and we get all their talks in a collection
-        // Note: this is the `talks` relation, but under the hood
-        //       Spot actually calls the relation method on entity
-        $speaker->shouldReceive('relation->execute')->once()->andReturn([$talk]);
-
-        // That talk also has comments and meta information
-        // Note: these actually return entities for comment and meta
-        //       but in the interest of brevity are faked as strings
-        $talk->shouldReceive('relation->execute')->times(2)->andReturn(['comment'], ['meta']);
-
-        // We loop over each of those and delete them using mapper
-        $talkCommentsMapper->shouldReceive('delete')->once()->with('comment');
-        $talkMetaMapper->shouldReceive('delete')->once()->with('meta');
-
-        // Finally, we delete the talk itself
-        $talkMapper->shouldReceive('delete')->once()->with($talk);
-
-        // Once all those pesky talks are gone, we remove the speaker!
-        $userMapper->shouldReceive('delete')->once()->with($speaker);
-
-        // So lets wire all this into spot locator and replace
-        // into the application instance
-        $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\User::class)->andReturn($userMapper);
-        $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\Talk::class)->andReturn($talkMapper);
-        $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\TalkComment::class)->andReturn($talkCommentsMapper);
-        $spot->shouldReceive('mapper')->with(\OpenCFP\Domain\Entity\TalkMeta::class)->andReturn($talkMetaMapper);
-
-        // All of this stuff should be done in a transaction
-        $spot->shouldReceive('config->connection->beginTransaction')->once();
-        $spot->shouldReceive('config->connection->commit')->once();
-
-        unset($this->app['spot']);
-        $this->app['spot'] = $spot;
-
-        // Execute the controller and capture the output
-        $controller = new \OpenCFP\Http\Controller\Admin\SpeakersController();
-        $controller->setApplication($this->app);
-        $response = $controller->deleteAction($request);
-
-        // Assert mock expectations.
-        m::close();
-
-        $this->assertInstanceOf(RedirectResponse::class, $response);
+    /**
+     * @test
+     */
+    public function deleteRedirectsOnFailure()
+    {
+        $this->asAdmin()
+            ->get('/admin/speakers/delete/255')
+            ->assertRedirect();
     }
 }

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -83,6 +83,12 @@ class TestResponse
         return $this;
     }
 
+    public function assertFlashContains($flash)
+    {
+        Assert::assertContains($flash, $this->app['session']->get('flash'));
+        return $this;
+    }
+
     public function dd()
     {
         dd($this->getContent());

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -85,7 +85,9 @@ class TestResponse
 
     public function assertFlashContains($flash)
     {
-        Assert::assertContains($flash, $this->app['session']->get('flash'));
+        $fullFlash = $this->app['session']->get('flash');
+        $fullFlash= is_array($fullFlash) ? $fullFlash : [];
+        Assert::assertContains($flash, $fullFlash);
         return $this;
     }
 


### PR DESCRIPTION
This PR changes the speakers controller to use Illuminate.

* It moves the delete functionality out of this controller, and into the models. Overriding the standard delete functionality of the User and Talk model to also delete things related to them.
* It adds options for talk comments and favorites to factory functions.
* It fixes a few routes that still had /admin/ prefixed to them
* It adds assertFlashContains to the TestResponse Class.

The coverage for the SpeakersController is below what i'd like, but ive been running into issues, which i assume are related to the transactions.

The new delete functionality doesn't delete the users comments on other talks, or the entries related to them in the users_groups table. Since this wasn't in the old spot version. Adding this shouldn't be too much of an issue.


Related to #506.
