### PR TITLE
Fix: Add line dropped earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ jobs:
         - composer install
 
       before_script:
+        - source .travis/code-climate.sh
         - sh .travis/setup-mail.sh
         - mysql -e "CREATE DATABASE $TRAVIS_DB" -uroot
         - cp phinx.yml.dist phinx.yml


### PR DESCRIPTION
This PR

* [x] adds a line to `.travis.yml` which appears to have been dropped when resolving merge conflicts

Follows #590.

💁‍♂️ See https://travis-ci.org/opencfp/opencfp/jobs/301537620#L755-L756:

```
$ if [[ "$WITH_COVERAGE" == "true" ]]; then code-climate-before-script; fi
code-climate-before-script: command not found
```
