### PR TITLE
Enhancement: Enable blank_line_before_statement fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,6 +13,7 @@ $config = PhpCsFixer\Config::create()
             'syntax' => 'short'
         ],
         'blank_line_after_opening_tag' => true,
+        'blank_line_before_statement' => true,
         'cast_spaces' => true,
         'method_separation' => true,
         'no_alias_functions' => true,

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -321,12 +321,15 @@ class Application extends SilexApplication
             switch ($code) {
                 case Response::HTTP_UNAUTHORIZED:
                     $message = $twig->render('error/401.twig');
+
                     break;
                 case Response::HTTP_FORBIDDEN:
                     $message = $twig->render('error/403.twig');
+
                     break;
                 case Response::HTTP_NOT_FOUND:
                     $message = $twig->render('error/404.twig');
+
                     break;
                 default:
                     $message = $twig->render('error/500.twig');

--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -47,6 +47,7 @@ class UserCreateCommand extends BaseCommand
 
         if ($user == false) {
             $io->error('User Already Exists!');
+
             return 1;
         }
 

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -435,6 +435,7 @@ class Talk extends Mapper
     {
         $format = new TalkFormatter();
         $output = $format->createdFormattedOutput($talk, $admin_user_id, $userData);
+
         return $output;
     }
 

--- a/classes/Domain/Model/Airport.php
+++ b/classes/Domain/Model/Airport.php
@@ -23,6 +23,7 @@ class Airport extends Eloquent implements AirportInformationDatabase
         if (!$airport) {
             throw new \Exception("An airport matching '{$code}' was not found.");
         }
+
         return $airport;
     }
 }

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -44,6 +44,7 @@ class Talk extends Eloquent
         $this->deleteComments();
         $this->deleteFavorites();
         $this->deleteMeta();
+
         return parent::delete();
     }
 

--- a/classes/Domain/Model/TalkMeta.php
+++ b/classes/Domain/Model/TalkMeta.php
@@ -41,6 +41,7 @@ class TalkMeta extends Eloquent
             $this->viewed = true;
             $this->save();
         }
+
         return $this;
     }
 }

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -42,6 +42,7 @@ class User extends Eloquent
             if ((int) $talk['id'] == (int) $talkId) {
                 return false;
             }
+
             return true;
         });
 
@@ -67,6 +68,7 @@ class User extends Eloquent
         if ($search == '' || $search == null) {
             return $builder->orderBy($orderByColumn, $orderByDirection);
         }
+
         return $builder
             ->where('first_name', 'like', '%' . $search. '%')
             ->orWhere('last_name', 'like', '%' . $search. '%')

--- a/classes/Domain/Services/Pagination.php
+++ b/classes/Domain/Services/Pagination.php
@@ -28,10 +28,12 @@ class Pagination
     {
         $routeGenerator = function ($page) use ($queryParams, $baseUrl) {
             $queryParams['page'] = $page;
+
             return $baseUrl . http_build_query($queryParams);
         };
 
         $view = new DefaultView();
+
         return $view->render(
             $this->pagerFanta,
             $routeGenerator,

--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -81,9 +81,11 @@ class ProfileImageProcessor
             if ($speakerPhoto->save($this->publishDir . '/' . $publishFilename)) {
                 unlink($this->publishDir . '/' . $tempFilename);
             }
+
             return $publishFilename;
         } catch (\Exception $e) {
             unlink($this->publishDir . '/' . $tempFilename);
+
             throw $e;
         }
     }

--- a/classes/Domain/Services/ResetEmailer.php
+++ b/classes/Domain/Services/ResetEmailer.php
@@ -51,6 +51,7 @@ class ResetEmailer
 
         try {
             $message = $this->preparedMessage($email, $parameters);
+
             return $this->swift_mailer->send($message);
         } catch (\Exception $e) {
             echo $e;

--- a/classes/Domain/Services/TalkRating/YesNoRating.php
+++ b/classes/Domain/Services/TalkRating/YesNoRating.php
@@ -9,6 +9,7 @@ class YesNoRating extends TalkRating
         if ($rating < -1 || $rating > 1) {
             return false;
         }
+
         return true;
     }
 

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -24,30 +24,37 @@ class TalkFilter
         switch (strtolower($filter)) {
             case 'selected':
                 return $this->talk_mapper->getSelected($admin_user_id, $options);
+
                 break;
 
             case 'notviewed':
                 return $this->talk_mapper->getNotViewedByUserId($admin_user_id, $options);
+
                 break;
 
             case 'notrated':
                 return $this->talk_mapper->getNotRatedByUserId($admin_user_id, $options);
+
                 break;
 
             case 'toprated':
                 return $this->talk_mapper->getTopRatedByUserId($admin_user_id, $options);
+
                 break;
 
             case 'plusone':
                 return $this->talk_mapper->getPlusOneByUserId($admin_user_id, $options);
+
                 break;
 
             case 'viewed':
                 return $this->talk_mapper->getViewedByUserId($admin_user_id, $options);
+
                 break;
 
             case 'favorited':
                 return $this->talk_mapper->getFavoritesByUserId($admin_user_id, $options);
+
                 break;
 
             default:

--- a/classes/Domain/ValidationException.php
+++ b/classes/Domain/ValidationException.php
@@ -10,6 +10,7 @@ class ValidationException extends \Exception
     {
         $instance = new static('There was an error.');
         $instance->errors = $errors;
+
         return $instance;
     }
 

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -82,12 +82,14 @@ class ExportsController extends BaseController
             ) {
             $info = "'". $info;
         }
+
         return $info;
     }
 
     private function startsWith($haystack, $needle)
     {
         $length = strlen($needle);
+
         return (substr($haystack, 0, $length) === $needle);
     }
 

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -47,6 +47,7 @@ class SpeakersController extends BaseController
             }
 
             $speaker['is_admin'] = in_array($speaker['id'], $adminUserIds);
+
             return $speaker;
         })->toArray();
 
@@ -122,6 +123,7 @@ class SpeakersController extends BaseController
         $capsule = $this->service(Capsule::class);
 
         $capsule->getConnection()->beginTransaction();
+
         try {
             $user = User::findorFail($req->get('id'));
             $user->delete($req->get('id'));
@@ -160,6 +162,7 @@ class SpeakersController extends BaseController
 
             return $this->redirectTo('admin_speakers');
         }
+
         try {
             $user = $accounts->findById($req->get('id'));
             $accounts->demoteFrom($user->getLogin());
@@ -184,6 +187,7 @@ class SpeakersController extends BaseController
     {
         /* @var AccountManagement $accounts */
         $accounts = $this->service(AccountManagement::class);
+
         try {
             $user = $accounts->findById($req->get('id'));
             if ($user->hasAccess('admin')) {
@@ -192,6 +196,7 @@ class SpeakersController extends BaseController
                     'short' => 'Error',
                     'ext' => 'User already is in the Admin group.',
                 ]);
+
                 return $this->redirectTo('admin_speakers');
             }
 

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -96,6 +96,7 @@ class TalksController extends BaseController
             'otherTalks' => $otherTalks,
             'comments' => $talk->comments()->get(),
         ];
+
         return $this->render('admin/talks/view.twig', $templateData);
     }
 
@@ -135,8 +136,10 @@ class TalksController extends BaseController
                 ->first();
             if ($favorite instanceof  Favorite) {
                 $favorite->delete();
+
                 return true;
             }
+
             return false;
         }
 
@@ -161,6 +164,7 @@ class TalksController extends BaseController
         if ($talk instanceof Talk) {
             $talk->selected = $req->get('delete') == true ? 0 :1;
             $talk->save();
+
             return true;
         }
 

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -19,6 +19,7 @@ class ForgotController extends BaseController
             'form' => $form->createView(),
             'current_page' => 'Forgot Password',
         ];
+
         return $this->render('security/forgot_password.twig', $data);
     }
 
@@ -49,6 +50,7 @@ class ForgotController extends BaseController
             $user = $accounts->findByLogin($data['email']);
         } catch (UserNotFoundException $e) {
             $this->service('session')->set('flash', $this->successfulSendFlashParameters($data['email']));
+
             return $this->redirectTo('forgot_password');
         }
 
@@ -78,6 +80,7 @@ class ForgotController extends BaseController
 
         $errorMessage = 'The reset you have requested appears to be invalid, please try again.';
         $error = 0;
+
         try {
             /** @var AccountManagement $accounts */
             $accounts = $this->service(AccountManagement::class);
@@ -127,6 +130,7 @@ class ForgotController extends BaseController
         if (! $form->isValid()) {
             $form->get('user_id')->setData($user_id);
             $form->get('reset_code')->setData($reset_code);
+
             return $this->render('user/reset_password.twig', ['form' => $form->createView()]);
         }
              

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -78,6 +78,7 @@ class ProfileController extends BaseController
             }
             unset($sanitized_data['speaker_photo']);
             User::find($userId)->update($sanitized_data);
+
             return $this->redirectTo('dashboard');
         }
         $this->service('session')->set('flash', [
@@ -171,6 +172,7 @@ class ProfileController extends BaseController
             'speaker_info' => $req->get('speaker_info') ?: null,
             'speaker_bio' => $req->get('speaker_bio') ?: null,
         ];
+
         return $form_data;
     }
 
@@ -193,6 +195,7 @@ class ProfileController extends BaseController
         $sanitizedData['id'] = $sanitizedData['user_id'];
         unset($sanitizedData['user_id']);
         $sanitizedData['has_made_profile'] = 1;
+
         return $sanitizedData;
     }
 }

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -88,6 +88,7 @@ class TalksController extends BaseController
             'otherTalks' => $otherTalks,
             'comments' => $talk->comments()->get(),
         ];
+
         return $this->render('reviewer/talks/view.twig', $templateData);
     }
 
@@ -104,6 +105,7 @@ class TalksController extends BaseController
         } catch (TalkRatingException $e) {
             return false;
         }
+
         return true;
     }
 }

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -52,6 +52,7 @@ class SecurityController extends BaseController
     public function outAction()
     {
         $this->service(Authentication::class)->logout();
+
         return $this->redirectTo('homepage');
     }
 }

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -29,6 +29,7 @@ class TalkController extends BaseController
             'types' => $this->getTalkTypes(),
         ];
         $form = new TalkForm($request_data, $this->service('purifier'), $options);
+
         return $form;
     }
     

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -252,6 +252,7 @@ class SignupForm extends Form
             return true;
         } else {
             $this->_addErrorMessage('You did not enter a valid joind.in URL');
+
             return false;
         }
     }
@@ -339,6 +340,7 @@ class SignupForm extends Form
         }
 
         $this->_addErrorMessage('You must agree to abide by our code of conduct in order to submit');
+
         return false;
     }
 }

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -156,11 +156,13 @@ class TalkForm extends Form
 
         if (empty($this->_cleanData['category']) || !isset($this->_cleanData['category'])) {
             $this->_addErrorMessage('You must choose what category of talk you are submitting');
+
             return false;
         }
 
         if (!isset($validCategories[$this->_cleanData['category']])) {
             $this->_addErrorMessage('You did not choose a valid talk category');
+
             return false;
         }
 

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -64,6 +64,7 @@ class ApplicationServiceProvider implements ServiceProviderInterface
 
             $capsule->setAsGlobal();
             $capsule->bootEloquent();
+
             return $capsule;
         };
 

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -64,6 +64,7 @@ class TwigServiceProvider implements ServiceProviderInterface
                     $app->config('talk.types')
                 )
             );
+
             return $twig;
         });
     }

--- a/classes/Provider/YamlConfigDriver.php
+++ b/classes/Provider/YamlConfigDriver.php
@@ -12,6 +12,7 @@ class YamlConfigDriver
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
         $config = Yaml::parse(file_get_contents($filename));
+
         return $config ?: [];
     }
 

--- a/tests/Application/SpeakersTest.php
+++ b/tests/Application/SpeakersTest.php
@@ -228,6 +228,7 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
         $stub = m::mock(\stdClass::class);
         $stub->shouldReceive('talks')->andReturnSelf();
         $stub->shouldReceive('find')->andReturnNull();
+
         return $stub;
     }
 

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -123,6 +123,7 @@ class DashboardControllerTest extends WebTestCase
     {
         $speakerProfileDouble = m::mock(SpeakerProfile::class);
         $speakerProfileDouble->shouldReceive($stubMethods);
+
         return $speakerProfileDouble;
     }
 }

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -74,12 +74,14 @@ class TestResponse
     public function assertSee($content)
     {
         Assert::assertContains($content, $this->getContent());
+
         return $this;
     }
 
     public function assertNotSee($content)
     {
         Assert::assertNotContains($content, $this->getContent());
+
         return $this;
     }
 
@@ -88,6 +90,7 @@ class TestResponse
         $fullFlash = $this->app['session']->get('flash');
         $fullFlash= is_array($fullFlash) ? $fullFlash : [];
         Assert::assertContains($flash, $fullFlash);
+
         return $this;
     }
 

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -54,6 +54,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
     {
         $app = new Application(BASE_PATH, Environment::testing());
         $app['session.test'] = true;
+
         return $app;
     }
 
@@ -73,6 +74,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
     protected function swap($service, $instance)
     {
         $this->app[$service] = $instance;
+
         return $instance;
     }
 
@@ -86,6 +88,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
     public function withHeaders(array $headers): self
     {
         $this->headers = array_merge($this->headers, $headers);
+
         return $this;
     }
 
@@ -100,18 +103,21 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
     public function withHeader(string $name, string $value): self
     {
         $this->headers[$name] = $value;
+
         return $this;
     }
 
     public function withNoHeaders()
     {
         $this->headers = [];
+
         return $this;
     }
 
     public function withServerVariables(array $server): self
     {
         $this->server = $server;
+
         return $this;
     }
 
@@ -159,6 +165,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
         $cfp->shouldReceive('isOpen')->andReturn(true);
         $this->swap('callforproposal', $cfp);
         $this->app['twig']->addGlobal('cfp_open', true);
+
         return $this;
     }
 
@@ -168,6 +175,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
         $cfp->shouldReceive('isOpen')->andReturn(false);
         $this->swap('callforproposal', $cfp);
         $this->app['twig']->addGlobal('cfp_open', false);
+
         return $this;
     }
 
@@ -177,6 +185,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
         $config['application']['online_conference'] = true;
         $this->app['config'] = $config;
         $this->app['twig']->addGlobal('site', $this->app->config('application'));
+
         return $this;
     }
 
@@ -197,6 +206,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
         $auth->shouldReceive('user')->andReturn($user);
         $auth->shouldReceive('userId')->andReturn($id);
         $this->swap(Authentication::class, $auth);
+
         return $this;
     }
 
@@ -217,6 +227,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
         $auth->shouldReceive('user')->andReturn($user);
         $auth->shouldReceive('userId')->andReturn($id);
         $this->swap(Authentication::class, $auth);
+
         return $this;
     }
 
@@ -235,6 +246,7 @@ class WebTestCase extends \PHPUnit\Framework\TestCase
         $auth->shouldReceive('user')->andReturn($user);
         $auth->shouldReceive('userId')->andReturn($id);
         $this->swap(Authentication::class, $auth);
+
         return $this;
     }
 }


### PR DESCRIPTION
❗️ Blocked by #596.

This PR

* [x] enables and configures the `blank_line_before_statement` fixer
* [x] runs `make cs`

Replaces #584.
Follows #587.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**blank_line_before_statement** [`@Symfony`]
>
>An empty line feed must precede any configured statement.
>
>Configuration options:
>
>* `statements` (`array`): list of statements which must be preceded by an empty line; defaults to `['break', 'continue', 'declare', 'return', 'throw', 'try']`