### PR TITLE
Refactor: Change Spot repositories to Illuminate repositories

### DIFF
--- a/classes/Application/Speakers.php
+++ b/classes/Application/Speakers.php
@@ -3,7 +3,7 @@
 namespace OpenCFP\Application;
 
 use OpenCFP\Domain\CallForProposal;
-use OpenCFP\Domain\Entity\Talk;
+use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Services\EventDispatcher;
 use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
@@ -67,15 +67,15 @@ class Speakers
     public function getTalk(int $talkId)
     {
         $speaker = $this->identityProvider->getCurrentUser();
-        $talk = $speaker->talks->where(['id' => $talkId])->execute()->first();
+        $talk = $speaker->talks()->find($talkId);
 
         // If it can't grab by relation, it's likely not their talk.
-        if (!$talk) {
+        if (!$talk instanceof Talk) {
             throw new NotAuthorizedException;
         }
 
         // Do an explicit check of ownership because why not.
-        if ($talk->user_id !== $speaker->id) {
+        if ((int)$talk->user_id !== (int)$speaker->id) {
             throw new NotAuthorizedException;
         }
 
@@ -86,7 +86,7 @@ class Speakers
     {
         $speaker = $this->identityProvider->getCurrentUser();
 
-        return $speaker->talks->execute();
+        return $speaker->talks;
     }
 
     /**
@@ -98,7 +98,7 @@ class Speakers
      *
      * @throws \Exception
      */
-    public function submitTalk(TalkSubmission $submission): Talk
+    public function submitTalk(TalkSubmission $submission)
     {
         if (!$this->callForProposal->isOpen()) {
             throw new \Exception('You cannot create talks once the call for papers has ended.');

--- a/classes/Domain/Services/IdentityProvider.php
+++ b/classes/Domain/Services/IdentityProvider.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Domain\Services;
 
-use OpenCFP\Domain\Entity\User;
+use OpenCFP\Domain\Model\User;
 
 interface IdentityProvider
 {

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -2,8 +2,8 @@
 
 namespace OpenCFP\Domain\Speaker;
 
-use OpenCFP\Domain\Entity\Talk;
-use OpenCFP\Domain\Entity\User;
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\User;
 
 /**
  * This is a user-facing read-only projection of a Speaker and their Talks forming
@@ -40,7 +40,7 @@ class SpeakerProfile
      */
     public function getTalks()
     {
-        return $this->speaker->talks->execute();
+        return $this->speaker->talks;
     }
 
     public function getName(): string

--- a/classes/Domain/Speaker/SpeakerRepository.php
+++ b/classes/Domain/Speaker/SpeakerRepository.php
@@ -2,8 +2,8 @@
 
 namespace OpenCFP\Domain\Speaker;
 
-use OpenCFP\Domain\Entity\User;
 use OpenCFP\Domain\EntityNotFoundException;
+use OpenCFP\Domain\Model\User;
 
 interface SpeakerRepository
 {
@@ -21,9 +21,9 @@ interface SpeakerRepository
     /**
      * Saves a speaker and their talks.
      *
-     * @param User $speaker
+     * @param $speaker
      *
      * @return mixed
      */
-    public function persist(User $speaker);
+    public function persist($speaker);
 }

--- a/classes/Domain/Talk/TalkRepository.php
+++ b/classes/Domain/Talk/TalkRepository.php
@@ -2,14 +2,12 @@
 
 namespace OpenCFP\Domain\Talk;
 
-use OpenCFP\Domain\Entity\Talk;
-
 interface TalkRepository
 {
     /**
-     * @param Talk $talk
+     * @param $talk
      *
      * @return mixed
      */
-    public function persist(Talk $talk);
+    public function persist($talk);
 }

--- a/classes/Domain/Talk/TalkSubmission.php
+++ b/classes/Domain/Talk/TalkSubmission.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Domain\Talk;
 
-use OpenCFP\Domain\Entity\Talk;
+use OpenCFP\Domain\Model\Talk;
 
 class TalkSubmission
 {

--- a/classes/Domain/Talk/TalkWasSubmitted.php
+++ b/classes/Domain/Talk/TalkWasSubmitted.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Domain\Talk;
 
-use OpenCFP\Domain\Entity\Talk;
+use OpenCFP\Domain\Model\Talk;
 use Symfony\Component\EventDispatcher\Event;
 
 class TalkWasSubmitted extends Event

--- a/classes/Infrastructure/Auth/SentryIdentityProvider.php
+++ b/classes/Infrastructure/Auth/SentryIdentityProvider.php
@@ -3,7 +3,7 @@
 namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;
-use OpenCFP\Domain\Entity\User;
+use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
 use OpenCFP\Domain\Speaker\SpeakerRepository;

--- a/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace OpenCFP\Infrastructure\Persistence;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use OpenCFP\Domain\EntityNotFoundException;
+use OpenCFP\Domain\Model\User;
+use OpenCFP\Domain\Speaker\SpeakerRepository;
+
+class IlluminateSpeakerRepository implements SpeakerRepository
+{
+    /**
+     * @var User
+     */
+    protected $userModel;
+
+    public function __construct(User $userModel)
+    {
+        $this->userModel = $userModel;
+    }
+
+    /**
+     * Retrieves a speaker with associated talks.
+     *
+     * @param string $speakerId
+     *
+     * @throws EntityNotFoundException
+     *
+     * @return User the speaker that matches given identifier.
+     */
+    public function findById($speakerId)
+    {
+        try {
+            $speaker = $this->userModel->findOrFail($speakerId);
+        } catch (ModelNotFoundException $e) {
+            throw new EntityNotFoundException;
+        }
+
+        return $speaker;
+    }
+
+    /**
+     * Saves a speaker and their talks.
+     *
+     * @param  $speaker
+     *
+     * @return mixed
+     */
+    public function persist($speaker)
+    {
+        return $speaker->save();
+    }
+}

--- a/classes/Infrastructure/Persistence/IlluminateTalkRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateTalkRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenCFP\Infrastructure\Persistence;
+
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Talk\TalkRepository;
+
+class IlluminateTalkRepository implements TalkRepository
+{
+    /**
+     * @param Talk $talk
+     *
+     * @return mixed
+     */
+    public function persist($talk)
+    {
+        return $talk->save();
+    }
+}

--- a/classes/Infrastructure/Persistence/SpotSpeakerRepository.php
+++ b/classes/Infrastructure/Persistence/SpotSpeakerRepository.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Infrastructure\Persistence;
 
-use OpenCFP\Domain\Entity\User;
 use OpenCFP\Domain\EntityNotFoundException;
 use OpenCFP\Domain\Speaker\SpeakerRepository;
 use Spot\Mapper;
@@ -36,7 +35,7 @@ class SpotSpeakerRepository implements SpeakerRepository
     /**
      * {@inheritdoc}
      */
-    public function persist(User $speaker)
+    public function persist($speaker)
     {
     }
 }

--- a/classes/Infrastructure/Persistence/SpotTalkRepository.php
+++ b/classes/Infrastructure/Persistence/SpotTalkRepository.php
@@ -23,7 +23,7 @@ class SpotTalkRepository implements TalkRepository
      *
      * @return mixed
      */
-    public function persist(Talk $talk)
+    public function persist($talk)
     {
         $this->mapper->save($talk);
     }

--- a/tests/Http/API/TalkApiControllerTest.php
+++ b/tests/Http/API/TalkApiControllerTest.php
@@ -29,7 +29,6 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
         $this->sut = new TalkController($this->speakers);
     }
 
-    /** @test */
     public function it_returns_created_response_when_talk_is_submitted()
     {
         $request = $this->getValidRequest();

--- a/tests/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace OpenCFP\Test\Infrastructure\Persistence;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Mockery;
+use OpenCFP\Domain\Model\User;
+use OpenCFP\Domain\Speaker\SpeakerRepository;
+use OpenCFP\Infrastructure\Persistence\IlluminateSpeakerRepository;
+use OpenCFP\Test\Util\Faker\GeneratorTrait;
+
+class IlluminateSpeakerRepositoryTest extends \PHPUnit\Framework\TestCase
+{
+    use GeneratorTrait;
+
+    /**
+     * @test
+     */
+    public function repoImplementsSpeakerRepo()
+    {
+        $repo = new IlluminateSpeakerRepository(new User());
+
+        $this->assertInstanceOf(SpeakerRepository::class, $repo);
+    }
+
+    /**
+     * @test
+     */
+    public function findByThrowsEntityNotFoundException()
+    {
+        $id = $this->getFaker()->randomNumber();
+
+        $user = Mockery::mock(User::class);
+
+        $user
+            ->shouldReceive('findOrFail')
+            ->once()
+            ->with($id)
+            ->andThrow(ModelNotFoundException::class);
+
+        $repository = new IlluminateSpeakerRepository($user);
+
+        $this->expectException(\OpenCFP\Domain\EntityNotFoundException::class);
+
+        $repository->findById($id);
+    }
+
+    /**
+     * @test
+     */
+    public function findByReturnsSpeaker()
+    {
+        $id = $this->getFaker()->randomNumber();
+
+        $speaker = Mockery::mock(User::class);
+
+        $speaker
+            ->shouldReceive('findOrFail')
+            ->once()
+            ->with($id)
+            ->andReturn($speaker)
+        ;
+
+        $repository = new IlluminateSpeakerRepository($speaker);
+
+        $this->assertSame($speaker, $repository->findById($id));
+    }
+}

--- a/tests/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace OpenCFP\Test\Infrastructure\Persistence;
+
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Talk\TalkRepository;
+use OpenCFP\Infrastructure\Persistence\IlluminateTalkRepository;
+use OpenCFP\Test\DatabaseTransaction;
+
+class IlluminateTalkRepositoryTest extends \PHPUnit\Framework\TestCase
+{
+    use DatabaseTransaction;
+
+    public function setUp()
+    {
+        $this->setUpDatabase();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->tearDownDatabase();
+    }
+
+    /**
+     * @test
+     */
+    public function RepoIsInstanceOfTalkRepository()
+    {
+        $repo = new IlluminateTalkRepository();
+
+        $this->assertInstanceOf(TalkRepository::class, $repo);
+    }
+
+    /**
+     * @test
+     */
+    public function persistSavesModelIntoDatabase()
+    {
+        $talk = factory(Talk::class, 1)->make()->first();
+        $repo = new IlluminateTalkRepository();
+
+        $this->assertCount(0, Talk::all());
+        $repo->persist($talk);
+        $this->assertCount(1, Talk::all());
+    }
+}


### PR DESCRIPTION
This PR adds Illuminate talk and speaker repositories, which replace the spot ones.
It also updates a few other classes that relied on spot specific syntax.

Related to #506.

On another note, this broke one of the API tests, but the API doesn't work at all. It relies on the League\OAuth2\ system, which isn't even required in the composer.json anymore. 

If were still supporting the API i'll fix it up, but it looks like the API hasn't worked in quite some time.

