### PR TITLE
Enhancement: Remove models from static access PHPMD rule

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,6 +12,8 @@ engines:
       standard: PSR2
   phpmd:
     enabled: true
+    config:
+      rulesets: "codesize,controversial,design,naming,unusedcode,PHPMDRuleSet.xml"
 
 ratings:
   paths:

--- a/PHPMDRuleSet.xml
+++ b/PHPMDRuleSet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="PHPMD rule set for my project" xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>Custom rules for checking the OpenCFP Project</description>
+
+    <rule ref="rulesets/cleancode.xml">
+        <exclude name="StaticAccess"/>
+    </rule>
+
+    <rule ref="rulesets/cleancode.xml/StaticAccess">
+        <properties>
+            <property name="exceptions" value="Airport,Favorite,Group,Talk,TalkComment,TalkMeta,User" />
+        </properties>
+    </rule>
+</ruleset>


### PR DESCRIPTION
This PR adds a custom ruleset to our PHP MD code climate check.

 * [x] Our Models are an exception on the static access rule

Fixes #586.
