### PR TITLE
Enhancement: Enable no_alias_functions fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,6 +13,7 @@ $config = PhpCsFixer\Config::create()
             'syntax' => 'short'
         ],
         'blank_line_after_opening_tag' => true,
+        'no_alias_functions' => true,
         'no_empty_phpdoc' => true,
         'no_extra_consecutive_blank_lines' => true,
         'no_unused_imports' => true,

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -23,11 +23,11 @@ class TalkForm extends Form
 
     public function __construct(array $data, \HTMLPurifier $purifier, array $options = [])
     {
-        if (!key_exists('desired', $data) || $data['desired'] === null) {
+        if (!array_key_exists('desired', $data) || $data['desired'] === null) {
             $data['desired'] = 0;
         }
 
-        if (!key_exists('sponsor', $data) || $data['sponsor'] === null) {
+        if (!array_key_exists('sponsor', $data) || $data['sponsor'] === null) {
             $data['sponsor'] = 0;
         }
 


### PR DESCRIPTION
This PR

* [x] enables the `no_alias_functions` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**no_alias_functions** [`@Symfony:risky`]
>
>Master functions shall be used instead of aliases.
>
>Risky rule: risky when any of the alias functions are overridden.