### PR TITLE
Fix PHPMD ruleset

### DIFF
--- a/PHPMDRuleSet.xml
+++ b/PHPMDRuleSet.xml
@@ -11,7 +11,7 @@
 
     <rule ref="rulesets/cleancode.xml/StaticAccess">
         <properties>
-            <property name="exceptions" value="Airport,Favorite,Group,Talk,TalkComment,TalkMeta,User" />
+            <property name="exceptions" value="\OpenCFP\Domain\Model\Airport,\OpenCFP\Domain\Model\Favorite,\OpenCFP\Domain\Model\Group,\OpenCFP\Domain\Model\Talk,\OpenCFP\Domain\Model\TalkComment,\OpenCFP\Domain\Model\TalkMeta,\OpenCFP\Domain\Model\User" />
         </properties>
     </rule>
 </ruleset>


### PR DESCRIPTION
It looks like the exceptions need to be fully namespaces.

If this works correctly it should show the issues as being fixed in the Code Climate overview of the PR