### PR TITLE
Fix: Do not attempt to report coverage using old reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,9 +73,6 @@ jobs:
       after_script:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
-      after_success:
-        - vendor/bin/test-reporter --coverage-report build/logs/clover.xml
-
     - <<: *TEST
 
       php: 7.1


### PR DESCRIPTION
This PR

* [x] removes an invocation of the non-existent test reporter from `.travis.yml`

Follows #562.