### PR TITLE
[WIP] Fix: Always collect coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ jobs:
             - sqlite3
 
       before_install:
-        - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then WITH_COVERAGE=true; else WITH_COVERAGE=false; fi
         - if [[ "$WITH_COVERAGE" == "false" ]]; then phpenv config-rm xdebug.ini; fi
         - composer validate --no-check-publish
 
@@ -70,10 +69,10 @@ jobs:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
       script:
-        - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; else vendor/bin/phpunit; fi
+        - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
       after_success:
-        - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/test-reporter --coverage-report build/logs/clover.xml; fi
+        - vendor/bin/test-reporter --coverage-report build/logs/clover.xml
 
     - stage: Asset
 


### PR DESCRIPTION
❗️ Blocked by #579.

This PR

* [x] always collects coverage

Follows https://github.com/opencfp/opencfp/pull/561#issuecomment-343460931.

💁‍♂️ Note that we should probably modify in regard to #579, that is, when PHP 7.1 is added to the build matrix. We should probably collect coverage only on the latest stable PHP version we decide to add to the build matrix. 

As you can see below, coverage diffs are now displayed in the build statuses:

![screen shot 2017-11-13 at 11 54 56](https://user-images.githubusercontent.com/605483/32722238-9008fe34-c869-11e7-94e4-f8fa10608eaa.png)