### PR TITLE
Enhancement: Collect coverage on a single PHP version only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ jobs:
 
       php: 7.0
 
+      env:
+        - WITH_COVERAGE=false
+
       addons:
         apt:
           sources:
@@ -59,23 +62,25 @@ jobs:
         - composer install
 
       before_script:
+        - source .travis/code-climate.sh
         - sh tools/travis/setup-mail.sh
         - mysql -e "CREATE DATABASE $TRAVIS_DB" -uroot
         - cp phinx.yml.dist phinx.yml
         - vendor/bin/phinx migrate -e testing
-        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        - chmod +x ./cc-test-reporter
-        - ./cc-test-reporter before-build
+        - if [[ "$WITH_COVERAGE" == "true" ]]; then code-climate-before-script; fi
 
       script:
-        - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+        - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; else vendor/bin/phpunit; fi
 
       after_script:
-        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+        - if [[ "$WITH_COVERAGE" == "true" ]]; then code-climate-after-script; fi
 
     - <<: *TEST
 
       php: 7.1
+
+      env:
+        - WITH_COVERAGE=true
 
     - stage: Asset
 

--- a/.travis/code-climate.sh
+++ b/.travis/code-climate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# See
+#
+# - https://github.com/codeclimate/test-reporter#installation--usage
+# - https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+
+function code-climate-before-script()
+{
+    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+    chmod +x ./cc-test-reporter
+    ./cc-test-reporter before-build
+}
+
+function code-climate-after-script()
+{
+    ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+}


### PR DESCRIPTION
This PR

* [x] collects coverage on a single PHP version only

Follows #581.

💁‍♂️ The idea is to speed up the build by collecting coverage on a single PHP version build only, and using the latest version of it (faster).

### Before

![screen shot 2017-11-13 at 18 29 05](https://user-images.githubusercontent.com/605483/32739590-9cf6fc18-c8a0-11e7-9694-c0b2d07dbdbe.png)


### After

![screen shot 2017-11-13 at 18 28 29](https://user-images.githubusercontent.com/605483/32739582-96e0f37e-c8a0-11e7-9690-43a0f7e9af26.png)
