### PR TITLE
Enhancement: Enable cast_spaces fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,6 +13,7 @@ $config = PhpCsFixer\Config::create()
             'syntax' => 'short'
         ],
         'blank_line_after_opening_tag' => true,
+        'cast_spaces' => true,
         'method_separation' => true,
         'no_alias_functions' => true,
         'no_empty_phpdoc' => true,

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -277,7 +277,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotContains(
             '<input id="form-talk-title" type="text" name="title" class="form-control" placeholder="Talk Title"',
-            (string)$response
+            (string) $response
         );
         $this->assertNotContains(
             '<div class="form-group">',
@@ -299,7 +299,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         $this->app['spot']->shouldReceive('where')->with(['id' => 1])->andReturn($this->app['spot']);
         $this->app['spot']->shouldReceive('execute')->andReturn($this->app['spot']);
         $this->app['spot']->shouldReceive('first')->andReturn($this->app['spot']);
-        $this->app['spot']->shouldReceive('toArray')->andReturn(['user_id'=> (int)$this->app[Authentication::class]->user()->getId() + 2]);
+        $this->app['spot']->shouldReceive('toArray')->andReturn(['user_id'=> (int) $this->app[Authentication::class]->user()->getId() + 2]);
 
         $response = $controller->editAction($this->req);
         $this->assertInstanceOf(
@@ -324,7 +324,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         $this->app['spot']->shouldReceive('first')->andReturn($this->app['spot']);
         $this->app['spot']->shouldReceive('toArray')->andReturn(
             [
-                'user_id' => (int)$this->app[Authentication::class]->user()->getId(),
+                'user_id' => (int) $this->app[Authentication::class]->user()->getId(),
                 'title' => 'Title of talk to edit',
                 'description' => 'The Description',
                 'type' => 'regular',
@@ -344,7 +344,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertContains(
             'Talk Title',
-            (string)$response
+            (string) $response
         );
     }
 


### PR DESCRIPTION
This PR

* [x] enables the `cast_spaces` fixer
* [x] runs `make cs`

Replaces #584.
Follows #587.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**cast_spaces** [`@Symfony`]
>
>A single space or none should be between cast and variable.
>
>Configuration options:
>
>* `space` (`'none'`, `'single'`): spacing to apply between cast and variable; defaults to `'single'`