### PR TITLE
Enhancement: Enable no_trailing_comma_in_singleline_array fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -15,6 +15,7 @@ $config = PhpCsFixer\Config::create()
         'blank_line_after_opening_tag' => true,
         'no_empty_phpdoc' => true,
         'no_extra_consecutive_blank_lines' => true,
+        'no_trailing_comma_in_singleline_array' => true,
         'no_unused_imports' => true,
         'ordered_imports' => true,
         'phpdoc_align' => true,

--- a/tests/Domain/Entity/Mapper/UserTest.php
+++ b/tests/Domain/Entity/Mapper/UserTest.php
@@ -14,7 +14,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     private $app;
     /** @var  \OpenCFP\Domain\Entity\Mapper\User */
     private $mapper;
-    private $entities = ['User',];
+    private $entities = ['User'];
 
     protected function setUp()
     {


### PR DESCRIPTION
This PR

* [x] enables the `no_trailing_comma_in_singleline_array` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**no_trailing_comma_in_singleline_array** [`@Symfony`]
>
>PHP single-line arrays should not have trailing comma.