### PR TITLE
Enhancement: Enable binary_operator_spaces fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -12,6 +12,9 @@ $config = PhpCsFixer\Config::create()
         'array_syntax' => [
             'syntax' => 'short'
         ],
+        'binary_operator_spaces' => [
+            'default' => 'align',
+        ],
         'blank_line_after_opening_tag' => true,
         'blank_line_before_statement' => true,
         'cast_spaces' => true,

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -44,8 +44,8 @@ class Application extends SilexApplication
     {
         parent::__construct();
 
-        $this['path'] = $basePath;
-        $this['env'] = $environment;
+        $this['path']  = $basePath;
+        $this['env']   = $environment;
         $this['debug'] = true;
 
         $this->bindPathsInApplicationContainer();
@@ -71,19 +71,19 @@ class Application extends SilexApplication
         $this->register(new TranslationServiceProvider);
         $this->register(new MonologServiceProvider, [
             'monolog.logfile' => $this->config('log.path') ?: "{$basePath}/log/app.log",
-            'monolog.name' => 'opencfp',
-            'monlog.level' => strtoupper(
+            'monolog.name'    => 'opencfp',
+            'monlog.level'    => strtoupper(
                 $this->config('log.level') ?: 'debug'
             ),
         ]);
         $this->register(new SwiftmailerServiceProvider, [
             'swiftmailer.options' => [
-                'host' => $this->config('mail.host'),
-                'port' => $this->config('mail.port'),
-                'username' => $this->config('mail.username'),
-                'password' => $this->config('mail.password'),
+                'host'       => $this->config('mail.host'),
+                'port'       => $this->config('mail.port'),
+                'username'   => $this->config('mail.username'),
+                'password'   => $this->config('mail.password'),
                 'encryption' => $this->config('mail.encryption'),
-                'auth_mode' => $this->config('mail.auth_mode'),
+                'auth_mode'  => $this->config('mail.auth_mode'),
             ],
         ]);
 

--- a/classes/Application/Speakers.php
+++ b/classes/Application/Speakers.php
@@ -36,11 +36,11 @@ class Speakers
         TalkRepository $talks,
         EventDispatcher $dispatcher
     ) {
-        $this->speakers = $speakers;
+        $this->speakers         = $speakers;
         $this->identityProvider = $identityProvider;
-        $this->talks = $talks;
-        $this->callForProposal = $callForProposal;
-        $this->dispatcher = $dispatcher;
+        $this->talks            = $talks;
+        $this->callForProposal  = $callForProposal;
+        $this->dispatcher       = $dispatcher;
     }
 
     /**
@@ -67,7 +67,7 @@ class Speakers
     public function getTalk(int $talkId)
     {
         $speaker = $this->identityProvider->getCurrentUser();
-        $talk = $speaker->talks()->find($talkId);
+        $talk    = $speaker->talks()->find($talkId);
 
         // If it can't grab by relation, it's likely not their talk.
         if (!$talk instanceof Talk) {

--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -40,9 +40,9 @@ class UserCreateCommand extends BaseCommand
 
         $user = $this->createUser([
             'first_name' => $input->getOption('first_name'),
-            'last_name' => $input->getOption('last_name'),
-            'password' => $input->getOption('password'),
-            'email' => $input->getOption('email'),
+            'last_name'  => $input->getOption('last_name'),
+            'password'   => $input->getOption('password'),
+            'email'      => $input->getOption('email'),
         ]);
 
         if ($user == false) {
@@ -70,9 +70,9 @@ class UserCreateCommand extends BaseCommand
         try {
             $user_data = [
                 'first_name' => $data['first_name'],
-                'last_name' => $data['last_name'],
-                'email' => $data['email'],
-                'password' => $data['password'],
+                'last_name'  => $data['last_name'],
+                'email'      => $data['email'],
+                'password'   => $data['password'],
             ];
 
             /** @var AccountManagement $accounts */

--- a/classes/Domain/Entity/Favorite.php
+++ b/classes/Domain/Entity/Favorite.php
@@ -11,10 +11,10 @@ class Favorite extends Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'id'            => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
             'admin_user_id' => ['type' => 'integer', 'required' => true],
-            'talk_id' => ['type' => 'integer', 'required' => true],
-            'created' => ['type' => 'datetime', 'value' => new \DateTime()],
+            'talk_id'       => ['type' => 'integer', 'required' => true],
+            'created'       => ['type' => 'datetime', 'value' => new \DateTime()],
         ];
     }
 

--- a/classes/Domain/Entity/Group.php
+++ b/classes/Domain/Entity/Group.php
@@ -11,11 +11,11 @@ class Group extends Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
-            'name' => ['type' => 'string', 'length' => 255, 'required' => true],
+            'id'          => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'name'        => ['type' => 'string', 'length' => 255, 'required' => true],
             'permissions' => ['type' => 'text'],
-            'created_at' => ['type' => 'datetime', 'value' => new \DateTime()],
-            'updated_at' => ['type' => 'datetime', 'value' => new \DateTime()],
+            'created_at'  => ['type' => 'datetime', 'value' => new \DateTime()],
+            'updated_at'  => ['type' => 'datetime', 'value' => new \DateTime()],
         ];
     }
 

--- a/classes/Domain/Entity/Mapper/Talk.php
+++ b/classes/Domain/Entity/Mapper/Talk.php
@@ -39,7 +39,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 'created_at',
-                'sort' => 'ASC',
+                'sort'     => 'ASC',
             ]
         );
 
@@ -77,7 +77,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 'created_at',
-                'sort' => 'DESC',
+                'sort'     => 'DESC',
             ]
         );
 
@@ -133,7 +133,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 'f.created',
-                'sort' => 'DESC',
+                'sort'     => 'DESC',
             ]
         );
 
@@ -169,7 +169,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 'total_rating',
-                'sort' => 'DESC',
+                'sort'     => 'DESC',
             ]
         );
 
@@ -204,7 +204,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 't.created_at',
-                'sort' => 'DESC',
+                'sort'     => 'DESC',
             ]
         );
 
@@ -239,7 +239,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 't.created_at',
-                'sort' => 'DESC',
+                'sort'     => 'DESC',
             ]
         );
 
@@ -274,7 +274,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 'm.created',
-                'sort' => 'DESC',
+                'sort'     => 'DESC',
             ]
         );
 
@@ -309,7 +309,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 'm.created',
-                'sort' => 'DESC',
+                'sort'     => 'DESC',
             ]
         );
 
@@ -344,7 +344,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 't.created_at',
-                'sort' => 'DESC',
+                'sort'     => 'DESC',
             ]
         );
 
@@ -383,7 +383,7 @@ class Talk extends Mapper
             $options,
             [
                 'order_by' => 'created_at',
-                'sort' => 'DESC',
+                'sort'     => 'DESC',
             ]
         );
 

--- a/classes/Domain/Entity/Phinxlog.php
+++ b/classes/Domain/Entity/Phinxlog.php
@@ -11,9 +11,9 @@ class Phinxlog extends Entity
     public static function fields()
     {
         return [
-            'version' => ['type' => 'bigint', 'required' => true],
+            'version'    => ['type' => 'bigint', 'required' => true],
             'start_time' => ['type' => 'time', 'value' => time()],
-            'end_time' => ['type' => 'time', 'value' => null],
+            'end_time'   => ['type' => 'time', 'value' => null],
         ];
     }
 }

--- a/classes/Domain/Entity/Tag.php
+++ b/classes/Domain/Entity/Tag.php
@@ -13,7 +13,7 @@ class Tag extends Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'id'  => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
             'tag' => ['type' => 'string', 'length' => 50, 'required' => true, 'unique' => 'tag'],
         ];
     }

--- a/classes/Domain/Entity/Talk.php
+++ b/classes/Domain/Entity/Talk.php
@@ -6,35 +6,35 @@ use Spot\Entity;
 
 class Talk extends Entity
 {
-    protected static $table = 'talks';
+    protected static $table  = 'talks';
     protected static $mapper = \OpenCFP\Domain\Entity\Mapper\Talk::class;
 
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
-            'title' => ['type' => 'string', 'length' => 100, 'required' => true],
+            'id'          => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'title'       => ['type' => 'string', 'length' => 100, 'required' => true],
             'description' => ['type' => 'text'],
-            'type' => ['type' => 'string', 'length' => 50],
-            'user_id' => ['type' => 'integer', 'required' => true],
-            'level' => ['type' => 'string', 'length' => 50],
-            'category' => ['type' => 'string', 'length' => 50],
-            'desired' => ['type' => 'smallint', 'value' => 0],
-            'slides' => ['type' => 'string', 'length' => 255],
-            'other' => ['type' => 'text'],
-            'sponsor' => ['type' => 'smallint', 'value' => 0],
-            'selected' => ['type' => 'smallint', 'value' => 0],
-            'created_at' => ['type' => 'datetime', 'value' => new \DateTime()],
-            'updated_at' => ['type' => 'datetime', 'value' => new \DateTime()],
+            'type'        => ['type' => 'string', 'length' => 50],
+            'user_id'     => ['type' => 'integer', 'required' => true],
+            'level'       => ['type' => 'string', 'length' => 50],
+            'category'    => ['type' => 'string', 'length' => 50],
+            'desired'     => ['type' => 'smallint', 'value' => 0],
+            'slides'      => ['type' => 'string', 'length' => 255],
+            'other'       => ['type' => 'text'],
+            'sponsor'     => ['type' => 'smallint', 'value' => 0],
+            'selected'    => ['type' => 'smallint', 'value' => 0],
+            'created_at'  => ['type' => 'datetime', 'value' => new \DateTime()],
+            'updated_at'  => ['type' => 'datetime', 'value' => new \DateTime()],
         ];
     }
 
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'speaker' => $mapper->belongsTo($entity, \OpenCFP\Domain\Entity\User::class, 'user_id'),
+            'speaker'   => $mapper->belongsTo($entity, \OpenCFP\Domain\Entity\User::class, 'user_id'),
             'favorites' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\Favorite::class, 'talk_id'),
-            'comments' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\TalkComment::class, 'talk_id')
+            'comments'  => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\TalkComment::class, 'talk_id')
                 ->order(['created' => 'ASC']),
             'meta' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\TalkMeta::class, 'talk_id'),
         ];
@@ -43,16 +43,16 @@ class Talk extends Entity
     public function toArrayForApi()
     {
         return [
-            'id' => $this->id,
-            'title' => $this->title,
+            'id'          => $this->id,
+            'title'       => $this->title,
             'description' => $this->description,
-            'type' => $this->type,
-            'level' => $this->level,
-            'category' => $this->category,
-            'desired' => $this->desired,
-            'slides' => $this->slides,
-            'other' => $this->other,
-            'sponsor' => $this->sponsor,
+            'type'        => $this->type,
+            'level'       => $this->level,
+            'category'    => $this->category,
+            'desired'     => $this->desired,
+            'slides'      => $this->slides,
+            'other'       => $this->other,
+            'sponsor'     => $this->sponsor,
         ];
     }
 }

--- a/classes/Domain/Entity/TalkComment.php
+++ b/classes/Domain/Entity/TalkComment.php
@@ -9,7 +9,7 @@ class TalkComment extends \Spot\Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'id'      => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
             'user_id' => ['type' => 'integer', 'required' => true],
             'talk_id' => ['type' => 'integer', 'required' => true],
             'message' => ['type' => 'text', 'required' => true],

--- a/classes/Domain/Entity/TalkMeta.php
+++ b/classes/Domain/Entity/TalkMeta.php
@@ -9,12 +9,12 @@ class TalkMeta extends \Spot\Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'id'            => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
             'admin_user_id' => ['type' => 'integer', 'required' => true],
-            'talk_id' => ['type' => 'integer', 'required' => true],
-            'rating' => ['type' => 'smallint', 'default' => 0],
-            'viewed' => ['type' => 'boolean', 'default' => false],
-            'created' => ['type' => 'datetime', 'value' => new \DateTime()],
+            'talk_id'       => ['type' => 'integer', 'required' => true],
+            'rating'        => ['type' => 'smallint', 'default' => 0],
+            'viewed'        => ['type' => 'boolean', 'default' => false],
+            'created'       => ['type' => 'datetime', 'value' => new \DateTime()],
         ];
     }
 

--- a/classes/Domain/Entity/TalkTag.php
+++ b/classes/Domain/Entity/TalkTag.php
@@ -11,9 +11,9 @@ class TalkTag extends Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'primary' => true, 'autoincrement' => true],
+            'id'      => ['type' => 'integer', 'primary' => true, 'autoincrement' => true],
             'talk_id' => ['type' => 'integer', 'required' => true, 'unique' => 'talk_tag'],
-            'tag_id' => ['type' => 'integer', 'required' => true, 'unique' => 'talk_tag'],
+            'tag_id'  => ['type' => 'integer', 'required' => true, 'unique' => 'talk_tag'],
         ];
     }
 

--- a/classes/Domain/Entity/Throttle.php
+++ b/classes/Domain/Entity/Throttle.php
@@ -11,15 +11,15 @@ class Throttle extends Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
-            'user_id' => ['type' => 'integer'],
-            'ip_address' => ['type' => 'string', 'length' => 255, 'value' => null],
-            'attempts' => ['type' => 'integer', 'value' => 0],
-            'suspended' => ['type' => 'smallint', 'value' => 0],
-            'banned' => ['type' => 'smallint', 'value' => 0],
+            'id'              => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'user_id'         => ['type' => 'integer'],
+            'ip_address'      => ['type' => 'string', 'length' => 255, 'value' => null],
+            'attempts'        => ['type' => 'integer', 'value' => 0],
+            'suspended'       => ['type' => 'smallint', 'value' => 0],
+            'banned'          => ['type' => 'smallint', 'value' => 0],
             'last_attempt_at' => ['type' => 'time', 'value' => null],
-            'suspended_at' => ['type' => 'time', 'value' => null],
-            'banned_at' => ['type' => 'time', 'value' => null],
+            'suspended_at'    => ['type' => 'time', 'value' => null],
+            'banned_at'       => ['type' => 'time', 'value' => null],
         ];
     }
 }

--- a/classes/Domain/Entity/User.php
+++ b/classes/Domain/Entity/User.php
@@ -6,44 +6,44 @@ use Spot\Entity;
 
 class User extends Entity
 {
-    protected static $table = 'users';
+    protected static $table  = 'users';
     protected static $mapper = \OpenCFP\Domain\Entity\Mapper\User::class;
 
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
-            'email' => ['type' => 'string', 'length' => 255, 'required' => true],
-            'password' => ['type' => 'string', 'length' => 255, 'required' => true],
-            'permissions' => ['type' => 'text'],
-            'activated' => ['type' => 'smallint', 'value' => 0],
-            'activation_code' => ['type' => 'string', 'length' => 255],
-            'activated_at' => ['type' => 'datetime'],
-            'last_login' => ['type' => 'string', 'length' => 255],
-            'persist_code' => ['type' => 'string', 'length' => 255],
+            'id'                  => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'email'               => ['type' => 'string', 'length' => 255, 'required' => true],
+            'password'            => ['type' => 'string', 'length' => 255, 'required' => true],
+            'permissions'         => ['type' => 'text'],
+            'activated'           => ['type' => 'smallint', 'value' => 0],
+            'activation_code'     => ['type' => 'string', 'length' => 255],
+            'activated_at'        => ['type' => 'datetime'],
+            'last_login'          => ['type' => 'string', 'length' => 255],
+            'persist_code'        => ['type' => 'string', 'length' => 255],
             'reset_password_code' => ['type' => 'string', 'length' => 255],
-            'first_name' => ['type' => 'string', 'length' => 255],
-            'last_name' => ['type' => 'string', 'length' => 255],
-            'created_at' => ['type' => 'datetime', 'value' => new \DateTime()],
-            'updated_at' => ['type' => 'datetime', 'value' => new \DateTime()],
-            'company' => ['type' => 'string', 'length' => 255],
-            'twitter' => ['type' => 'string', 'length' => 255],
-            'url' => ['type' => 'string', 'length' => 255],
-            'airport' => ['type' => 'string', 'length' => 5],
-            'hotel' => ['type' => 'smallint', 'value' => 0],
-            'transportation' => ['type' => 'smallint', 'value' => 0],
-            'info' => ['type' => 'text'],
-            'bio' => ['type' => 'text'],
-            'photo_path' => ['type' => 'string', 'length' => 255],
-            'has_made_profile' => ['type' => 'smallint', 'value' => 0],
+            'first_name'          => ['type' => 'string', 'length' => 255],
+            'last_name'           => ['type' => 'string', 'length' => 255],
+            'created_at'          => ['type' => 'datetime', 'value' => new \DateTime()],
+            'updated_at'          => ['type' => 'datetime', 'value' => new \DateTime()],
+            'company'             => ['type' => 'string', 'length' => 255],
+            'twitter'             => ['type' => 'string', 'length' => 255],
+            'url'                 => ['type' => 'string', 'length' => 255],
+            'airport'             => ['type' => 'string', 'length' => 5],
+            'hotel'               => ['type' => 'smallint', 'value' => 0],
+            'transportation'      => ['type' => 'smallint', 'value' => 0],
+            'info'                => ['type' => 'text'],
+            'bio'                 => ['type' => 'text'],
+            'photo_path'          => ['type' => 'string', 'length' => 255],
+            'has_made_profile'    => ['type' => 'smallint', 'value' => 0],
         ];
     }
 
     public static function relations(\Spot\MapperInterface $mapper, \Spot\EntityInterface $entity)
     {
         return [
-            'talks' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\Talk::class, 'user_id'),
-            'groups' => $mapper->hasManyThrough($entity, \OpenCFP\Domain\Entity\Group::class, \OpenCFP\Domain\Entity\UserGroup::class, 'group_id', 'user_id'),
+            'talks'    => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\Talk::class, 'user_id'),
+            'groups'   => $mapper->hasManyThrough($entity, \OpenCFP\Domain\Entity\Group::class, \OpenCFP\Domain\Entity\UserGroup::class, 'group_id', 'user_id'),
             'comments' => $mapper->hasMany($entity, \OpenCFP\Domain\Entity\TalkComment::class, 'user_id'),
         ];
     }

--- a/classes/Domain/Entity/UserGroup.php
+++ b/classes/Domain/Entity/UserGroup.php
@@ -11,8 +11,8 @@ class UserGroup extends Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
-            'user_id' => ['type' => 'integer'],
+            'id'       => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'user_id'  => ['type' => 'integer'],
             'group_id' => ['type' => 'integer'],
         ];
     }

--- a/classes/Domain/Model/Airport.php
+++ b/classes/Domain/Model/Airport.php
@@ -6,7 +6,7 @@ use OpenCFP\Domain\Services\AirportInformationDatabase;
 
 class Airport extends Eloquent implements AirportInformationDatabase
 {
-    protected $table = 'airports';
+    protected $table   = 'airports';
     public $timestamps = false;
 
     /**

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -37,7 +37,7 @@ class User extends Eloquent
      */
     public function getOtherTalks($talkId = 0): Collection
     {
-        $allTalks = $this->talks;
+        $allTalks   = $this->talks;
         $otherTalks = $allTalks->filter(function ($talk) use ($talkId) {
             if ((int) $talk['id'] == (int) $talkId) {
                 return false;

--- a/classes/Domain/OAuth/Client.php
+++ b/classes/Domain/OAuth/Client.php
@@ -13,9 +13,9 @@ class Client extends Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'string', 'autoincrement' => false, 'primary' => true],
+            'id'     => ['type' => 'string', 'autoincrement' => false, 'primary' => true],
             'secret' => ['type' => 'string', 'length' => 255, 'required' => true],
-            'name' => ['type' => 'string', 'length' => 255],
+            'name'   => ['type' => 'string', 'length' => 255],
         ];
     }
 
@@ -35,9 +35,9 @@ class Client extends Entity
         }
 
         return [
-            'id' => $this->id,
-            'secret' => $this->secret,
-            'name' => $this->name,
+            'id'            => $this->id,
+            'secret'        => $this->secret,
+            'name'          => $this->name,
             'redirect_uris' => $redirectUris,
         ];
     }

--- a/classes/Domain/OAuth/Endpoint.php
+++ b/classes/Domain/OAuth/Endpoint.php
@@ -11,8 +11,8 @@ class Endpoint extends Entity
     public static function fields()
     {
         return [
-            'id' => ['type' => 'string', 'autoincrement' => true, 'primary' => true],
-            'client_id' => ['type' => 'string', 'length' => 255, 'required' => true],
+            'id'           => ['type' => 'string', 'autoincrement' => true, 'primary' => true],
+            'client_id'    => ['type' => 'string', 'length' => 255, 'required' => true],
             'redirect_uri' => ['type' => 'string', 'length' => 255, 'required' => true],
         ];
     }

--- a/classes/Domain/Services/Pagination.php
+++ b/classes/Domain/Services/Pagination.php
@@ -11,7 +11,7 @@ class Pagination
 
     public function __construct($talkList, int $perPage = 20)
     {
-        $adapter = new \Pagerfanta\Adapter\ArrayAdapter($talkList);
+        $adapter    = new \Pagerfanta\Adapter\ArrayAdapter($talkList);
         $pagerFanta = new Pagerfanta($adapter);
         $pagerFanta->setMaxPerPage($perPage);
         $this->pagerFanta = $pagerFanta;

--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -39,8 +39,8 @@ class ProfileImageProcessor
     public function __construct($publishDir, RandomStringGenerator $generator, $size = 250)
     {
         $this->publishDir = $publishDir;
-        $this->size = $size;
-        $this->generator = $generator;
+        $this->size       = $size;
+        $this->generator  = $generator;
     }
 
     /**

--- a/classes/Domain/Services/ResetEmailer.php
+++ b/classes/Domain/Services/ResetEmailer.php
@@ -33,7 +33,7 @@ class ResetEmailer
     public function __construct(\Swift_Mailer $swiftMailer, \Twig_Template $template, $configEmail, $configTitle)
     {
         $this->swift_mailer = $swiftMailer;
-        $this->template = $template;
+        $this->template     = $template;
         $this->config_email = $configEmail;
         $this->config_title = $configTitle;
     }
@@ -69,12 +69,12 @@ class ResetEmailer
     {
         return [
             'reset_code' => $resetCode,
-            'method' => (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')
+            'method'     => (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')
                 ? 'https' : 'http',
-            'host' => !empty($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost',
+            'host'    => !empty($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost',
             'user_id' => $userId,
-            'email' => $this->config_email,
-            'title' => $this->config_title,
+            'email'   => $this->config_email,
+            'title'   => $this->config_title,
         ];
     }
 

--- a/classes/Domain/Services/TalkRating/TalkRating.php
+++ b/classes/Domain/Services/TalkRating/TalkRating.php
@@ -14,7 +14,7 @@ abstract class TalkRating implements TalkRatingStrategy
     public function __construct(TalkMeta $meta, Authentication $auth)
     {
         $this->adminId = $auth->userId();
-        $this->meta = $meta;
+        $this->meta    = $meta;
     }
 
     /**
@@ -23,7 +23,7 @@ abstract class TalkRating implements TalkRatingStrategy
      */
     protected function saveRating(int $talkId, $rating)
     {
-        $meta = $this->fetchMetaInfo($talkId);
+        $meta         = $this->fetchMetaInfo($talkId);
         $meta->rating = $rating;
         $meta->save();
     }
@@ -32,7 +32,7 @@ abstract class TalkRating implements TalkRatingStrategy
     {
         return $this->meta->firstOrCreate([
             'admin_user_id' => $this->adminId,
-            'talk_id' => $talkId,
+            'talk_id'       => $talkId,
         ]);
     }
 }

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -101,11 +101,11 @@ class SpeakerProfile
     public function toArrayForApi()
     {
         return [
-            'name' => $this->getName(),
-            'email' => $this->getEmail(),
+            'name'    => $this->getName(),
+            'email'   => $this->getEmail(),
             'twitter' => $this->getTwitter(),
-            'url' => $this->getUrl(),
-            'bio' => $this->getBio(),
+            'url'     => $this->getUrl(),
+            'bio'     => $this->getBio(),
         ];
     }
 }

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -46,41 +46,41 @@ class TalkFormatter implements TalkFormat
         $meta = $this->getTalkMeta($talk, $admin_user_id);
 
         $output = [
-            'id' => $talk->id,
-            'title' => $talk->title,
-            'type' => $talk->type,
-            'category' => $talk->category,
-            'created_at' => $talk->created_at,
-            'selected' => $talk->selected,
-            'favorite' => $talk->favorite,
-            'meta' => $meta,
+            'id'          => $talk->id,
+            'title'       => $talk->title,
+            'type'        => $talk->type,
+            'category'    => $talk->category,
+            'created_at'  => $talk->created_at,
+            'selected'    => $talk->selected,
+            'favorite'    => $talk->favorite,
+            'meta'        => $meta,
             'description' => $talk->description,
-            'slides' => $talk->slides,
-            'other' => $talk->other,
-            'level' => $talk->level,
-            'desired' => $talk->desired,
-            'sponsor' => $talk->sponsor,
+            'slides'      => $talk->slides,
+            'other'       => $talk->other,
+            'level'       => $talk->level,
+            'desired'     => $talk->desired,
+            'sponsor'     => $talk->sponsor,
         ];
 
         if ($talk->speaker && $userData) {
             $output['user'] = [
-                'id' => $talk->speaker->id,
+                'id'         => $talk->speaker->id,
                 'first_name' => $talk->speaker->first_name,
-                'last_name' => $talk->speaker->last_name,
+                'last_name'  => $talk->speaker->last_name,
             ];
 
             $output += [
-                'speaker_id' => $talk->speaker->id,
-                'speaker_first_name' => $talk->speaker->first_name,
-                'speaker_last_name' => $talk->speaker->last_name,
-                'speaker_email' => $talk->speaker->email,
-                'speaker_company' => $talk->speaker->company,
-                'speaker_twitter' => $talk->speaker->twitter,
-                'speaker_airport' => $talk->speaker->airport,
-                'speaker_hotel' => $talk->speaker->hotel,
+                'speaker_id'             => $talk->speaker->id,
+                'speaker_first_name'     => $talk->speaker->first_name,
+                'speaker_last_name'      => $talk->speaker->last_name,
+                'speaker_email'          => $talk->speaker->email,
+                'speaker_company'        => $talk->speaker->company,
+                'speaker_twitter'        => $talk->speaker->twitter,
+                'speaker_airport'        => $talk->speaker->airport,
+                'speaker_hotel'          => $talk->speaker->hotel,
                 'speaker_transportation' => $talk->speaker->transportation,
-                'speaker_info' => $talk->speaker->info,
-                'speaker_bio' => $talk->speaker->bio,
+                'speaker_info'           => $talk->speaker->info,
+                'speaker_bio'            => $talk->speaker->bio,
             ];
         }
 

--- a/classes/Domain/Talk/TalkSubmission.php
+++ b/classes/Domain/Talk/TalkSubmission.php
@@ -26,16 +26,16 @@ class TalkSubmission
     public function toTalk(): Talk
     {
         $data = array_merge([
-            'title' => '',
+            'title'       => '',
             'description' => '',
-            'type' => '',
-            'level' => '',
-            'category' => '',
-            'desired' => '',
-            'slides' => '',
-            'other' => '',
-            'sponsor' => '',
-            'user_id' => '',
+            'type'        => '',
+            'level'       => '',
+            'category'    => '',
+            'desired'     => '',
+            'slides'      => '',
+            'other'       => '',
+            'sponsor'     => '',
+            'user_id'     => '',
         ], $this->data);
 
         return new Talk($data);

--- a/classes/Domain/ValidationException.php
+++ b/classes/Domain/ValidationException.php
@@ -8,7 +8,7 @@ class ValidationException extends \Exception
 
     public static function withErrors(array $errors = [])
     {
-        $instance = new static('There was an error.');
+        $instance         = new static('There was an error.');
         $instance->errors = $errors;
 
         return $instance;

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -14,7 +14,7 @@ class DashboardController extends BaseController
 {
     public function indexAction()
     {
-        $userId = $this->service(Authentication::class)->userId();
+        $userId        = $this->service(Authentication::class)->userId();
         $talkFormatter = new TalkFormatter();
 
         /** @var Collection $recent_talks */
@@ -22,11 +22,11 @@ class DashboardController extends BaseController
         $recent_talks = $talkFormatter->formatList($recent_talks, $userId);
 
         $templateData = [
-            'speakerTotal' => User::count(),
-            'talkTotal' => Talk::count(),
+            'speakerTotal'  => User::count(),
+            'talkTotal'     => Talk::count(),
             'favoriteTotal' => Favorite::count(),
-            'selectTotal' => Talk::where('selected', 1)->count(),
-            'talks' => $recent_talks,
+            'selectTotal'   => Talk::where('selected', 1)->count(),
+            'talks'         => $recent_talks,
         ];
 
         return $this->render('admin/index.twig', $templateData);

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -26,16 +26,16 @@ class ExportsController extends BaseController
 
     public function emailExportAction()
     {
-        $talks = Talk::all();
+        $talks     = Talk::all();
         $formatted = [];
 
         foreach ($talks as $talk) {
             $formatted[] = [
-                'title' => $talk->title,
-                'selected' => $talk->selected,
+                'title'      => $talk->title,
+                'selected'   => $talk->selected,
                 'first_name' => $talk->speaker->first_name,
-                'last_name' => $talk->speaker->last_name,
-                'email' => $talk->speaker->email,
+                'last_name'  => $talk->speaker->last_name,
+                'email'      => $talk->speaker->email,
             ];
         }
 
@@ -47,9 +47,9 @@ class ExportsController extends BaseController
         $talkFormatter = new TalkFormatter();
 
         $admin_user_id = $this->service(Authentication::class)->userId();
-        $talks = Talk::orderBy('created_at', 'DESC');
-        $talks = $where == null ? $talks : $talks->where($where);
-        $talks = $talkFormatter->formatList($talks->get(), $admin_user_id, $attributed)->toArray();
+        $talks         = Talk::orderBy('created_at', 'DESC');
+        $talks         = $where == null ? $talks : $talks->where($where);
+        $talks         = $talkFormatter->formatList($talks->get(), $admin_user_id, $attributed)->toArray();
 
         foreach ($talks as $talk => $info) {
             $talks[$talk]['created_at'] = $info['created_at']->format('Y-m-d H:i:s');
@@ -97,9 +97,9 @@ class ExportsController extends BaseController
     {
         if (count($contents) === 0) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'There were no talks that matched selected criteria.',
+                'ext'   => 'There were no talks that matched selected criteria.',
             ]);
 
             return $this->redirectTo('admin');

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -22,26 +22,26 @@ class SpeakersController extends BaseController
         $search = $req->get('search');
 
         /** @var AccountManagement $accounts */
-        $accounts = $this->service(AccountManagement::class);
-        $adminUsers = $accounts->findByRole('Admin');
+        $accounts     = $this->service(AccountManagement::class);
+        $adminUsers   = $accounts->findByRole('Admin');
         $adminUserIds = array_column($adminUsers, 'id');
 
         $rawSpeakers = User::search($search)->get();
 
-        $airports = $this->service(AirportInformationDatabase::class);
+        $airports    = $this->service(AirportInformationDatabase::class);
         $rawSpeakers = $rawSpeakers->map(function ($speaker) use ($airports, $adminUserIds) {
             try {
                 $airport = $airports->withCode($speaker['airport']);
 
                 $speaker['airport'] = [
-                    'code' => $airport->code,
-                    'name' => $airport->name,
+                    'code'    => $airport->code,
+                    'name'    => $airport->name,
                     'country' => $airport->country,
                 ];
             } catch (\Exception $e) {
                 $speaker['airport'] = [
-                    'code' => null,
-                    'name' => null,
+                    'code'    => null,
+                    'name'    => null,
                     'country' => null,
                 ];
             }
@@ -57,13 +57,13 @@ class SpeakersController extends BaseController
         $pagination = $pagerfanta->createView('/admin/speakers?');
 
         $templateData = [
-            'airport' => $this->app->config('application.airport'),
-            'arrival' => date('Y-m-d', $this->app->config('application.arrival')),
-            'departure' => date('Y-m-d', $this->app->config('application.departure')),
+            'airport'    => $this->app->config('application.airport'),
+            'arrival'    => date('Y-m-d', $this->app->config('application.arrival')),
+            'departure'  => date('Y-m-d', $this->app->config('application.departure')),
             'pagination' => $pagination,
-            'speakers' => $pagerfanta->getFanta(),
-            'page' => $pagerfanta->getCurrentPage(),
-            'search' => $search ?: '',
+            'speakers'   => $pagerfanta->getFanta(),
+            'page'       => $pagerfanta->getCurrentPage(),
+            'search'     => $search ?: '',
         ];
 
         return $this->render('admin/speaker/index.twig', $templateData);
@@ -75,9 +75,9 @@ class SpeakersController extends BaseController
 
         if (!$speaker_details instanceof User) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'Could not find requested speaker',
+                'ext'   => 'Could not find requested speaker',
             ]);
 
             return $this->app->redirect($this->url('admin_speakers'));
@@ -89,14 +89,14 @@ class SpeakersController extends BaseController
             $airport = $airports->withCode($speaker_details->airport);
 
             $speaker_details->airport = [
-                'code' => $airport->code,
-                'name' => $airport->name,
+                'code'    => $airport->code,
+                'name'    => $airport->name,
                 'country' => $airport->country,
             ];
         } catch (\Exception $e) {
             $speaker_details->airport = [
-                'code' => null,
-                'name' => null,
+                'code'    => null,
+                'name'    => null,
                 'country' => null,
             ];
         }
@@ -105,13 +105,13 @@ class SpeakersController extends BaseController
 
         // Build and render the template
         $templateData = [
-            'airport' => $this->app->config('application.airport'),
-            'arrival' => date('Y-m-d', $this->app->config('application.arrival')),
-            'departure' => date('Y-m-d', $this->app->config('application.departure')),
-            'speaker' => new SpeakerProfile($speaker_details),
-            'talks' => $talks,
+            'airport'    => $this->app->config('application.airport'),
+            'arrival'    => date('Y-m-d', $this->app->config('application.arrival')),
+            'departure'  => date('Y-m-d', $this->app->config('application.departure')),
+            'speaker'    => new SpeakerProfile($speaker_details),
+            'talks'      => $talks,
             'photo_path' => '/uploads/',
-            'page' => $req->get('page'),
+            'page'       => $req->get('page'),
         ];
 
         return $this->render('admin/speaker/view.twig', $templateData);
@@ -127,22 +127,22 @@ class SpeakersController extends BaseController
         try {
             $user = User::findorFail($req->get('id'));
             $user->delete($req->get('id'));
-            $ext = 'Successfully deleted the requested user';
-            $type = 'success';
+            $ext   = 'Successfully deleted the requested user';
+            $type  = 'success';
             $short = 'Success';
             $capsule->getConnection()->commit();
         } catch (\Exception $e) {
             $capsule->getConnection()->rollBack();
-            $ext = 'Unable to delete the requested user';
-            $type = 'error';
+            $ext   = 'Unable to delete the requested user';
+            $type  = 'error';
             $short = 'Error';
         }
 
         // Set flash message
         $this->service('session')->set('flash', [
-            'type' => $type,
+            'type'  => $type,
             'short' => $short,
-            'ext' => $ext,
+            'ext'   => $ext,
         ]);
 
         return $this->redirectTo('admin_speakers');
@@ -155,9 +155,9 @@ class SpeakersController extends BaseController
 
         if ($this->service(Authentication::class)->userId() == $req->get('id')) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'Sorry, you cannot remove yourself as Admin.',
+                'ext'   => 'Sorry, you cannot remove yourself as Admin.',
             ]);
 
             return $this->redirectTo('admin_speakers');
@@ -168,15 +168,15 @@ class SpeakersController extends BaseController
             $accounts->demoteFrom($user->getLogin());
 
             $this->service('session')->set('flash', [
-                'type' => 'success',
+                'type'  => 'success',
                 'short' => 'Success',
-                'ext' => '',
+                'ext'   => '',
             ]);
         } catch (\Exception $e) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'We were unable to remove the Admin. Please try again.',
+                'ext'   => 'We were unable to remove the Admin. Please try again.',
             ]);
         }
 
@@ -192,9 +192,9 @@ class SpeakersController extends BaseController
             $user = $accounts->findById($req->get('id'));
             if ($user->hasAccess('admin')) {
                 $this->service('session')->set('flash', [
-                    'type' => 'error',
+                    'type'  => 'error',
                     'short' => 'Error',
-                    'ext' => 'User already is in the Admin group.',
+                    'ext'   => 'User already is in the Admin group.',
                 ]);
 
                 return $this->redirectTo('admin_speakers');
@@ -203,15 +203,15 @@ class SpeakersController extends BaseController
             $accounts->promoteTo($user->getLogin());
 
             $this->service('session')->set('flash', [
-                'type' => 'success',
+                'type'  => 'success',
                 'short' => 'Success',
-                'ext' => '',
+                'ext'   => '',
             ]);
         } catch (\Exception $e) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'We were unable to promote the Admin. Please try again.',
+                'ext'   => 'We were unable to promote the Admin. Please try again.',
             ]);
         }
 

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -25,9 +25,9 @@ class TalksController extends BaseController
         $auth = $this->service(Authentication::class);
 
         $admin_user_id = $auth->userId();
-        $options = [
+        $options       = [
             'order_by' => $req->get('order_by'),
-            'sort' => $req->get('sort'),
+            'sort'     => $req->get('sort'),
         ];
 
         $pager_formatted_talks = $this->service(TalkFilter::class)->getFilteredTalks(
@@ -37,21 +37,21 @@ class TalksController extends BaseController
         );
 
         // Set up our page stuff
-        $per_page = (int) $req->get('per_page') ?: 20;
+        $per_page   = (int) $req->get('per_page') ?: 20;
         $pagerfanta = new Pagination($pager_formatted_talks, $per_page);
         $pagerfanta->setCurrentPage($req->get('page'));
         $pagination = $pagerfanta->createView('/admin/talks?', $req->query->all());
 
         $templateData = [
-            'pagination' => $pagination,
-            'talks' => $pagerfanta->getFanta(),
-            'page' => $pagerfanta->getCurrentPage(),
+            'pagination'   => $pagination,
+            'talks'        => $pagerfanta->getFanta(),
+            'page'         => $pagerfanta->getCurrentPage(),
             'current_page' => $req->getRequestUri(),
             'totalRecords' => count($pager_formatted_talks),
-            'filter' => $req->get('filter'),
-            'per_page' => $per_page,
-            'sort' => $req->get('sort'),
-            'order_by' => $req->get('order_by'),
+            'filter'       => $req->get('filter'),
+            'per_page'     => $per_page,
+            'sort'         => $req->get('sort'),
+            'order_by'     => $req->get('order_by'),
         ];
 
         return $this->render('admin/talks/index.twig', $templateData);
@@ -60,15 +60,15 @@ class TalksController extends BaseController
     public function viewAction(Request $req)
     {
         $talkId = $req->get('id');
-        $talk = Talk::where('id', $talkId)
+        $talk   = Talk::where('id', $talkId)
             ->with(['comments'])
             ->first();
 
         if (!$talk instanceof Talk) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'Could not find requested talk',
+                'ext'   => 'Could not find requested talk',
             ]);
 
             return $this->app->redirect($this->url('admin_talks'));
@@ -81,20 +81,20 @@ class TalksController extends BaseController
             ->meta()
             ->firstOrNew([
                 'admin_user_id' => $userId,
-                'talk_id' => $talkId,
+                'talk_id'       => $talkId,
             ]);
         $talkMeta->viewTalk();
 
-        $speaker = $talk->speaker;
+        $speaker    = $talk->speaker;
         $otherTalks = $speaker->getOtherTalks($talkId);
 
         // Build and render the template
         $templateData = [
-            'talk' => $talk->toArray(),
-            'talk_meta' => $talkMeta,
-            'speaker' => new SpeakerProfile($speaker),
+            'talk'       => $talk->toArray(),
+            'talk_meta'  => $talkMeta,
+            'speaker'    => new SpeakerProfile($speaker),
             'otherTalks' => $otherTalks,
-            'comments' => $talk->comments()->get(),
+            'comments'   => $talk->comments()->get(),
         ];
 
         return $this->render('admin/talks/view.twig', $templateData);
@@ -107,7 +107,7 @@ class TalksController extends BaseController
 
         try {
             $talk_rating = (int) $req->get('rating');
-            $talk_id = (int) $req->get('id');
+            $talk_id     = (int) $req->get('id');
 
             $talkRatingStrategy->rate($talk_id, $talk_rating);
         } catch (TalkRatingException $e) {
@@ -127,7 +127,7 @@ class TalksController extends BaseController
     public function favoriteAction(Request $req)
     {
         $admin_user_id = $this->service(Authentication::class)->userId();
-        $talkId = (int) $req->get('id');
+        $talkId        = (int) $req->get('id');
 
         if ($req->get('delete') !== null) {
             // Delete the record that matches
@@ -145,7 +145,7 @@ class TalksController extends BaseController
 
         Favorite::firstOrCreate([
             'admin_user_id' => $admin_user_id,
-            'talk_id' => $talkId,
+            'talk_id'       => $talkId,
         ]);
 
         return true;
@@ -182,9 +182,9 @@ class TalksController extends BaseController
         ]);
 
         $this->service('session')->set('flash', [
-                'type' => 'success',
+                'type'  => 'success',
                 'short' => 'Success',
-                'ext' => 'Comment Added!',
+                'ext'   => 'Comment Added!',
             ]);
 
         return $this->app->redirect($this->url('admin_talk_view', ['id' => $talk_id]));

--- a/classes/Http/Controller/BaseController.php
+++ b/classes/Http/Controller/BaseController.php
@@ -75,7 +75,7 @@ abstract class BaseController
     {
         /** @var Request $request */
         $request = $this->service('request_stack')->getCurrentRequest();
-        $data = $request->query->all() + $request->request->all() + $request->files->all();
+        $data    = $request->query->all() + $request->request->all() + $request->files->all();
 
         $validation = new Factory(
             new Translator(new FileLoader(new Filesystem(), __DIR__ . '/../../../resources/lang'), 'en'),

--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -28,7 +28,7 @@ class DashboardController extends BaseController
             $cfp = $this->service('callforproposal');
 
             return $this->render('dashboard.twig', [
-                'profile' => $profile,
+                'profile'  => $profile,
                 'cfp_open' => $cfp->isOpen(),
             ]);
         } catch (NotAuthenticatedException $e) {

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -16,7 +16,7 @@ class ForgotController extends BaseController
     {
         $form = $this->service('form.factory')->createBuilder(ForgotForm::class)->getForm();
         $data = [
-            'form' => $form->createView(),
+            'form'         => $form->createView(),
             'current_page' => 'Forgot Password',
         ];
 
@@ -32,9 +32,9 @@ class ForgotController extends BaseController
 
         if (!$form->isValid()) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'Please enter a properly formatted email address',
+                'ext'   => 'Please enter a properly formatted email address',
             ]);
 
             return $this->redirectTo('forgot_password');
@@ -59,9 +59,9 @@ class ForgotController extends BaseController
 
         if ($response == false) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'We were unable to send your password reset request. Please try again',
+                'ext'   => 'We were unable to send your password reset request. Please try again',
             ]);
 
             return $this->redirectTo('forgot_password');
@@ -79,7 +79,7 @@ class ForgotController extends BaseController
         }
 
         $errorMessage = 'The reset you have requested appears to be invalid, please try again.';
-        $error = 0;
+        $error        = 0;
 
         try {
             /** @var AccountManagement $accounts */
@@ -96,20 +96,20 @@ class ForgotController extends BaseController
 
         if ($error > 0) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => $errorMessage,
+                'ext'   => $errorMessage,
             ]);
         }
         
         // Build password form and display it to the user
         $form_options = [
-            'user_id' => $req->get('user_id'),
+            'user_id'    => $req->get('user_id'),
             'reset_code' => $req->get('reset_code'),
         ];
         $form = $this->service('form.factory')->create(new ResetForm());
 
-        $data['form'] = $form->createView($form_options);
+        $data['form']  = $form->createView($form_options);
         $data['flash'] = $this->getFlash($this->app);
 
         return $this->render('user/forgot_password.twig', $data);
@@ -117,7 +117,7 @@ class ForgotController extends BaseController
 
     public function processResetAction(Request $req)
     {
-        $user_id = $req->get('user_id');
+        $user_id    = $req->get('user_id');
         $reset_code = $req->get('reset_code');
 
         if (empty($reset_code)) {
@@ -135,7 +135,7 @@ class ForgotController extends BaseController
         }
              
         $errorMessage = 'The reset you have requested appears to be invalid, please try again.';
-        $error = 0;
+        $error        = 0;
 
         try {
             /** @var AccountManagement $accounts */
@@ -152,9 +152,9 @@ class ForgotController extends BaseController
 
         if ($error > 0) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => $errorMessage,
+                'ext'   => $errorMessage,
             ]);
         }
 
@@ -170,10 +170,10 @@ class ForgotController extends BaseController
             return $this->render('user/reset_password.twig', ['form' => $form->createView()]);
         }
 
-        $data = $form->getData();
-        $user_id = $data['user_id'];
+        $data       = $form->getData();
+        $user_id    = $data['user_id'];
         $reset_code = $data['reset_code'];
-        $password = $data['password'];
+        $password   = $data['password'];
 
         if (empty($reset_code)) {
             throw new \Exception();
@@ -195,9 +195,9 @@ class ForgotController extends BaseController
          */
         if ($user->checkPassword($password) === true) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'Please select a different password than your current one.',
+                'ext'   => 'Please select a different password than your current one.',
             ]);
 
             return $this->redirectTo('login');
@@ -206,9 +206,9 @@ class ForgotController extends BaseController
         // Everything looks good, let's actually reset their password
         if ($user->attemptResetPassword($reset_code, $password)) {
             $this->service('session')->set('flash', [
-                'type' => 'success',
+                'type'  => 'success',
                 'short' => 'Success',
-                'ext' => "You've successfully reset your password.",
+                'ext'   => "You've successfully reset your password.",
             ]);
 
             return $this->redirectTo('login');
@@ -216,9 +216,9 @@ class ForgotController extends BaseController
 
         // user may have tried using the recovery twice
         $this->service('session')->set('flash', [
-            'type' => 'error',
+            'type'  => 'error',
             'short' => 'Error',
-            'ext' => 'Password reset failed, please contact the administrator.',
+            'ext'   => 'Password reset failed, please contact the administrator.',
         ]);
 
         return $this->redirectTo('homepage');
@@ -227,9 +227,9 @@ class ForgotController extends BaseController
     protected function successfulSendFlashParameters($email)
     {
         return [
-            'type' => 'success',
+            'type'  => 'success',
             'short' => 'Success',
-            'ext' => "If your email was valid, we sent a link to reset your password to $email",
+            'ext'   => "If your email was valid, we sent a link to reset your password to $email",
         ];
     }
 }

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -15,9 +15,9 @@ class ProfileController extends BaseController
 
         if ((string) $user->getId() !== $req->get('id')) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => "You cannot edit someone else's profile",
+                'ext'   => "You cannot edit someone else's profile",
             ]);
 
             return $this->redirectTo('dashboard');
@@ -26,22 +26,22 @@ class ProfileController extends BaseController
         $speaker_data = User::find($user->getId())->toArray();
 
         $form_data = [
-            'email' => $user->getLogin(),
-            'first_name' => $speaker_data['first_name'],
-            'last_name' => $speaker_data['last_name'],
-            'company' => $speaker_data['company'],
-            'twitter' => $speaker_data['twitter'],
-            'url' => $speaker_data['url'],
-            'speaker_info' => $speaker_data['info'],
-            'speaker_bio' => $speaker_data['bio'],
-            'speaker_photo' => $speaker_data['photo_path'],
-            'preview_photo' => '/uploads/' . $speaker_data['photo_path'],
-            'airport' => $speaker_data['airport'],
+            'email'          => $user->getLogin(),
+            'first_name'     => $speaker_data['first_name'],
+            'last_name'      => $speaker_data['last_name'],
+            'company'        => $speaker_data['company'],
+            'twitter'        => $speaker_data['twitter'],
+            'url'            => $speaker_data['url'],
+            'speaker_info'   => $speaker_data['info'],
+            'speaker_bio'    => $speaker_data['bio'],
+            'speaker_photo'  => $speaker_data['photo_path'],
+            'preview_photo'  => '/uploads/' . $speaker_data['photo_path'],
+            'airport'        => $speaker_data['airport'],
             'transportation' => $speaker_data['transportation'],
-            'hotel' => $speaker_data['hotel'],
-            'id' => $user->getId(),
-            'formAction' => $this->url('user_update'),
-            'buttonInfo' => 'Update Profile',
+            'hotel'          => $speaker_data['hotel'],
+            'id'             => $user->getId(),
+            'formAction'     => $this->url('user_update'),
+            'buttonInfo'     => 'Update Profile',
         ];
 
         return $this->render('user/edit.twig', $form_data) ;
@@ -53,9 +53,9 @@ class ProfileController extends BaseController
 
         if ((string) $userId !== $req->get('id')) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => "You cannot edit someone else's profile",
+                'ext'   => "You cannot edit someone else's profile",
             ]);
 
             return $this->redirectTo('dashboard');
@@ -67,7 +67,7 @@ class ProfileController extends BaseController
             $form_data['speaker_photo'] = $req->files->get('speaker_photo');
         }
 
-        $form = new SignupForm($form_data, $this->service('purifier'));
+        $form    = new SignupForm($form_data, $this->service('purifier'));
         $isValid = $form->validateAll('update');
 
         if ($isValid) {
@@ -82,15 +82,15 @@ class ProfileController extends BaseController
             return $this->redirectTo('dashboard');
         }
         $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => implode('<br>', $form->getErrorMessages()),
+                'ext'   => implode('<br>', $form->getErrorMessages()),
             ]);
 
         $form_data['formAction'] = $this->url('user_update');
         $form_data['buttonInfo'] = 'Update Profile';
-        $form_data['id'] = $userId;
-        $form_data['flash'] = $this->service('session')->get('flash');
+        $form_data['id']         = $userId;
+        $form_data['flash']      = $this->service('session')->get('flash');
 
         return $this->render('user/edit.twig', $form_data);
     }
@@ -109,7 +109,7 @@ class ProfileController extends BaseController
          * validation code to make sure our password changes are good
          */
         $formData = [
-            'password' => $req->get('password'),
+            'password'  => $req->get('password'),
             'password2' => $req->get('password_confirm'),
         ];
         $form = new SignupForm($formData, $this->service('purifier'));
@@ -117,9 +117,9 @@ class ProfileController extends BaseController
 
         if ($form->validatePasswords() === false) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => implode('<br>', $form->getErrorMessages()),
+                'ext'   => implode('<br>', $form->getErrorMessages()),
             ]);
 
             return $this->redirectTo('password_edit');
@@ -130,22 +130,22 @@ class ProfileController extends BaseController
          * own built-in password reset functionality to do it
          */
         $sanitized_data = $form->getCleanData();
-        $reset_code = $user->getResetPasswordCode();
+        $reset_code     = $user->getResetPasswordCode();
 
         if (! $user->attemptResetPassword($reset_code, $sanitized_data['password'])) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'Unable to update your password in the database. Please try again.',
+                'ext'   => 'Unable to update your password in the database. Please try again.',
             ]);
 
             return $this->redirectTo('password_edit');
         }
 
         $this->service('session')->set('flash', [
-            'type' => 'success',
+            'type'  => 'success',
             'short' => 'Success',
-            'ext' => 'Changed your password.',
+            'ext'   => 'Changed your password.',
         ]);
 
         return $this->redirectTo('password_edit');
@@ -159,18 +159,18 @@ class ProfileController extends BaseController
     private function getFormData(Request $req): array
     {
         $form_data = [
-            'email' => $req->get('email'),
-            'user_id' => $req->get('id'),
-            'first_name' => $req->get('first_name'),
-            'last_name' => $req->get('last_name'),
-            'company' => $req->get('company'),
-            'twitter' => $req->get('twitter'),
-            'url' => $req->get('url'),
-            'airport' => $req->get('airport'),
+            'email'          => $req->get('email'),
+            'user_id'        => $req->get('id'),
+            'first_name'     => $req->get('first_name'),
+            'last_name'      => $req->get('last_name'),
+            'company'        => $req->get('company'),
+            'twitter'        => $req->get('twitter'),
+            'url'            => $req->get('url'),
+            'airport'        => $req->get('airport'),
             'transportation' => (int) $req->get('transportation'),
-            'hotel' => (int) $req->get('hotel'),
-            'speaker_info' => $req->get('speaker_info') ?: null,
-            'speaker_bio' => $req->get('speaker_bio') ?: null,
+            'hotel'          => (int) $req->get('hotel'),
+            'speaker_info'   => $req->get('speaker_info') ?: null,
+            'speaker_bio'    => $req->get('speaker_bio') ?: null,
         ];
 
         return $form_data;

--- a/classes/Http/Controller/Reviewer/DashBoardController.php
+++ b/classes/Http/Controller/Reviewer/DashBoardController.php
@@ -14,7 +14,7 @@ class DashBoardController extends BaseController
 {
     public function indexAction()
     {
-        $userId = $this->service(Authentication::class)->userId();
+        $userId        = $this->service(Authentication::class)->userId();
         $talkFormatter = new TalkFormatter();
 
         /** @var Collection $recent_talks */
@@ -22,11 +22,11 @@ class DashBoardController extends BaseController
         $recent_talks = $talkFormatter->formatList($recent_talks, $userId);
 
         $templateData = [
-            'speakerTotal' => User::count(),
-            'talkTotal' => Talk::count(),
+            'speakerTotal'  => User::count(),
+            'talkTotal'     => Talk::count(),
             'favoriteTotal' => Favorite::count(),
-            'selectTotal' => Talk::where('selected', 1)->count(),
-            'talks' => $recent_talks,
+            'selectTotal'   => Talk::where('selected', 1)->count(),
+            'talks'         => $recent_talks,
         ];
 
         return $this->render('reviewer/index.twig', $templateData);

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -12,7 +12,7 @@ class SpeakersController extends BaseController
 {
     public function indexAction(Request $req)
     {
-        $search = $req->get('search');
+        $search   = $req->get('search');
         $speakers = User::search($search)->get()->toArray();
         // Set up our page stuff
         $pagerfanta = new Pagination($speakers);
@@ -21,9 +21,9 @@ class SpeakersController extends BaseController
 
         $templateData = [
             'pagination' => $pagination,
-            'speakers' => $pagerfanta->getFanta(),
-            'page' => $pagerfanta->getCurrentPage(),
-            'search' => $search ?: '',
+            'speakers'   => $pagerfanta->getFanta(),
+            'page'       => $pagerfanta->getCurrentPage(),
+            'search'     => $search ?: '',
         ];
 
         return $this->render('reviewer/speaker/index.twig', $templateData);
@@ -35,20 +35,20 @@ class SpeakersController extends BaseController
 
         if (!$speakerDetails instanceof User) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'Could not find requested speaker',
+                'ext'   => 'Could not find requested speaker',
             ]);
 
             return $this->app->redirect($this->url('reviewer_speakers'));
         }
 
-        $talks = $speakerDetails->talks()->get()->toArray();
+        $talks        = $speakerDetails->talks()->get()->toArray();
         $templateData = [
-            'speaker' => new SpeakerProfile($speakerDetails),
-            'talks' => $talks,
+            'speaker'    => new SpeakerProfile($speakerDetails),
+            'talks'      => $talks,
             'photo_path' => '/uploads/',
-            'page' => $req->get('page'),
+            'page'       => $req->get('page'),
         ];
 
         return $this->render('reviewer/speaker/view.twig', $templateData);

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -20,7 +20,7 @@ class TalksController extends BaseController
 
         $options = [
             'order_by' => $req->get('order_by'),
-            'sort' => $req->get('sort'),
+            'sort'     => $req->get('sort'),
         ];
 
         $pager_formatted_talks = $this->service(TalkFilter::class)->getFilteredTalks(
@@ -29,21 +29,21 @@ class TalksController extends BaseController
             $options
         );
 
-        $per_page = (int) $req->get('per_page') ?: 20;
+        $per_page   = (int) $req->get('per_page') ?: 20;
         $pagerfanta = new Pagination($pager_formatted_talks, $per_page);
         $pagerfanta->setCurrentPage($req->get('page'));
         $pagination = $pagerfanta->createView('/reviewer/talks?', $req->query->all());
 
         $templateData = [
-            'pagination' => $pagination,
-            'talks' => $pagerfanta->getFanta(),
-            'page' => $pagerfanta->getCurrentPage(),
+            'pagination'   => $pagination,
+            'talks'        => $pagerfanta->getFanta(),
+            'page'         => $pagerfanta->getCurrentPage(),
             'current_page' => $req->getRequestUri(),
             'totalRecords' => count($pager_formatted_talks),
-            'filter' => $req->get('filter'),
-            'per_page' => $per_page,
-            'sort' => $req->get('sort'),
-            'order_by' => $req->get('order_by'),
+            'filter'       => $req->get('filter'),
+            'per_page'     => $per_page,
+            'sort'         => $req->get('sort'),
+            'order_by'     => $req->get('order_by'),
         ];
 
         return $this->render('reviewer/talks/index.twig', $templateData);
@@ -52,15 +52,15 @@ class TalksController extends BaseController
     public function viewAction(Request $req)
     {
         $talkId = $req->get('id');
-        $talk = Talk::where('id', $talkId)
+        $talk   = Talk::where('id', $talkId)
             ->with(['comments'])
             ->first();
 
         if (!$talk instanceof Talk) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'Could not find requested talk',
+                'ext'   => 'Could not find requested talk',
             ]);
 
             return $this->app->redirect($this->url('admin_talks'));
@@ -73,20 +73,20 @@ class TalksController extends BaseController
             ->meta()
             ->firstOrNew([
                 'admin_user_id' => $userId,
-                'talk_id' => $talkId,
+                'talk_id'       => $talkId,
             ]);
         $talkMeta->viewTalk();
 
-        $speaker = $talk->speaker;
+        $speaker    = $talk->speaker;
         $otherTalks = $speaker->getOtherTalks($talkId);
 
         // Build and render the template
         $templateData = [
-            'talk' => $talk->toArray(),
-            'talk_meta' => $talkMeta,
-            'speaker' => new SpeakerProfile($speaker),
+            'talk'       => $talk->toArray(),
+            'talk_meta'  => $talkMeta,
+            'speaker'    => new SpeakerProfile($speaker),
             'otherTalks' => $otherTalks,
-            'comments' => $talk->comments()->get(),
+            'comments'   => $talk->comments()->get(),
         ];
 
         return $this->render('reviewer/talks/view.twig', $templateData);
@@ -99,7 +99,7 @@ class TalksController extends BaseController
 
         try {
             $talk_rating = (int) $req->get('rating');
-            $talk_id = (int) $req->get('id');
+            $talk_id     = (int) $req->get('id');
 
             $talkRatingStrategy->rate($talk_id, $talk_rating);
         } catch (TalkRatingException $e) {

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -35,9 +35,9 @@ class SecurityController extends BaseController
             return $this->redirectTo('dashboard');
         } catch (\Exception $e) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => $e->getMessage(),
+                'ext'   => $e->getMessage(),
             ]);
 
             $template_data = [

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -25,9 +25,9 @@ class SignupController extends BaseController
 
         if (! $cfp->isOpen()) {
             $this->service('session')->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'Sorry, the call for papers has ended.',
+                'ext'   => 'Sorry, the call for papers has ended.',
             ]);
 
             return $this->redirectTo('homepage');
@@ -40,9 +40,9 @@ class SignupController extends BaseController
     {
         try {
             $this->validate([
-                'email' => 'required|email',
+                'email'    => 'required|email',
                 'password' => 'required',
-                'coc' => 'accepted',
+                'coc'      => 'accepted',
             ]);
 
             /** @var AccountManagement $accounts */
@@ -61,9 +61,9 @@ class SignupController extends BaseController
             }
 
             $app['session']->set('flash', [
-                'type' => 'success',
+                'type'  => 'success',
                 'short' => 'Success',
-                'ext' => "You've successfully created your account!",
+                'ext'   => "You've successfully created your account!",
             ]);
 
             // Automatically authenticate the newly created user.
@@ -72,17 +72,17 @@ class SignupController extends BaseController
             return $this->redirectTo('dashboard');
         } catch (ValidationException $e) {
             $app['session']->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => $e->getMessage(),
-                'ext' => $e->errors(),
+                'ext'   => $e->errors(),
             ]);
 
             return $this->redirectBack();
         } catch (UserExistsException $e) {
             $app['session']->set('flash', [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'A user already exists with that email address',
+                'ext'   => 'A user already exists with that email address',
             ]);
 
             return $this->redirectBack();

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -25,8 +25,8 @@ class TalkController extends BaseController
     {
         $options = [
             'categories' => $this->getTalkCategories(),
-            'levels' => $this->getTalkLevels(),
-            'types' => $this->getTalkTypes(),
+            'levels'     => $this->getTalkLevels(),
+            'types'      => $this->getTalkTypes(),
         ];
         $form = new TalkForm($request_data, $this->service('purifier'), $options);
 
@@ -39,18 +39,18 @@ class TalkController extends BaseController
         
         if ($categories === null) {
             $categories = [
-                'api' => 'APIs (REST, SOAP, etc.)',
+                'api'               => 'APIs (REST, SOAP, etc.)',
                 'continuousdelivery'=> 'Continuous Delivery',
-                'database'=> 'Database',
-                'development'=> 'Development',
-                'devops' => 'Devops',
-                'framework' => 'Framework',
-                'ibmi' => 'IBMi',
-                'javascript' => 'JavaScript',
-                'security' => 'Security',
-                'testing' => 'Testing',
-                'uiux' => 'UI/UX',
-                'other' => 'Other',
+                'database'          => 'Database',
+                'development'       => 'Development',
+                'devops'            => 'Devops',
+                'framework'         => 'Framework',
+                'ibmi'              => 'IBMi',
+                'javascript'        => 'JavaScript',
+                'security'          => 'Security',
+                'testing'           => 'Testing',
+                'uiux'              => 'UI/UX',
+                'other'             => 'Other',
             ];
         }
         
@@ -63,7 +63,7 @@ class TalkController extends BaseController
 
         if ($types === null) {
             $types = [
-                'regular' => 'Regular',
+                'regular'  => 'Regular',
                 'tutorial' => 'Tutorial',
             ];
         }
@@ -77,8 +77,8 @@ class TalkController extends BaseController
 
         if ($levels === null) {
             $levels = [
-                'entry' => 'Entry level',
-                'mid' => 'Mid-level',
+                'entry'    => 'Entry level',
+                'mid'      => 'Mid-level',
                 'advanced' => 'Advanced',
             ];
         }
@@ -99,7 +99,7 @@ class TalkController extends BaseController
         $speakers = $this->service('application.speakers');
 
         try {
-            $id = filter_var($req->get('id'), FILTER_VALIDATE_INT);
+            $id   = filter_var($req->get('id'), FILTER_VALIDATE_INT);
             $talk = $speakers->getTalk($id);
         } catch (NotAuthorizedException $e) {
             return $this->redirectTo('dashboard');
@@ -117,7 +117,7 @@ class TalkController extends BaseController
      */
     public function editAction(Request $req)
     {
-        $id = $req->get('id');
+        $id      = $req->get('id');
         $talk_id = filter_var($id, FILTER_VALIDATE_INT);
 
         // You can only edit talks while the CfP is open
@@ -126,9 +126,9 @@ class TalkController extends BaseController
             $this->service('session')->set(
                 'flash',
                 [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Read Only',
-                'ext' => 'You cannot edit talks once the call for papers has ended', ]
+                'ext'   => 'You cannot edit talks once the call for papers has ended', ]
             );
 
             return $this->app->redirect($this->url('talk_view', ['id' => $talk_id]));
@@ -144,28 +144,28 @@ class TalkController extends BaseController
         $spot = $this->service('spot');
 
         $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $talk_info = $talk_mapper->where(['id' => $talk_id])->execute()->first()->toArray();
+        $talk_info   = $talk_mapper->where(['id' => $talk_id])->execute()->first()->toArray();
 
         if ($talk_info['user_id'] !== (int) $user->getId()) {
             return $this->redirectTo('dashboard');
         }
 
         $data = [
-            'formAction' => $this->url('talk_update'),
+            'formAction'     => $this->url('talk_update'),
             'talkCategories' => $this->getTalkCategories(),
-            'talkTypes' => $this->getTalkTypes(),
-            'talkLevels' => $this->getTalkLevels(),
-            'id' => $talk_id,
-            'title' => html_entity_decode($talk_info['title']),
-            'description' => html_entity_decode($talk_info['description']),
-            'type' => $talk_info['type'],
-            'level' => $talk_info['level'],
-            'category' => $talk_info['category'],
-            'desired' => $talk_info['desired'],
-            'slides' => $talk_info['slides'],
-            'other' => $talk_info['other'],
-            'sponsor' => $talk_info['sponsor'],
-            'buttonInfo' => 'Update my talk!',
+            'talkTypes'      => $this->getTalkTypes(),
+            'talkLevels'     => $this->getTalkLevels(),
+            'id'             => $talk_id,
+            'title'          => html_entity_decode($talk_info['title']),
+            'description'    => html_entity_decode($talk_info['description']),
+            'type'           => $talk_info['type'],
+            'level'          => $talk_info['level'],
+            'category'       => $talk_info['category'],
+            'desired'        => $talk_info['desired'],
+            'slides'         => $talk_info['slides'],
+            'other'          => $talk_info['other'],
+            'sponsor'        => $talk_info['sponsor'],
+            'buttonInfo'     => 'Update my talk!',
         ];
 
         return $this->render('talk/edit.twig', $data);
@@ -185,29 +185,29 @@ class TalkController extends BaseController
             $this->service('session')->set(
                 'flash',
                 [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'You cannot create talks once the call for papers has ended', ]
+                'ext'   => 'You cannot create talks once the call for papers has ended', ]
             );
 
             return $this->redirectTo('dashboard');
         }
 
         $data = [
-            'formAction' => $this->url('talk_create'),
+            'formAction'     => $this->url('talk_create'),
             'talkCategories' => $this->getTalkCategories(),
-            'talkTypes' => $this->getTalkTypes(),
-            'talkLevels' => $this->getTalkLevels(),
-            'title' => $req->get('title'),
-            'description' => $req->get('description'),
-            'type' => $req->get('type'),
-            'level' => $req->get('level'),
-            'category' => $req->get('category'),
-            'desired' => $req->get('desired'),
-            'slides' => $req->get('slides'),
-            'other' => $req->get('other'),
-            'sponsor' => $req->get('sponsor'),
-            'buttonInfo' => 'Submit my talk!',
+            'talkTypes'      => $this->getTalkTypes(),
+            'talkLevels'     => $this->getTalkLevels(),
+            'title'          => $req->get('title'),
+            'description'    => $req->get('description'),
+            'type'           => $req->get('type'),
+            'level'          => $req->get('level'),
+            'category'       => $req->get('category'),
+            'desired'        => $req->get('desired'),
+            'slides'         => $req->get('slides'),
+            'other'          => $req->get('other'),
+            'sponsor'        => $req->get('sponsor'),
+            'buttonInfo'     => 'Submit my talk!',
         ];
 
         return $this->render('talk/create.twig', $data);
@@ -228,9 +228,9 @@ class TalkController extends BaseController
             $this->service('session')->set(
                 'flash',
                 [
-                'type' => 'error',
+                'type'  => 'error',
                 'short' => 'Error',
-                'ext' => 'You cannot create talks once the call for papers has ended', ]
+                'ext'   => 'You cannot create talks once the call for papers has ended', ]
             );
 
             return $this->redirectTo('dashboard');
@@ -239,16 +239,16 @@ class TalkController extends BaseController
         $user = $this->service(Authentication::class)->user();
 
         $request_data = [
-            'title' => $req->get('title'),
+            'title'       => $req->get('title'),
             'description' => $req->get('description'),
-            'type' => $req->get('type'),
-            'level' => $req->get('level'),
-            'category' => $req->get('category'),
-            'desired' => $req->get('desired'),
-            'slides' => $req->get('slides'),
-            'other' => $req->get('other'),
-            'sponsor' => $req->get('sponsor'),
-            'user_id' => $req->get('user_id'),
+            'type'        => $req->get('type'),
+            'level'       => $req->get('level'),
+            'category'    => $req->get('category'),
+            'desired'     => $req->get('desired'),
+            'slides'      => $req->get('slides'),
+            'other'       => $req->get('other'),
+            'sponsor'     => $req->get('sponsor'),
+            'user_id'     => $req->get('user_id'),
         ];
 
         $form = $this->getTalkForm($request_data);
@@ -262,17 +262,17 @@ class TalkController extends BaseController
             $spot = $this->service('spot');
 
             $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-            $data = [
-                'title' => $sanitized_data['title'],
+            $data        = [
+                'title'       => $sanitized_data['title'],
                 'description' => $sanitized_data['description'],
-                'type' => $sanitized_data['type'],
-                'level' => $sanitized_data['level'],
-                'category' => $sanitized_data['category'],
-                'desired' => $sanitized_data['desired'],
-                'slides' => $sanitized_data['slides'],
-                'other' => $sanitized_data['other'],
-                'sponsor' => $sanitized_data['sponsor'],
-                'user_id' => (int) $user->getId(),
+                'type'        => $sanitized_data['type'],
+                'level'       => $sanitized_data['level'],
+                'category'    => $sanitized_data['category'],
+                'desired'     => $sanitized_data['desired'],
+                'slides'      => $sanitized_data['slides'],
+                'other'       => $sanitized_data['other'],
+                'sponsor'     => $sanitized_data['sponsor'],
+                'user_id'     => (int) $user->getId(),
             ];
 
             $talk = $talk_mapper->build($data);
@@ -285,9 +285,9 @@ class TalkController extends BaseController
             }
 
             $this->service('session')->set('flash', [
-                'type' => 'success',
+                'type'  => 'success',
                 'short' => 'Success',
-                'ext' => 'Successfully saved talk.',
+                'ext'   => 'Successfully saved talk.',
             ]);
 
             // send email to speaker showing submission
@@ -297,32 +297,32 @@ class TalkController extends BaseController
         }
 
         $data = [
-            'formAction' => $this->url('talk_create'),
+            'formAction'     => $this->url('talk_create'),
             'talkCategories' => $this->getTalkCategories(),
-            'talkTypes' => $this->getTalkTypes(),
-            'talkLevels' => $this->getTalkLevels(),
-            'title' => $req->get('title'),
-            'description' => $req->get('description'),
-            'type' => $req->get('type'),
-            'level' => $req->get('level'),
-            'category' => $req->get('category'),
-            'desired' => $req->get('desired'),
-            'slides' => $req->get('slides'),
-            'other' => $req->get('other'),
-            'sponsor' => $req->get('sponsor'),
-            'buttonInfo' => 'Submit my talk!',
+            'talkTypes'      => $this->getTalkTypes(),
+            'talkLevels'     => $this->getTalkLevels(),
+            'title'          => $req->get('title'),
+            'description'    => $req->get('description'),
+            'type'           => $req->get('type'),
+            'level'          => $req->get('level'),
+            'category'       => $req->get('category'),
+            'desired'        => $req->get('desired'),
+            'slides'         => $req->get('slides'),
+            'other'          => $req->get('other'),
+            'sponsor'        => $req->get('sponsor'),
+            'buttonInfo'     => 'Submit my talk!',
         ];
 
         $this->service('session')->set('flash', [
-            'type' => 'error',
+            'type'  => 'error',
             'short' => 'Error',
-            'ext' => implode('<br>', $form->getErrorMessages()),
+            'ext'   => implode('<br>', $form->getErrorMessages()),
         ]);
 
         $this->service('session')->set('flash', [
-            'type' => 'error',
+            'type'  => 'error',
             'short' => 'Error',
-            'ext' => implode('<br>', $form->getErrorMessages()),
+            'ext'   => implode('<br>', $form->getErrorMessages()),
         ]);
         $data['flash'] = $this->getFlash($this->app);
 
@@ -334,17 +334,17 @@ class TalkController extends BaseController
         $user = $this->service(Authentication::class)->user();
 
         $request_data = [
-            'id' => $req->get('id'),
-            'title' => $req->get('title'),
+            'id'          => $req->get('id'),
+            'title'       => $req->get('title'),
             'description' => $req->get('description'),
-            'type' => $req->get('type'),
-            'level' => $req->get('level'),
-            'category' => $req->get('category'),
-            'desired' => $req->get('desired'),
-            'slides' => $req->get('slides'),
-            'other' => $req->get('other'),
-            'sponsor' => $req->get('sponsor'),
-            'user_id' => $req->get('user_id'),
+            'type'        => $req->get('type'),
+            'level'       => $req->get('level'),
+            'category'    => $req->get('category'),
+            'desired'     => $req->get('desired'),
+            'slides'      => $req->get('slides'),
+            'other'       => $req->get('other'),
+            'sponsor'     => $req->get('sponsor'),
+            'user_id'     => $req->get('user_id'),
         ];
 
         $form = $this->getTalkForm($request_data);
@@ -355,21 +355,21 @@ class TalkController extends BaseController
             $sanitized_data = $form->getCleanData();
 
             /* @var Locator $spot */
-            $spot = $this->service('spot');
+            $spot        = $this->service('spot');
             $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-            $data = [
-                'id' => (int) $sanitized_data['id'],
-                'title' => $sanitized_data['title'],
+            $data        = [
+                'id'          => (int) $sanitized_data['id'],
+                'title'       => $sanitized_data['title'],
                 'description' => $sanitized_data['description'],
-                'type' => $sanitized_data['type'],
-                'level' => $sanitized_data['level'],
-                'category' => $sanitized_data['category'],
-                'desired' => $sanitized_data['desired'],
-                'slides' => $sanitized_data['slides'],
-                'other' => $sanitized_data['other'],
-                'sponsor' => $sanitized_data['sponsor'],
-                'user_id' => (int) $user->getId(),
-                'updated_at' => new \DateTime(),
+                'type'        => $sanitized_data['type'],
+                'level'       => $sanitized_data['level'],
+                'category'    => $sanitized_data['category'],
+                'desired'     => $sanitized_data['desired'],
+                'slides'      => $sanitized_data['slides'],
+                'other'       => $sanitized_data['other'],
+                'sponsor'     => $sanitized_data['sponsor'],
+                'user_id'     => (int) $user->getId(),
+                'updated_at'  => new \DateTime(),
             ];
 
             $talk = $talk_mapper->get($data['id']);
@@ -386,9 +386,9 @@ class TalkController extends BaseController
             }
 
             $this->service('session')->set('flash', [
-                'type' => 'success',
+                'type'  => 'success',
                 'short' => 'Success',
-                'ext' => 'Successfully saved talk.',
+                'ext'   => 'Successfully saved talk.',
             ]);
 
             // send email to speaker showing submission
@@ -398,27 +398,27 @@ class TalkController extends BaseController
         }
 
         $data = [
-            'formAction' => $this->url('talk_update'),
+            'formAction'     => $this->url('talk_update'),
             'talkCategories' => $this->getTalkCategories(),
-            'talkTypes' => $this->getTalkTypes(),
-            'talkLevels' => $this->getTalkLevels(),
-            'id' => $req->get('id'),
-            'title' => $req->get('title'),
-            'description' => $req->get('description'),
-            'type' => $req->get('type'),
-            'level' => $req->get('level'),
-            'category' => $req->get('category'),
-            'desired' => $req->get('desired'),
-            'slides' => $req->get('slides'),
-            'other' => $req->get('other'),
-            'sponsor' => $req->get('sponsor'),
-            'buttonInfo' => 'Update my talk!',
+            'talkTypes'      => $this->getTalkTypes(),
+            'talkLevels'     => $this->getTalkLevels(),
+            'id'             => $req->get('id'),
+            'title'          => $req->get('title'),
+            'description'    => $req->get('description'),
+            'type'           => $req->get('type'),
+            'level'          => $req->get('level'),
+            'category'       => $req->get('category'),
+            'desired'        => $req->get('desired'),
+            'slides'         => $req->get('slides'),
+            'other'          => $req->get('other'),
+            'sponsor'        => $req->get('sponsor'),
+            'buttonInfo'     => 'Update my talk!',
         ];
 
         $this->service('session')->set('flash', [
-            'type' => 'error',
+            'type'  => 'error',
             'short' => 'Error',
-            'ext' => implode('<br>', $form->getErrorMessages()),
+            'ext'   => implode('<br>', $form->getErrorMessages()),
         ]);
 
         $data['flash'] = $this->getFlash($this->app);
@@ -433,9 +433,9 @@ class TalkController extends BaseController
             return $app->json(['delete' => 'no']);
         }
 
-        $user = $this->service(Authentication::class)->user();
+        $user        = $this->service(Authentication::class)->user();
         $talk_mapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $talk = $talk_mapper->get($req->get('tid'));
+        $talk        = $talk_mapper->get($req->get('tid'));
 
         if ($talk->user_id !== (int) $user->getId()) {
             return $app->json(['delete' => 'no']);
@@ -461,22 +461,22 @@ class TalkController extends BaseController
         $spot = $app['spot'];
 
         $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $talk = $mapper->get($talk_id);
+        $talk   = $mapper->get($talk_id);
 
         /* @var Twig_Environment $twig */
         $twig = $app['twig'];
 
         // Build our email that we will send
-        $template = $twig->loadTemplate('emails/talk_submit.twig');
+        $template   = $twig->loadTemplate('emails/talk_submit.twig');
         $parameters = [
-            'email' => $this->app->config('application.email'),
-            'title' => $this->app->config('application.title'),
-            'talk' => $talk->title,
+            'email'   => $this->app->config('application.email'),
+            'title'   => $this->app->config('application.title'),
+            'talk'    => $talk->title,
             'enddate' => $this->app->config('application.enddate'),
         ];
 
         try {
-            $mailer = $app['mailer'];
+            $mailer  = $app['mailer'];
             $message = new Swift_Message();
 
             $message->setTo($email);

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -37,7 +37,7 @@ abstract class Form
     public function populate(array $data)
     {
         $this->_taintedData = $data;
-        $this->_cleanData = null;
+        $this->_cleanData   = null;
     }
 
     /**
@@ -60,7 +60,7 @@ abstract class Form
      */
     public function hasRequiredFields(): bool
     {
-        $dataKeys = array_keys($this->_taintedData);
+        $dataKeys    = array_keys($this->_taintedData);
         $foundFields = array_intersect($this->_fieldList, $dataKeys);
 
         return ($foundFields == $this->_fieldList);
@@ -184,7 +184,7 @@ abstract class Form
     protected function internalSanitize(array $taintedData): array
     {
         $purifier  = $this->_purifier;
-        $filtered = array_map(
+        $filtered  = array_map(
             function ($field) use ($purifier) {
                 return $purifier->purify($field);
             },

--- a/classes/Http/Form/ResetForm.php
+++ b/classes/Http/Form/ResetForm.php
@@ -14,9 +14,9 @@ class ResetForm extends AbstractType
     {
         $builder
             ->add('password', RepeatedType::class, [
-                'type' => PasswordType::class,
-                'first_options' => ['label' => 'Password (minimum 5 characters)'],
-                'second_options' => ['label' => 'Password (confirm)'],
+                'type'            => PasswordType::class,
+                'first_options'   => ['label' => 'Password (minimum 5 characters)'],
+                'second_options'  => ['label' => 'Password (confirm)'],
                 'invalid_message' => 'Passwords did not match', ])
             ->add('user_id', HiddenType::class)
             ->add('reset_code', HiddenType::class)

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -35,22 +35,22 @@ class SignupForm extends Form
     {
         $this->sanitize();
         $valid_passwords = true;
-        $agree_coc = true;
+        $agree_coc       = true;
 
         if ($action == 'create') {
             $valid_passwords = $this->validatePasswords();
-            $agree_coc = $this->validateAgreeCoc();
+            $agree_coc       = $this->validateAgreeCoc();
         }
 
-        $valid_email = $this->validateEmail();
-        $valid_first_name = $this->validateFirstName();
-        $valid_last_name = $this->validateLastName();
-        $valid_company = $this->validateCompany();
-        $valid_twitter = $this->validateTwitter();
-        $valid_url = $this->validateUrl();
+        $valid_email         = $this->validateEmail();
+        $valid_first_name    = $this->validateFirstName();
+        $valid_last_name     = $this->validateLastName();
+        $valid_company       = $this->validateCompany();
+        $valid_twitter       = $this->validateTwitter();
+        $valid_url           = $this->validateUrl();
         $valid_speaker_photo = $this->validateSpeakerPhoto();
-        $valid_speaker_info = true;
-        $valid_speaker_bio = true;
+        $valid_speaker_info  = true;
+        $valid_speaker_bio   = true;
 
         if (!empty($this->_taintedData['speaker_info'])) {
             $valid_speaker_info = $this->validateSpeakerInfo();
@@ -145,7 +145,7 @@ class SignupForm extends Form
      */
     public function validatePasswords(): bool
     {
-        $passwd = $this->_cleanData['password'];
+        $passwd  = $this->_cleanData['password'];
         $passwd2 = $this->_cleanData['password2'];
 
         if ($passwd == '' || $passwd2 == '') {
@@ -182,7 +182,7 @@ class SignupForm extends Form
      */
     public function validateFirstName(): bool
     {
-        $first_name = $this->_cleanData['first_name'];
+        $first_name          = $this->_cleanData['first_name'];
         $validation_response = true;
 
         if (empty($first_name)) {
@@ -210,7 +210,7 @@ class SignupForm extends Form
      */
     public function validateLastName(): bool
     {
-        $last_name = $this->_cleanData['last_name'];
+        $last_name           = $this->_cleanData['last_name'];
         $validation_response = true;
 
         if (empty($last_name)) {
@@ -269,8 +269,8 @@ class SignupForm extends Form
             FILTER_SANITIZE_STRING
         );
         $validation_response = true;
-        $speakerInfo = strip_tags($speakerInfo);
-        $speakerInfo = $this->_purifier->purify($speakerInfo);
+        $speakerInfo         = strip_tags($speakerInfo);
+        $speakerInfo         = $this->_purifier->purify($speakerInfo);
 
         if (empty($speakerInfo)) {
             $this->_addErrorMessage('You submitted speaker info but it was empty after sanitizing');
@@ -292,8 +292,8 @@ class SignupForm extends Form
             FILTER_SANITIZE_STRING
         );
         $validation_response = true;
-        $speaker_bio = strip_tags($speaker_bio);
-        $speaker_bio = $this->_purifier->purify($speaker_bio);
+        $speaker_bio         = strip_tags($speaker_bio);
+        $speaker_bio         = $this->_purifier->purify($speaker_bio);
 
         if (empty($speaker_bio)) {
             $this->_addErrorMessage('You submitted speaker bio information but it was empty after sanitizing');

--- a/classes/Http/OAuth/AuthorizationController.php
+++ b/classes/Http/OAuth/AuthorizationController.php
@@ -32,7 +32,7 @@ class AuthorizationController extends ApiController
      */
     public function __construct(AuthorizationServer $server, IdentityProvider $identityProvider)
     {
-        $this->server = $server;
+        $this->server           = $server;
         $this->identityProvider = $identityProvider;
     }
 
@@ -66,7 +66,7 @@ class AuthorizationController extends ApiController
             return $this->redirectTo('login');
         } catch (OAuthException $e) {
             return $this->setStatusCode($e->httpStatusCode)->respond([
-                'error' => $e->errorType,
+                'error'   => $e->errorType,
                 'message' => $e->getMessage(),
             ], $e->getHttpHeaders());
         }
@@ -90,7 +90,7 @@ class AuthorizationController extends ApiController
             $error = new AccessDeniedException;
 
             $redirectUri = RedirectUri::make($authParams['redirect_uri'], [
-                'error' => $error->errorType,
+                'error'   => $error->errorType,
                 'message' => $error->getMessage(),
             ]);
 
@@ -113,7 +113,7 @@ class AuthorizationController extends ApiController
             return $this->respond($response);
         } catch (\Exception $e) {
             return $this->setStatusCode($e->httpStatusCode)->respond([
-                'error' => $e->errorType,
+                'error'   => $e->errorType,
                 'message' => $e->getMessage(),
             ], $e->getHttpHeaders());
         }

--- a/classes/Http/OAuth/ClientRegistrationController.php
+++ b/classes/Http/OAuth/ClientRegistrationController.php
@@ -26,7 +26,7 @@ class ClientRegistrationController extends ApiController
 
     public function __construct(Mapper $clients, Mapper $endpoints, RandomStringGenerator $generator)
     {
-        $this->clients = $clients;
+        $this->clients   = $clients;
         $this->endpoints = $endpoints;
         $this->generator = $generator;
     }
@@ -37,18 +37,18 @@ class ClientRegistrationController extends ApiController
     public function registerClient(Request $request)
     {
         $clientIdentifier = $this->generator->generate(40);
-        $clientSecret = $this->generator->generate(40);
+        $clientSecret     = $this->generator->generate(40);
 
         try {
             $client = $this->clients->create([
-                'id' => $clientIdentifier,
+                'id'     => $clientIdentifier,
                 'secret' => $clientSecret,
-                'name' => $request->get('name'),
+                'name'   => $request->get('name'),
             ]);
 
             foreach ($request->get('redirect_uris') as $uri) {
                 $this->endpoints->create([
-                    'client_id' => $clientIdentifier,
+                    'client_id'    => $clientIdentifier,
                     'redirect_uri' => $uri,
                 ]);
             }

--- a/classes/Http/View/TalkHelper.php
+++ b/classes/Http/View/TalkHelper.php
@@ -34,8 +34,8 @@ class TalkHelper
     public function __construct($categories, $levels, $types)
     {
         $this->categories = $categories;
-        $this->levels = $levels;
-        $this->types = $types;
+        $this->levels     = $levels;
+        $this->types      = $types;
     }
 
     /**

--- a/classes/Infrastructure/Auth/OAuthIdentityProvider.php
+++ b/classes/Infrastructure/Auth/OAuthIdentityProvider.php
@@ -23,7 +23,7 @@ class OAuthIdentityProvider implements IdentityProvider
 
     public function __construct(ResourceServer $server, SpeakerRepository $speakerRepository)
     {
-        $this->server = $server;
+        $this->server            = $server;
         $this->speakerRepository = $speakerRepository;
     }
 

--- a/classes/Infrastructure/Auth/SentryAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentryAccountManagement.php
@@ -39,7 +39,7 @@ class SentryAccountManagement implements AccountManagement
     public function create($email, $password, array $data = []): UserInterface
     {
         $user = $this->sentry->createUser(array_merge([
-            'email' => $email,
+            'email'    => $email,
             'password' => $password,
         ], $data));
 

--- a/classes/Infrastructure/Auth/SentryIdentityProvider.php
+++ b/classes/Infrastructure/Auth/SentryIdentityProvider.php
@@ -15,7 +15,7 @@ class SentryIdentityProvider implements IdentityProvider
 
     public function __construct(Sentry $sentry, SpeakerRepository $mapper)
     {
-        $this->sentry = $sentry;
+        $this->sentry            = $sentry;
         $this->speakerRepository = $mapper;
     }
 

--- a/classes/Infrastructure/OAuth/AccessTokenStorage.php
+++ b/classes/Infrastructure/OAuth/AccessTokenStorage.php
@@ -46,8 +46,8 @@ class AccessTokenStorage extends AbstractStorage implements AccessTokenInterface
         if (count($result) > 0) {
             foreach ($result as $row) {
                 $scope = (new ScopeEntity($this->server))->hydrate([
-                    'id'            =>  $row['id'],
-                    'description'   =>  $row['description'],
+                    'id'            => $row['id'],
+                    'description'   => $row['description'],
                 ]);
                 $response[] = $scope;
             }
@@ -63,9 +63,9 @@ class AccessTokenStorage extends AbstractStorage implements AccessTokenInterface
     {
         Capsule::table('oauth_access_tokens')
                     ->insert([
-                        'access_token'     =>  $token,
-                        'session_id'    =>  $sessionId,
-                        'expire_time'   =>  $expireTime,
+                        'access_token'     => $token,
+                        'session_id'       => $sessionId,
+                        'expire_time'      => $expireTime,
                     ]);
     }
 
@@ -76,8 +76,8 @@ class AccessTokenStorage extends AbstractStorage implements AccessTokenInterface
     {
         Capsule::table('oauth_access_token_scopes')
                     ->insert([
-                        'access_token'  =>  $token->getId(),
-                        'scope' =>  $scope->getId(),
+                        'access_token'  => $token->getId(),
+                        'scope'         => $scope->getId(),
                     ]);
     }
 

--- a/classes/Infrastructure/OAuth/AuthCodeStorage.php
+++ b/classes/Infrastructure/OAuth/AuthCodeStorage.php
@@ -36,10 +36,10 @@ class AuthCodeStorage extends AbstractStorage implements AuthCodeInterface
     {
         Capsule::table('oauth_auth_codes')
                     ->insert([
-                        'auth_code'     =>  $token,
-                        'client_redirect_uri'  =>  $redirectUri,
-                        'session_id'    =>  $sessionId,
-                        'expire_time'   =>  $expireTime,
+                        'auth_code'            => $token,
+                        'client_redirect_uri'  => $redirectUri,
+                        'session_id'           => $sessionId,
+                        'expire_time'          => $expireTime,
                     ]);
     }
 
@@ -59,8 +59,8 @@ class AuthCodeStorage extends AbstractStorage implements AuthCodeInterface
         if (count($result) > 0) {
             foreach ($result as $row) {
                 $scope = (new ScopeEntity($this->server))->hydrate([
-                    'id'            =>  $row['id'],
-                    'description'   =>  $row['description'],
+                    'id'            => $row['id'],
+                    'description'   => $row['description'],
                 ]);
                 $response[] = $scope;
             }
@@ -76,8 +76,8 @@ class AuthCodeStorage extends AbstractStorage implements AuthCodeInterface
     {
         Capsule::table('oauth_auth_code_scopes')
                     ->insert([
-                        'auth_code' =>  $token->getId(),
-                        'scope'     =>  $scope->getId(),
+                        'auth_code' => $token->getId(),
+                        'scope'     => $scope->getId(),
                     ]);
     }
 

--- a/classes/Infrastructure/OAuth/ClientStorage.php
+++ b/classes/Infrastructure/OAuth/ClientStorage.php
@@ -35,8 +35,8 @@ class ClientStorage extends AbstractStorage implements ClientInterface
             $client = new ClientEntity($this->server);
 
             $clientData = [
-                'id'    =>  $result[0]['id'],
-                'name'  =>  $result[0]['name'],
+                'id'    => $result[0]['id'],
+                'name'  => $result[0]['name'],
             ];
 
             if ($redirectUri) {
@@ -65,8 +65,8 @@ class ClientStorage extends AbstractStorage implements ClientInterface
         if (count($result) === 1) {
             $client = new ClientEntity($this->server);
             $client->hydrate([
-                'id'    =>  $result[0]['id'],
-                'name'  =>  $result[0]['name'],
+                'id'    => $result[0]['id'],
+                'name'  => $result[0]['name'],
             ]);
 
             return $client;

--- a/classes/Infrastructure/OAuth/RefreshTokenStorage.php
+++ b/classes/Infrastructure/OAuth/RefreshTokenStorage.php
@@ -37,9 +37,9 @@ class RefreshTokenStorage extends AbstractStorage implements RefreshTokenInterfa
     {
         Capsule::table('oauth_refresh_tokens')
                     ->insert([
-                        'refresh_token'     =>  $token,
-                        'access_token'    =>  $accessToken,
-                        'expire_time'   =>  $expireTime,
+                        'refresh_token'     => $token,
+                        'access_token'      => $accessToken,
+                        'expire_time'       => $expireTime,
                     ]);
     }
 

--- a/classes/Infrastructure/OAuth/ScopeStorage.php
+++ b/classes/Infrastructure/OAuth/ScopeStorage.php
@@ -23,8 +23,8 @@ class ScopeStorage extends AbstractStorage implements ScopeInterface
         }
 
         return (new ScopeEntity($this->server))->hydrate([
-            'id'            =>  $result[0]['id'],
-            'description'   =>  $result[0]['description'],
+            'id'            => $result[0]['id'],
+            'description'   => $result[0]['description'],
         ]);
     }
 }

--- a/classes/Infrastructure/OAuth/SessionStorage.php
+++ b/classes/Infrastructure/OAuth/SessionStorage.php
@@ -72,8 +72,8 @@ class SessionStorage extends AbstractStorage implements SessionInterface
 
         foreach ($result as $scope) {
             $scopes[] = (new ScopeEntity($this->server))->hydrate([
-                'id'            =>  $scope['id'],
-                'description'   =>  $scope['description'],
+                'id'            => $scope['id'],
+                'description'   => $scope['description'],
             ]);
         }
 
@@ -87,9 +87,9 @@ class SessionStorage extends AbstractStorage implements SessionInterface
     {
         $id = Capsule::table('oauth_sessions')
                         ->insertGetId([
-                            'owner_type'  =>    $ownerType,
-                            'owner_id'    =>    $ownerId,
-                            'client_id'   =>    $clientId,
+                            'owner_type'  => $ownerType,
+                            'owner_id'    => $ownerId,
+                            'client_id'   => $clientId,
                         ]);
 
         return $id;
@@ -102,8 +102,8 @@ class SessionStorage extends AbstractStorage implements SessionInterface
     {
         Capsule::table('oauth_session_scopes')
                             ->insert([
-                                'session_id'    =>  $session->getId(),
-                                'scope'         =>  $scope->getId(),
+                                'session_id'    => $session->getId(),
+                                'scope'         => $scope->getId(),
                             ]);
     }
 }

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -92,10 +92,10 @@ class ApplicationServiceProvider implements ServiceProviderInterface
         };
 
         $app['oauth.resource'] = function ($app) {
-            $sessionStorage = new SessionStorage();
+            $sessionStorage     = new SessionStorage();
             $accessTokenStorage = new AccessTokenStorage();
-            $clientStorage = new ClientStorage();
-            $scopeStorage = new ScopeStorage();
+            $clientStorage      = new ClientStorage();
+            $scopeStorage       = new ScopeStorage();
 
             $server = new ResourceServer(
                 $sessionStorage,

--- a/classes/Provider/Gateways/OAuthGatewayProvider.php
+++ b/classes/Provider/Gateways/OAuthGatewayProvider.php
@@ -31,7 +31,7 @@ class OAuthGatewayProvider implements ServiceProviderInterface, BootableProvider
             /* @var Locator $spot */
             $spot = $app['spot'];
             
-            $userMapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
+            $userMapper        = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
             $speakerRepository = new SpotSpeakerRepository($userMapper);
 
             /* @var Sentry $sentry */

--- a/classes/Provider/SentryServiceProvider.php
+++ b/classes/Provider/SentryServiceProvider.php
@@ -14,12 +14,12 @@ class SentryServiceProvider implements ServiceProviderInterface
     public function register(Container $app)
     {
         $app['sentry'] = function ($app) {
-            $hasher = new \Cartalyst\Sentry\Hashing\NativeHasher;
-            $userProvider = new \Cartalyst\Sentry\Users\Eloquent\Provider($hasher);
-            $groupProvider = new \Cartalyst\Sentry\Groups\Eloquent\Provider;
+            $hasher           = new \Cartalyst\Sentry\Hashing\NativeHasher;
+            $userProvider     = new \Cartalyst\Sentry\Users\Eloquent\Provider($hasher);
+            $groupProvider    = new \Cartalyst\Sentry\Groups\Eloquent\Provider;
             $throttleProvider = new \Cartalyst\Sentry\Throttling\Eloquent\Provider($userProvider);
-            $session = new SymfonySentrySession($app['session']);
-            $cookie = new \Cartalyst\Sentry\Cookies\NativeCookie([]);
+            $session          = new SymfonySentrySession($app['session']);
+            $cookie           = new \Cartalyst\Sentry\Cookies\NativeCookie([]);
 
             $sentry = new \Cartalyst\Sentry\Sentry(
                 $userProvider,

--- a/classes/Provider/SpotServiceProvider.php
+++ b/classes/Provider/SpotServiceProvider.php
@@ -15,13 +15,13 @@ class SpotServiceProvider implements ServiceProviderInterface
     public function register(Container $app)
     {
         $app['spot'] = function ($app) {
-            $config = new SpotConfig();
+            $config   = new SpotConfig();
             $dbConfig = [
-                'dbname' => $app->config('database.database'),
-                'user' => $app->config('database.user'),
+                'dbname'   => $app->config('database.database'),
+                'user'     => $app->config('database.user'),
                 'password' => $app->config('database.password'),
-                'host' => $app->config('database.host'),
-                'driver' => 'pdo_mysql',
+                'host'     => $app->config('database.host'),
+                'driver'   => 'pdo_mysql',
             ];
 
             if ($app->config('database.port') !== null) {

--- a/classes/Provider/SymfonySentrySession.php
+++ b/classes/Provider/SymfonySentrySession.php
@@ -20,7 +20,7 @@ class SymfonySentrySession implements SentrySessionInterface
     public function __construct(SymfonySessionInterface $session, $key = null)
     {
         $this->session = $session;
-        $this->key = $key ?: 'cartalyst_sentry';
+        $this->key     = $key ?: 'cartalyst_sentry';
     }
 
     /**

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -28,7 +28,7 @@ class TwigServiceProvider implements ServiceProviderInterface
     public function register(Container $c)
     {
         $c->register(new SilexTwigServiceProvider, [
-            'twig.path' => $this->app->templatesPath(),
+            'twig.path'    => $this->app->templatesPath(),
             'twig.options' => [
                 'debug' => !$this->app->isProduction(),
                 'cache' => $this->app->config('cache.enabled') ? $this->app->cacheTwigPath() : false,

--- a/factories/Common.php
+++ b/factories/Common.php
@@ -4,19 +4,19 @@
 
 $factory->define(\OpenCFP\Domain\Model\User::class, function (\Faker\Generator $faker) {
     return [
-        'email' => $faker->unique()->safeEmail,
-        'password' => password_hash('secret', PASSWORD_BCRYPT),
-        'activated' => 1,
-        'first_name' => $faker->firstName,
-        'last_name' => $faker->lastName,
-        'company' => $faker->company,
-        'twitter' => '@' . $faker->userName,
-        'activated_at' => $faker->dateTimeInInterval('-2 months', '-1 months'),
-        'last_login' => $faker->dateTimeInInterval('-5 days', 'now'),
+        'email'          => $faker->unique()->safeEmail,
+        'password'       => password_hash('secret', PASSWORD_BCRYPT),
+        'activated'      => 1,
+        'first_name'     => $faker->firstName,
+        'last_name'      => $faker->lastName,
+        'company'        => $faker->company,
+        'twitter'        => '@' . $faker->userName,
+        'activated_at'   => $faker->dateTimeInInterval('-2 months', '-1 months'),
+        'last_login'     => $faker->dateTimeInInterval('-5 days', 'now'),
         'transportation' => $faker->randomElement([0, 1]),
-        'hotel' => $faker->randomElement([0, 1]),
-        'info' => $faker->realText(),
-        'bio' => $faker->realText(),
+        'hotel'          => $faker->randomElement([0, 1]),
+        'info'           => $faker->realText(),
+        'bio'            => $faker->realText(),
     ];
 });
 
@@ -25,22 +25,22 @@ $factory->define(\OpenCFP\Domain\Model\Talk::class, function (\Faker\Generator $
         'user_id' => function () {
             return factory(\OpenCFP\Domain\Model\User::class)->create()->id;
         },
-        'title' => $faker->sentence(),
+        'title'       => $faker->sentence(),
         'description' => $faker->realText(),
-        'other' => $faker->realText(),
-        'type' => $faker->randomElement(['regular', 'tutorial']),
-        'level' => $faker->randomElement(['entry', 'mid', 'advanced']),
-        'category' => $faker->randomElement(['api', 'database', 'development', 'testing']),
+        'other'       => $faker->realText(),
+        'type'        => $faker->randomElement(['regular', 'tutorial']),
+        'level'       => $faker->randomElement(['entry', 'mid', 'advanced']),
+        'category'    => $faker->randomElement(['api', 'database', 'development', 'testing']),
     ];
 });
 
 $factory->define(\OpenCFP\Domain\Model\TalkMeta::class, function (\Faker\Generator $faker) {
     return [
         'admin_user_id' => factory(\OpenCFP\Domain\Model\User::class)->create()->id,
-        'rating' => 1,
-        'viewed' => 1,
-        'talk_id' => factory(\OpenCFP\Domain\Model\Talk::class)->create()->id,
-        'created' => new \DateTime(),
+        'rating'        => 1,
+        'viewed'        => 1,
+        'talk_id'       => factory(\OpenCFP\Domain\Model\Talk::class)->create()->id,
+        'created'       => new \DateTime(),
     ];
 });
 
@@ -56,7 +56,7 @@ $factory->define(\OpenCFP\Domain\Model\TalkComment::class, function (\Faker\Gene
 $factory->define(\OpenCFP\Domain\Model\Favorite::class, function (\Faker\Generator $faker) {
     return [
         'admin_user_id' => factory(\OpenCFP\Domain\Model\User::class)->create()->id,
-        'talk_id' => factory(\OpenCFP\Domain\Model\Talk::class)->create()->id,
-        'created' => new \DateTime(),
+        'talk_id'       => factory(\OpenCFP\Domain\Model\Talk::class)->create()->id,
+        'created'       => new \DateTime(),
     ];
 });

--- a/tests/Application/SpeakersTest.php
+++ b/tests/Application/SpeakersTest.php
@@ -38,11 +38,11 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->identityProvider = m::mock(\OpenCFP\Domain\Services\IdentityProvider::class);
+        $this->identityProvider  = m::mock(\OpenCFP\Domain\Services\IdentityProvider::class);
         $this->speakerRepository = m::mock(\OpenCFP\Domain\Speaker\SpeakerRepository::class);
-        $this->talkRepository = m::mock(\OpenCFP\Domain\Talk\TalkRepository::class);
-        $this->callForProposal = m::mock(\OpenCFP\Domain\CallForProposal::class);
-        $this->dispatcher = m::mock(\OpenCFP\Domain\Services\EventDispatcher::class);
+        $this->talkRepository    = m::mock(\OpenCFP\Domain\Talk\TalkRepository::class);
+        $this->callForProposal   = m::mock(\OpenCFP\Domain\CallForProposal::class);
+        $this->dispatcher        = m::mock(\OpenCFP\Domain\Services\EventDispatcher::class);
 
         $this->sut = new Speakers($this->callForProposal, $this->identityProvider, $this->speakerRepository, $this->talkRepository, $this->dispatcher);
     }
@@ -157,11 +157,11 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
             ->once();
 
         $submission = TalkSubmission::fromNative([
-            'title' => 'Sample Talk',
+            'title'       => 'Sample Talk',
             'description' => 'Some example talk for our submission',
-            'type' => 'regular',
-            'category' => 'api',
-            'level' => 'mid',
+            'type'        => 'regular',
+            'category'    => 'api',
+            'level'       => 'mid',
         ]);
 
         /**
@@ -183,11 +183,11 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
             ->once()
             ->andReturn(false);
         $submission = TalkSubmission::fromNative([
-            'title' => 'Sample Talk',
+            'title'       => 'Sample Talk',
             'description' => 'Some example talk for our submission',
-            'type' => 'regular',
-            'category' => 'api',
-            'level' => 'mid',
+            'type'        => 'regular',
+            'category'    => 'api',
+            'level'       => 'mid',
         ]);
 
         $this->expectException(\Exception::class);
@@ -215,10 +215,10 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
     private function getSpeaker()
     {
         return new User([
-            'id' => self::SPEAKER_ID,
-            'email' => 'speaker@opencfp.org',
+            'id'         => self::SPEAKER_ID,
+            'email'      => 'speaker@opencfp.org',
             'first_name' => 'Fake',
-            'last_name' => 'Speaker',
+            'last_name'  => 'Speaker',
         ]);
     }
 
@@ -235,15 +235,15 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
     private function getSpeakerFromMisbehavingRelation()
     {
         // Set up stub speaker.
-        $stub = m::mock(\stdClass::class);
+        $stub     = m::mock(\stdClass::class);
         $stub->id = self::SPEAKER_ID;
 
         // Set up talks.
         $talk = m::mock(\stdClass::class);
         $talk->shouldReceive('find')->andReturn(
             new Talk([
-                'id' => 1,
-                'title' => 'Testy Talk',
+                'id'      => 1,
+                'title'   => 'Testy Talk',
                 'user_id' => self::SPEAKER_ID + 1, // Not the speaker!
             ])
         );
@@ -255,15 +255,15 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
     private function getSpeakerWithOneTalk()
     {
         // Set up stub speaker.
-        $stub = m::mock(\stdClass::class);
+        $stub     = m::mock(\stdClass::class);
         $stub->id = self::SPEAKER_ID;
 
         // Set up talks.
         $talk= m::mock(\stdClass::class);
         $talk->shouldReceive('find')->andReturn(
             new Talk([
-                'id' => 1,
-                'title' => 'Testy Talk',
+                'id'      => 1,
+                'title'   => 'Testy Talk',
                 'user_id' => self::SPEAKER_ID,
             ])
         );
@@ -275,24 +275,24 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
     private function getSpeakerWithManyTalks()
     {
         // Set up stub speaker.
-        $stub = m::mock(\stdClass::class);
+        $stub     = m::mock(\stdClass::class);
         $stub->id = self::SPEAKER_ID;
 
         // Set up talks.
         $stub->talks = [
             new Talk([
-                'id' => 1,
-                'title' => 'Testy Talk',
+                'id'      => 1,
+                'title'   => 'Testy Talk',
                 'user_id' => self::SPEAKER_ID,
             ]),
             new Talk([
-                'id' => 2,
-                'title' => 'Another Talk',
+                'id'      => 2,
+                'title'   => 'Another Talk',
                 'user_id' => self::SPEAKER_ID,
             ]),
             new Talk([
-                'id' => 3,
-                'title' => 'Yet Another Talk',
+                'id'      => 3,
+                'title'   => 'Yet Another Talk',
                 'user_id' => self::SPEAKER_ID,
             ]),
         ];

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -19,7 +19,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
      */
     public function it_should_run_and_have_output()
     {
-        $this->sut = new Application(BASE_PATH, Environment::testing());
+        $this->sut                 = new Application(BASE_PATH, Environment::testing());
         $this->sut['session.test'] = true;
 
         // We start an output buffer because the Application sends its response to

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -40,7 +40,7 @@ class BaseTestCase extends \PHPUnit\Framework\TestCase
 
     public function createApplication()
     {
-        $app = new Application(BASE_PATH, Environment::testing());
+        $app                 = new Application(BASE_PATH, Environment::testing());
         $app['session.test'] = true;
 
         return $app;

--- a/tests/Console/AdminPromoteCommandTest.php
+++ b/tests/Console/AdminPromoteCommandTest.php
@@ -26,12 +26,12 @@ class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
     public function promoteDetectsNonExistentUser()
     {
         // Create our input and output dependencies
-        $input = $this->createInputInterfaceWithEmail('test@opencfp.dev');
+        $input  = $this->createInputInterfaceWithEmail('test@opencfp.dev');
         $output = $this->createOutputInterface();
 
         $accounts = Mockery::mock(AccountManagement::class);
         $accounts->shouldReceive('findByLogin')->andThrow(new \Cartalyst\Sentry\Users\UserNotFoundException);
-        $app = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app                           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
         $app[AccountManagement::class] = $accounts;
 
         // Create our command object and inject our application
@@ -47,7 +47,7 @@ class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
     public function promoteExistingNonAdminAccount()
     {
         // Create our input and output dependencies
-        $input = $this->createInputInterfaceWithEmail('test@opencfp.dev');
+        $input  = $this->createInputInterfaceWithEmail('test@opencfp.dev');
         $output = $this->createOutputInterface();
 
         /**
@@ -71,9 +71,9 @@ class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
             ->with('test@opencfp.dev', 'Admin');
 
         // Create our command object and inject our application
-        $app = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app                           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
         $app[AccountManagement::class] = $accounts;
-        $command = new \OpenCFP\Console\Command\AdminPromoteCommand();
+        $command                       = new \OpenCFP\Console\Command\AdminPromoteCommand();
         $command->setApp($app);
         $response = $command->execute($input, $output);
 

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -54,7 +54,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
 
     public function testConstructorSetsApplication()
     {
-        $baseApp = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $baseApp     = new \OpenCFP\Application(BASE_PATH, Environment::testing());
         $application = new Application($baseApp);
 
         $this->assertAttributeSame($baseApp, 'app', $application);
@@ -63,7 +63,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     public function testHasDefaultCommands()
     {
         $appContainer = new \OpenCFP\Application(BASE_PATH, Environment::testing());
-        $application = new Application($appContainer);
+        $application  = new Application($appContainer);
 
         $expected = [
             Console\Command\HelpCommand::class,
@@ -89,7 +89,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     public function testAdminDemoteDetectsNonExistentUser()
     {
         // Create our input and output dependencies
-        $input = $this->createInputInterfaceWithEmail('test@opencfp.dev');
+        $input  = $this->createInputInterfaceWithEmail('test@opencfp.dev');
         $output = $this->createOutputInterface();
 
         /**
@@ -98,7 +98,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
          */
         $sentry = Mockery::mock(\Cartalyst\Sentry\Sentry::class);
         $sentry->shouldReceive('getUserProvider->findByLogin')->andThrow(new \Cartalyst\Sentry\Users\UserNotFoundException);
-        $app = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
         $app['sentry'] = $sentry;
 
         // Create our command object and inject our application
@@ -111,7 +111,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     public function testAdminDemoteWillNotDemoteNonAdminAccounts()
     {
         // Create our input and output dependencies
-        $input = $this->createInputInterfaceWithEmail('test@opencfp.dev');
+        $input  = $this->createInputInterfaceWithEmail('test@opencfp.dev');
         $output = $this->createOutputInterface();
 
         /**
@@ -123,7 +123,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $sentry = Mockery::mock(\Cartalyst\Sentry\Sentry::class);
         $sentry->shouldReceive('getUserProvider->findByLogin')
             ->andReturn($user);
-        $app = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
         $app['sentry'] = $sentry;
 
         // Create our command object and inject our application
@@ -136,7 +136,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     public function testAdminDemoteSuccess()
     {
         // Create our input and output dependencies
-        $input = $this->createInputInterfaceWithEmail('test@opencfp.dev');
+        $input  = $this->createInputInterfaceWithEmail('test@opencfp.dev');
         $output = $this->createOutputInterface();
 
         /**
@@ -155,9 +155,9 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
             ->with('test@opencfp.dev', 'Admin');
 
         // Create our command object and inject our application
-        $app = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app                           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
         $app[AccountManagement::class] = $accounts;
-        $command = new \OpenCFP\Console\Command\AdminDemoteCommand();
+        $command                       = new \OpenCFP\Console\Command\AdminDemoteCommand();
         $command->setApp($app);
         $response = $command->execute($input, $output);
         $this->assertEquals($response, 0);

--- a/tests/ContainerAwareTest.php
+++ b/tests/ContainerAwareTest.php
@@ -9,7 +9,7 @@ class ContainerAwareTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllowsToRetrieveService()
     {
-        $slug = 'foo';
+        $slug    = 'foo';
         $service = 'bar';
 
         $application = $this->getApplicationMock();

--- a/tests/Domain/Entity/FavoriteTest.php
+++ b/tests/Domain/Entity/FavoriteTest.php
@@ -32,10 +32,10 @@ class FavoriteTest extends \PHPUnit\Framework\TestCase
 
         // Create a talk
         $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $data = [
-            'title' => 'Favorite Entity Test',
+        $data        = [
+            'title'       => 'Favorite Entity Test',
             'description' => 'This is a stubbed talk for a Favorite Entity Test',
-            'user_id' => 1,
+            'user_id'     => 1,
         ];
         $talk_mapper->migrate();
         $this->talk = $talk_mapper->create($data);
@@ -47,11 +47,11 @@ class FavoriteTest extends \PHPUnit\Framework\TestCase
     public function relationsCreatedCorrectly()
     {
         $created = new \DateTime();
-        $data = [
-            'id' => 1,
+        $data    = [
+            'id'            => 1,
             'admin_user_id' => 1,
-            'talk_id' => $this->talk->id,
-            'created' => $created,
+            'talk_id'       => $this->talk->id,
+            'created'       => $created,
         ];
         $favorite = $this->mapper->create($data);
 

--- a/tests/Domain/Entity/Mapper/TalkTest.php
+++ b/tests/Domain/Entity/Mapper/TalkTest.php
@@ -18,7 +18,7 @@ class TalkTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
-        $cfg = new \Spot\Config;
+        $cfg       = new \Spot\Config;
         $cfg->addConnection('sqlite', [
             'dbname' => 'sqlite::memory',
             'driver' => 'pdo_sqlite',
@@ -27,7 +27,7 @@ class TalkTest extends \PHPUnit\Framework\TestCase
         $spot = new \Spot\Locator($cfg);
 
         $this->app['spot'] = $spot;
-        $this->mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
+        $this->mapper      = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
 
         foreach ($this->entities as $entity) {
             $spot->mapper('OpenCFP\Domain\Entity\\' . $entity)->migrate();
@@ -40,7 +40,7 @@ class TalkTest extends \PHPUnit\Framework\TestCase
     public function getAdminFavoritesReturnsCorrectList()
     {
         // Create a test talk
-        $admin_user_id = 1;
+        $admin_user_id  = 1;
         $admin_majority = 3;
 
         /* @var Locator $spot */
@@ -49,19 +49,19 @@ class TalkTest extends \PHPUnit\Framework\TestCase
         $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
 
         $talk_data = [
-            'title' => 'Admin Favorite Talk',
+            'title'       => 'Admin Favorite Talk',
             'description' => "This talk has {$admin_majority} favorites!",
-            'user_id' => $admin_user_id,
-            'type' => 'regular',
-            'category' => 'api',
-            'level' => 'entry',
+            'user_id'     => $admin_user_id,
+            'type'        => 'regular',
+            'category'    => 'api',
+            'level'       => 'entry',
         ];
         $talk = $mapper->create($talk_data);
 
         $this->createAdminFavoredTalks($admin_user_id, $admin_majority, $talk);
         $mapper->createdFormattedOutput($talk, $admin_user_id);
         $admin_favorite_collection = $mapper->getFavoritesByUserId($admin_user_id);
-        $admin_favorite = $admin_favorite_collection[0];
+        $admin_favorite            = $admin_favorite_collection[0];
 
         $this->assertEquals(
             $talk->id,
@@ -76,7 +76,7 @@ class TalkTest extends \PHPUnit\Framework\TestCase
     public function getTopRatedByUserIdReturnsCorrectList()
     {
         // Create a test talk
-        $admin_user_id = 1;
+        $admin_user_id  = 1;
         $admin_majority = 3;
 
         /* @var Locator $spot */
@@ -85,19 +85,19 @@ class TalkTest extends \PHPUnit\Framework\TestCase
         $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
 
         $talk_data = [
-            'title' => 'Admin Favorite Talk',
+            'title'       => 'Admin Favorite Talk',
             'description' => "This talk has {$admin_majority} favorites!",
-            'user_id' => $admin_user_id,
-            'type' => 'regular',
-            'category' => 'api',
-            'level' => 'entry',
+            'user_id'     => $admin_user_id,
+            'type'        => 'regular',
+            'category'    => 'api',
+            'level'       => 'entry',
         ];
         $talk = $mapper->create($talk_data);
 
         $this->rateTalks($admin_user_id, $talk);
         $mapper->createdFormattedOutput($talk, $admin_user_id);
         $top_rated_collection = $mapper->getTopRatedByUserId($admin_user_id);
-        $top_rated = $top_rated_collection[0];
+        $top_rated            = $top_rated_collection[0];
 
         $this->assertEquals(
             $talk->id,
@@ -118,11 +118,11 @@ class TalkTest extends \PHPUnit\Framework\TestCase
         // Create a test user
         $user_mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $user_mapper->create([
-            'id' => $admin_user_id,
-            'email' => 'test@test.com',
-            'password' => 'supersecret',
+            'id'         => $admin_user_id,
+            'email'      => 'test@test.com',
+            'password'   => 'supersecret',
             'first_name' => 'Testy',
-            'last_name' => 'McTesterson',
+            'last_name'  => 'McTesterson',
         ]);
 
         // Create $admin_majority favorite records linked to that talk
@@ -131,9 +131,9 @@ class TalkTest extends \PHPUnit\Framework\TestCase
 
         for ($x = 1; $x <= $admin_majority; $x++) {
             $random_admin_id = rand();
-            $favorite_data = [
+            $favorite_data   = [
                 'admin_user_id' => $random_admin_id,
-                'talk_id' => $talk->id,
+                'talk_id'       => $talk->id,
             ];
             $favorite_mapper->create($favorite_data);
         }
@@ -147,18 +147,18 @@ class TalkTest extends \PHPUnit\Framework\TestCase
         // Create a test user
         $user_mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
         $user_mapper->create([
-            'id' => $admin_user_id,
-            'email' => 'test@test.com',
-            'password' => 'supersecret',
+            'id'         => $admin_user_id,
+            'email'      => 'test@test.com',
+            'password'   => 'supersecret',
             'first_name' => 'Testy',
-            'last_name' => 'McTesterson',
+            'last_name'  => 'McTesterson',
         ]);
 
         $talk_meta_mapper = $spot->mapper(\OpenCFP\Domain\Entity\TalkMeta::class);
 
-        $talk_meta = $talk_meta_mapper->get();
+        $talk_meta                = $talk_meta_mapper->get();
         $talk_meta->admin_user_id = $admin_user_id;
-        $talk_meta->talk_id = $talk->id;
+        $talk_meta->talk_id       = $talk->id;
 
         $talk_meta->rating = 1;
         $talk_meta_mapper->save($talk_meta);

--- a/tests/Domain/Entity/Mapper/UserTest.php
+++ b/tests/Domain/Entity/Mapper/UserTest.php
@@ -19,7 +19,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
-        $cfg = new \Spot\Config;
+        $cfg       = new \Spot\Config;
         $cfg->addConnection('sqlite', [
             'dbname' => 'sqlite::memory',
             'driver' => 'pdo_sqlite',
@@ -28,7 +28,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
         $spot = new Locator($cfg);
 
         $this->app['spot'] = $spot;
-        $this->mapper = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
+        $this->mapper      = $spot->mapper(\OpenCFP\Domain\Entity\User::class);
 
         foreach ($this->entities as $entity) {
             $spot->mapper('OpenCFP\Domain\Entity\\' . $entity)->migrate();
@@ -77,41 +77,41 @@ class UserTest extends \PHPUnit\Framework\TestCase
         $this->mapper->create(
             [
                 'first_name' => 'Jesse',
-                'last_name' => 'Kramer',
-                'email' => 'jkramer@example.com',
-                'password' => 'totallySecure1',
+                'last_name'  => 'Kramer',
+                'email'      => 'jkramer@example.com',
+                'password'   => 'totallySecure1',
             ]
         );
         $this->mapper->create(
             [
                 'first_name' => 'Arthur',
-                'last_name' => 'Hunter',
-                'email' => 'ahunter@example.com',
-                'password' => 'totallySecure1',
+                'last_name'  => 'Hunter',
+                'email'      => 'ahunter@example.com',
+                'password'   => 'totallySecure1',
             ]
         );
         $this->mapper->create(
             [
                 'first_name' => 'Bauke',
-                'last_name' => 'the Farmer',
-                'email' => 'nvkmn@example.com',
-                'password' => 'totallySecure1',
+                'last_name'  => 'the Farmer',
+                'email'      => 'nvkmn@example.com',
+                'password'   => 'totallySecure1',
             ]
         );
         $this->mapper->create(
             [
                 'first_name' => 'Adrie',
-                'last_name' => 'de Slager',
-                'email' => 'cowhammer@example.com',
-                'password' => 'totallySecure1',
+                'last_name'  => 'de Slager',
+                'email'      => 'cowhammer@example.com',
+                'password'   => 'totallySecure1',
             ]
         );
         $this->mapper->create(
             [
                 'first_name' => 'Antonius',
-                'last_name' => 'von Bil',
-                'email' => 'antonius@example.com',
-                'password' => 'totallySecure1',
+                'last_name'  => 'von Bil',
+                'email'      => 'antonius@example.com',
+                'password'   => 'totallySecure1',
             ]
         );
     }

--- a/tests/Domain/Entity/TalkTest.php
+++ b/tests/Domain/Entity/TalkTest.php
@@ -18,7 +18,7 @@ class TalkTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->app = new Application(BASE_PATH, Environment::testing());
-        $cfg = new \Spot\Config;
+        $cfg       = new \Spot\Config;
         $cfg->addConnection('sqlite', [
             'dbname' => 'sqlite::memory',
             'driver' => 'pdo_sqlite',
@@ -40,10 +40,10 @@ class TalkTest extends \PHPUnit\Framework\TestCase
     public function utf8CharactersCorrectlyEncoded()
     {
         $title = 'Battle: Feature Branches VS Feature Switching (╯°□°)╯︵ ┻━┻ ︵ ╯(°□° ╯)';
-        $data = [
-            'title' => $title,
+        $data  = [
+            'title'       => $title,
             'description' => 'Talk with UTF-8 characters in the title',
-            'user_id' => 1,
+            'user_id'     => 1,
         ];
         $talk = $this->mapper->create($data);
 
@@ -85,10 +85,10 @@ class TalkTest extends \PHPUnit\Framework\TestCase
     {
         for ($x = 1; $x <= $numTalks; $x++) {
             $title = uniqid();
-            $data = [
-                'title' => $title,
+            $data  = [
+                'title'       => $title,
                 'description' => "Description for $title",
-                'user_id' => 1,
+                'user_id'     => 1,
             ];
             $this->mapper->create($data);
         }

--- a/tests/Domain/Model/Interaction/TalkTest.php
+++ b/tests/Domain/Model/Interaction/TalkTest.php
@@ -47,7 +47,7 @@ class TalkTest extends BaseTestCase
     {
         /** @var TalkComment $meta */
         $comment = factory(TalkComment::class, 1)->create()->first();
-        $talk = $comment->talk()->first();
+        $talk    = $comment->talk()->first();
 
         $talk->delete();
         $this->assertCount(0, TalkComment::all());
@@ -60,7 +60,7 @@ class TalkTest extends BaseTestCase
     {
         /** @var TalkComment $comment */
         $comment = factory(TalkComment::class, 1)->create()->first();
-        $talk = $comment->talk()->first();
+        $talk    = $comment->talk()->first();
 
         $talk->deleteComments();
         $this->assertCount(0, TalkComment::all());
@@ -74,7 +74,7 @@ class TalkTest extends BaseTestCase
     {
         /** @var Favorite $favorite */
         $favorite = factory(Favorite::class, 1)->create()->first();
-        $talk = $favorite->talk()->first();
+        $talk     = $favorite->talk()->first();
 
         $talk->delete();
         $this->assertCount(0, Favorite::all());
@@ -87,7 +87,7 @@ class TalkTest extends BaseTestCase
     {
         /** @var Favorite $favorite */
         $favorite = factory(Favorite::class, 1)->create()->first();
-        $talk = $favorite->talk()->first();
+        $talk     = $favorite->talk()->first();
 
         $talk->deleteFavorites();
         $this->assertCount(0, Favorite::all());

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -37,9 +37,9 @@ class TalkTest extends BaseTestCase
      */
     public function createFormattedOutputWorksWithNoMeta()
     {
-        $talk = self::$talks;
+        $talk      = self::$talks;
         $formatter = new TalkFormatter();
-        $format =$formatter->createdFormattedOutput($talk->first(), 1);
+        $format    =$formatter->createdFormattedOutput($talk->first(), 1);
 
         $this->assertEquals(self::$talks->first()->title, $format['title']);
         $this->assertEquals(0, $format['meta']->rating);
@@ -55,7 +55,7 @@ class TalkTest extends BaseTestCase
 
         // Now to see if the meta gets put in correctly
         $talkFormatter = new TalkFormatter();
-        $secondFormat =$talkFormatter->createdFormattedOutput($talk->first(), 2);
+        $secondFormat  =$talkFormatter->createdFormattedOutput($talk->first(), 2);
 
         $this->assertEquals(1, $secondFormat['meta']->rating);
         $this->assertEquals(1, $secondFormat['meta']->viewed);

--- a/tests/Domain/Model/UserTest.php
+++ b/tests/Domain/Model/UserTest.php
@@ -42,39 +42,39 @@ class UserTest extends BaseTestCase
     private static function makeKnownUsers()
     {
         $userInfo = [
-            'password' => password_hash('secret', PASSWORD_BCRYPT),
-            'activated' => 1,
+            'password'         => password_hash('secret', PASSWORD_BCRYPT),
+            'activated'        => 1,
             'has_made_profile' => 1,
         ];
 
         User::create(array_merge([
-            'email' => 'henk@example.com',
+            'email'      => 'henk@example.com',
             'first_name' => 'Henk',
-            'last_name' => 'de Vries',
+            'last_name'  => 'de Vries',
         ], $userInfo));
 
         User::create(array_merge([
-            'email' => 'speaker@cfp.org',
+            'email'      => 'speaker@cfp.org',
             'first_name' => 'Speaker',
-            'last_name' => 'de Vries',
+            'last_name'  => 'de Vries',
         ], $userInfo));
 
         User::create(array_merge([
-            'email' => 'Vries@cfp.org',
+            'email'      => 'Vries@cfp.org',
             'first_name' => 'Vries',
-            'last_name' => 'van Henk',
+            'last_name'  => 'van Henk',
         ], $userInfo));
 
         User::create(array_merge([
-            'email' => 'd20@mail.com',
+            'email'      => 'd20@mail.com',
             'first_name' => 'Arthur',
-            'last_name' => 'Hunter',
+            'last_name'  => 'Hunter',
         ], $userInfo));
 
         User::create(array_merge([
-            'email' => 'hunter@hunter.xx',
+            'email'      => 'hunter@hunter.xx',
             'first_name' => 'Gon',
-            'last_name' => 'Freecss',
+            'last_name'  => 'Freecss',
         ], $userInfo));
     }
 }

--- a/tests/Domain/Services/TalkFormatterTest.php
+++ b/tests/Domain/Services/TalkFormatterTest.php
@@ -27,7 +27,7 @@ class TalkFormatterTest extends BaseTestCase
      */
     public function createFormattedOutputWorksWithNoMeta()
     {
-        $talk = new Talk;
+        $talk      = new Talk;
         $formatter = new TalkFormatter();
 
         $format =$formatter->createdFormattedOutput($talk->first(), 1);
@@ -44,7 +44,7 @@ class TalkFormatterTest extends BaseTestCase
     public function createFormattedOutputWorksWithMeta()
     {
         $formatter = new TalkFormatter();
-        $talk = new Talk;
+        $talk      = new Talk;
 
         // Now to see if the meta gets put in correctly
         $secondFormat =$formatter->createdFormattedOutput($talk->first(), 2);
@@ -59,7 +59,7 @@ class TalkFormatterTest extends BaseTestCase
     public function formatListReturnsAllTalksAsCollection()
     {
         $formatter = new TalkFormatter();
-        $talks = Talk::all();
+        $talks     = Talk::all();
         $formatted = $formatter->formatList($talks, 2);
         $this->assertEquals(count($talks), count($formatted));
         $this->assertInstanceOf(Collection::class, $formatted);
@@ -71,12 +71,12 @@ class TalkFormatterTest extends BaseTestCase
 
         $talk->create(
             [
-                'user_id' => 1,
-                'title' => 'One talk to rule them all',
+                'user_id'     => 1,
+                'title'       => 'One talk to rule them all',
                 'description' => 'Two is fine too',
-                'type' => 'regular',
-                'level' => 'entry',
-                'category' => 'api',
+                'type'        => 'regular',
+                'level'       => 'entry',
+                'category'    => 'api',
             ]
         );
 
@@ -84,30 +84,30 @@ class TalkFormatterTest extends BaseTestCase
         $meta->create(
             [
                 'admin_user_id' => 2,
-                'rating' => 1,
-                'viewed' => 1,
-                'talk_id' => $talk->first()->id,
-                'created' => new \DateTime(),
+                'rating'        => 1,
+                'viewed'        => 1,
+                'talk_id'       => $talk->first()->id,
+                'created'       => new \DateTime(),
             ]
         );
         $talk->create(
             [
-                'user_id' => 8,
-                'title' => 'Extra Extra',
+                'user_id'     => 8,
+                'title'       => 'Extra Extra',
                 'description' => 'Talk',
-                'type' => 'regular',
-                'level' => 'entry',
-                'category' => 'api',
+                'type'        => 'regular',
+                'level'       => 'entry',
+                'category'    => 'api',
             ]
         );
         $talk->create(
             [
-                'user_id' => 8,
-                'title' => 'Third',
+                'user_id'     => 8,
+                'title'       => 'Third',
                 'description' => 'Talk',
-                'type' => 'regular',
-                'level' => 'entry',
-                'category' => 'api',
+                'type'        => 'regular',
+                'level'       => 'entry',
+                'category'    => 'api',
             ]
         );
     }

--- a/tests/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Domain/Speaker/SpeakerProfileTest.php
@@ -15,7 +15,7 @@ class SpeakerProfileTest extends \PHPUnit\Framework\TestCase
         $faker = $this->getFaker();
 
         $firstName = $faker->firstName;
-        $lastName = $faker->lastName;
+        $lastName  = $faker->lastName;
 
         $speaker = new Entity\User();
 
@@ -178,11 +178,11 @@ class SpeakerProfileTest extends \PHPUnit\Framework\TestCase
         $faker = $this->getFaker();
 
         $firstName = $faker->firstName;
-        $lastName = $faker->lastName;
-        $email = $faker->email;
-        $twitter = $faker->userName;
-        $url = $faker->url;
-        $bio = $faker->text();
+        $lastName  = $faker->lastName;
+        $email     = $faker->email;
+        $twitter   = $faker->userName;
+        $url       = $faker->url;
+        $bio       = $faker->text();
 
         $speaker = new Entity\User();
 
@@ -196,11 +196,11 @@ class SpeakerProfileTest extends \PHPUnit\Framework\TestCase
         $profile = new SpeakerProfile($speaker);
 
         $expected = [
-            'name' => $firstName . ' ' . $lastName,
-            'email' => $email,
+            'name'    => $firstName . ' ' . $lastName,
+            'email'   => $email,
             'twitter' => $twitter,
-            'url' => $url,
-            'bio' => $bio,
+            'url'     => $url,
+            'bio'     => $bio,
         ];
 
         $this->assertSame($expected, $profile->toArrayForApi());

--- a/tests/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/Domain/Talk/TalkSubmissionTest.php
@@ -14,11 +14,11 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
         // represents the TalkSubmission only.
 
         $submission = TalkSubmission::fromNative([
-            'title' => 'Happy Path Submission',
+            'title'       => 'Happy Path Submission',
             'description' => 'I play by the rules.',
-            'type' => 'regular',
-            'level' => 'entry',
-            'category' => 'api',
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'api',
         ]);
 
         // Factory method for talk out of submission.
@@ -62,7 +62,7 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('description');
 
         TalkSubmission::fromNative([
-            'title' => 'Talk With No Description',
+            'title'       => 'Talk With No Description',
             'description' => '',
         ]);
     }
@@ -76,9 +76,9 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('talk type');
 
         TalkSubmission::fromNative([
-            'title' => 'Some off-the-wall Talk Type',
+            'title'       => 'Some off-the-wall Talk Type',
             'description' => 'I do not play by the rules.',
-            'type' => 'hamburger',
+            'type'        => 'hamburger',
         ]);
     }
 
@@ -91,10 +91,10 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('level');
 
         TalkSubmission::fromNative([
-            'title' => 'Invalid Skill Level Talk',
+            'title'       => 'Invalid Skill Level Talk',
             'description' => 'I do not play by the rules.',
-            'type' => 'regular',
-            'level' => 'over 9000',
+            'type'        => 'regular',
+            'level'       => 'over 9000',
         ]);
     }
 
@@ -107,11 +107,11 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('category');
 
         TalkSubmission::fromNative([
-            'title' => 'Invalid Categorized Talk',
+            'title'       => 'Invalid Categorized Talk',
             'description' => 'I do not play by the rules.',
-            'type' => 'regular',
-            'level' => 'entry',
-            'category' => 'skylanders',
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'skylanders',
         ]);
     }
 }

--- a/tests/Http/API/ProfileApiControllerTest.php
+++ b/tests/Http/API/ProfileApiControllerTest.php
@@ -26,7 +26,7 @@ class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->speakers = m::mock(\OpenCFP\Application\Speakers::class);
-        $this->sut = new ProfileController($this->speakers);
+        $this->sut      = new ProfileController($this->speakers);
     }
 
     /** @test */

--- a/tests/Http/API/TalkApiControllerTest.php
+++ b/tests/Http/API/TalkApiControllerTest.php
@@ -26,7 +26,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->speakers = m::mock(\OpenCFP\Application\Speakers::class);
-        $this->sut = new TalkController($this->speakers);
+        $this->sut      = new TalkController($this->speakers);
     }
 
     public function it_returns_created_response_when_talk_is_submitted()
@@ -37,7 +37,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
         // sane to test output of 201 Created response. Should be the talk
         // we submitted!
         $submission = TalkSubmission::fromNative($request->request->all());
-        $talk = $submission->toTalk();
+        $talk       = $submission->toTalk();
 
         $this->speakers->shouldReceive('submitTalk')
             ->once()
@@ -143,11 +143,11 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
     private function getValidRequest()
     {
         return $this->getRequest([
-            'title' => 'Happy Path Submission',
+            'title'       => 'Happy Path Submission',
             'description' => 'I play by the rules.',
-            'type' => 'regular',
-            'level' => 'entry',
-            'category' => 'api',
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'api',
         ]);
     }
 }

--- a/tests/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Http/Controller/Admin/DashboardControllerTest.php
@@ -72,16 +72,16 @@ class DashboardControllerTest extends WebTestCase
         $formatted = m::mock('overload:' . \OpenCFP\Domain\Talk\TalkFormatter::class);
         $formatted->shouldReceive('formatList')->andReturn([
             [
-                'id' => 1,
-                'title' => 'First Talk',
-                'type' => 'regular',
-                'category' => 'api',
+                'id'          => 1,
+                'title'       => 'First Talk',
+                'type'        => 'regular',
+                'category'    => 'api',
                 'description' => 'Talk is amazing',
-                'created_at' => new \DateTime(),
-                'user' => [
-                    'id' => 1,
+                'created_at'  => new \DateTime(),
+                'user'        => [
+                    'id'         => 1,
                     'first_name' => 'Speaker',
-                    'last_name' => 'Name',
+                    'last_name'  => 'Name',
                 ],
                 'meta' => [
                     'rating' => 0,
@@ -90,16 +90,16 @@ class DashboardControllerTest extends WebTestCase
                 'selected' => 0,
             ],
             [
-                'id' => 2,
-                'title' => 'The bug slayer strikes again!',
-                'type' => 'regular',
-                'category' => 'api',
+                'id'          => 2,
+                'title'       => 'The bug slayer strikes again!',
+                'type'        => 'regular',
+                'category'    => 'api',
                 'description' => 'Talk is amazing',
-                'created_at' => new \DateTime(),
-                'user' => [
-                    'id' => 1,
+                'created_at'  => new \DateTime(),
+                'user'        => [
+                    'id'         => 1,
                     'first_name' => 'Daan',
-                    'last_name' => 'The Bug Slayer',
+                    'last_name'  => 'The Bug Slayer',
                 ],
                 'meta' => [
                     'rating' => 0,

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -90,18 +90,18 @@ class DashboardControllerTest extends WebTestCase
         // We  have benefit of being able to stub an application
         // service for this.
         $profile = $this->stubProfileWith([
-            'getTalks' => [],
-            'getName' => $faker->name,
-            'getEmail' => $faker->companyEmail,
-            'getCompany' => $faker->company,
-            'getTwitter' => $faker->userName,
-            'getUrl' => $faker->url,
-            'getInfo' => $faker->text,
-            'getBio' => $faker->text,
+            'getTalks'          => [],
+            'getName'           => $faker->name,
+            'getEmail'          => $faker->companyEmail,
+            'getCompany'        => $faker->company,
+            'getTwitter'        => $faker->userName,
+            'getUrl'            => $faker->url,
+            'getInfo'           => $faker->text,
+            'getBio'            => $faker->text,
             'getTransportation' => true,
-            'getHotel' => true,
-            'getAirport' => 'RDU',
-            'getPhoto' => '',
+            'getHotel'          => true,
+            'getAirport'        => 'RDU',
+            'getPhoto'          => '',
         ]);
 
         $speakersDouble = m::mock(\OpenCFP\Application\Speakers::class)

--- a/tests/Http/Controller/ForgotControllerTest.php
+++ b/tests/Http/Controller/ForgotControllerTest.php
@@ -20,7 +20,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
 
     public function setup()
     {
-        $this->app = new Application(BASE_PATH, Environment::testing());
+        $this->app                 = new Application(BASE_PATH, Environment::testing());
         $this->app['session.test'] = true;
         ob_start();
         $this->app->run();
@@ -73,7 +73,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         $form_factory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('valid'));
         $this->app['form.factory'] = $form_factory;
 
-        $req = m::mock(\Symfony\Component\HttpFoundation\Request::class);
+        $req        = m::mock(\Symfony\Component\HttpFoundation\Request::class);
         $controller = new \OpenCFP\Http\Controller\ForgotController();
         $controller->setApplication($this->app);
         $controller->sendResetAction($req);
@@ -95,7 +95,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         $form_factory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('not valid'));
         $this->app['form.factory'] = $form_factory;
 
-        $req = m::mock(\Symfony\Component\HttpFoundation\Request::class);
+        $req        = m::mock(\Symfony\Component\HttpFoundation\Request::class);
         $controller = new \OpenCFP\Http\Controller\ForgotController();
         $controller->setApplication($this->app);
         $controller->sendResetAction($req);
@@ -116,7 +116,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         $form_factory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('valid'));
         $this->app['form.factory'] = $form_factory;
 
-        $req = m::mock(\Symfony\Component\HttpFoundation\Request::class);
+        $req        = m::mock(\Symfony\Component\HttpFoundation\Request::class);
         $controller = new \OpenCFP\Http\Controller\ForgotController();
         $controller->setApplication($this->app);
         $controller->sendResetAction($req);
@@ -147,7 +147,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         $form_factory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('valid'));
         $this->app['form.factory'] = $form_factory;
 
-        $req = m::mock(\Symfony\Component\HttpFoundation\Request::class);
+        $req        = m::mock(\Symfony\Component\HttpFoundation\Request::class);
         $controller = new \OpenCFP\Http\Controller\ForgotController();
         $controller->setApplication($this->app);
         $controller->sendResetAction($req);
@@ -172,7 +172,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
     private function createForm($valid_status)
     {
         $is_valid = ($valid_status == 'valid');
-        $form = m::mock(\OpenCFP\Http\Form\ForgotForm::class);
+        $form     = m::mock(\OpenCFP\Http\Form\ForgotForm::class);
         $form->shouldReceive('handleRequest');
         $form->shouldReceive('isValid')->andReturn($is_valid);
         $data = ['email' => 'test@opencfp.org'];

--- a/tests/Http/Controller/ProfileControllerTest.php
+++ b/tests/Http/Controller/ProfileControllerTest.php
@@ -103,10 +103,10 @@ class ProfileControllerTest extends WebTestCase
     private function putUserInRequest($isEmailValid, $id = 1): array
     {
         return [
-            'id' => $id,
-            'email' => $isEmailValid ? 'valideamial@cfp.org' : 'invalidEmail',
+            'id'         => $id,
+            'email'      => $isEmailValid ? 'valideamial@cfp.org' : 'invalidEmail',
             'first_name' => 'First',
-            'last_name' => 'Last',
+            'last_name'  => 'Last',
         ];
     }
 }

--- a/tests/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Http/Controller/Reviewer/TalksControllerTest.php
@@ -86,8 +86,8 @@ class TalksControllerTest extends WebTestCase
     protected function makeTalks()
     {
         $formatter = new TalkFormatter();
-        $toReturn = $formatter->formatList(self::$talks, 1);
-        $filter = Mockery::mock(TalkFilter::class);
+        $toReturn  = $formatter->formatList(self::$talks, 1);
+        $filter    = Mockery::mock(TalkFilter::class);
         $filter->shouldReceive('getFilteredTalks')->andReturn($toReturn->toArray());
         $this->swap(TalkFilter::class, $filter);
     }

--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -64,38 +64,38 @@ class SignupControllerTest extends WebTestCase
         $app->shouldReceive('offsetGet')->with('session')->andReturn(new Session(new MockFileSessionStorage()));
 
         // Create our URL generator
-        $url = 'http://opencfp/signup';
+        $url           = 'http://opencfp/signup';
         $url_generator = m::mock(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class);
         $url_generator->shouldReceive('generate')->andReturn($url);
         $app->shouldReceive('offsetGet')->with('url_generator')->andReturn($url_generator);
 
         // We need to set up our speaker information
         $form_data = [
-            'formAction' => $url,
-            'first_name' => 'Testy',
-            'last_name' => 'McTesterton',
-            'email' => 'test@opencfp.org',
-            'company' => null,
-            'twitter' => null,
-            'url' => 'https://joind.in/user/abc123',
-            'password' => 'wutwut',
-            'password2' => 'wutwut',
-            'airport' => null,
-            'speaker_info' => null,
-            'speaker_bio' => null,
+            'formAction'     => $url,
+            'first_name'     => 'Testy',
+            'last_name'      => 'McTesterton',
+            'email'          => 'test@opencfp.org',
+            'company'        => null,
+            'twitter'        => null,
+            'url'            => 'https://joind.in/user/abc123',
+            'password'       => 'wutwut',
+            'password2'      => 'wutwut',
+            'airport'        => null,
+            'speaker_info'   => null,
+            'speaker_bio'    => null,
             'transportation' => null,
-            'hotel' => null,
-            'buttonInfo' => 'Create my speaker profile',
-            'agree_coc' => null,
+            'hotel'          => null,
+            'buttonInfo'     => 'Create my speaker profile',
+            'agree_coc'      => null,
         ];
 
         // Set our HTMLPurifier we use for validation
-        $config = HTMLPurifier_Config::createDefault();
+        $config   = HTMLPurifier_Config::createDefault();
         $purifier = new HTMLPurifier($config);
         $app->shouldReceive('offsetGet')->with('purifier')->andReturn($purifier);
         $app->shouldReceive('config')->with('application.coc_link')->andReturn(null);
 
-        $user = m::mock(UserInterface::class);
+        $user     = m::mock(UserInterface::class);
         $user->id = 1;
 
         $auth = m::mock(Authentication::class);
@@ -109,7 +109,7 @@ class SignupControllerTest extends WebTestCase
 
         // Create an instance of our database
         $speaker = new \stdClass;
-        $mapper = m::mock(\stdClass::class);
+        $mapper  = m::mock(\stdClass::class);
         $mapper->shouldReceive('get')->andReturn($speaker);
         $mapper->shouldReceive('save');
         $spot = m::mock(Locator::class);
@@ -117,9 +117,9 @@ class SignupControllerTest extends WebTestCase
         $app->shouldReceive('offsetGet')->with('spot')->andReturn($spot);
 
         $request = Request::create('/signup', 'POST', [
-            'email' => 'test@example.com',
+            'email'    => 'test@example.com',
             'password' => 'pa$$w3rd',
-            'coc' => '1',
+            'coc'      => '1',
         ]);
 
         $requestStack = m::mock(\stdClass::class);
@@ -163,38 +163,38 @@ class SignupControllerTest extends WebTestCase
         $app->shouldReceive('offsetGet')->with('session')->andReturn(new Session(new MockFileSessionStorage()));
 
         // Create our URL generator
-        $url = 'http://opencfp/signup';
+        $url           = 'http://opencfp/signup';
         $url_generator = m::mock(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class);
         $url_generator->shouldReceive('generate')->andReturn($url);
         $app->shouldReceive('offsetGet')->with('url_generator')->andReturn($url_generator);
 
         // We need to set up our speaker information
         $form_data = [
-            'formAction' => 'http://opencfp/signup',
-            'first_name' => 'Testy',
-            'last_name' => 'McTesterton',
-            'email' => 'test@opencfp.org',
-            'company' => null,
-            'twitter' => null,
-            'url' => '',
-            'password' => 'wutwut',
-            'password2' => 'wutwut',
-            'airport' => null,
-            'speaker_info' => null,
-            'speaker_bio' => null,
+            'formAction'     => 'http://opencfp/signup',
+            'first_name'     => 'Testy',
+            'last_name'      => 'McTesterton',
+            'email'          => 'test@opencfp.org',
+            'company'        => null,
+            'twitter'        => null,
+            'url'            => '',
+            'password'       => 'wutwut',
+            'password2'      => 'wutwut',
+            'airport'        => null,
+            'speaker_info'   => null,
+            'speaker_bio'    => null,
             'transportation' => null,
-            'hotel' => null,
-            'buttonInfo' => 'Create my speaker profile',
-            'agree_coc' => null,
+            'hotel'          => null,
+            'buttonInfo'     => 'Create my speaker profile',
+            'agree_coc'      => null,
         ];
 
         // Set our HTMLPurifier we use for validation
-        $config = HTMLPurifier_Config::createDefault();
+        $config   = HTMLPurifier_Config::createDefault();
         $purifier = new HTMLPurifier($config);
         $app->shouldReceive('offsetGet')->with('purifier')->andReturn($purifier);
         $app->shouldReceive('config')->with('application.coc_link')->andReturn(null);
 
-        $user = m::mock(UserInterface::class);
+        $user     = m::mock(UserInterface::class);
         $user->id = 1;
 
         $accounts = m::mock(AccountManagement::class);
@@ -209,7 +209,7 @@ class SignupControllerTest extends WebTestCase
 
         // Create an instance of our database
         $speaker = new \stdClass;
-        $mapper = m::mock(\stdClass::class);
+        $mapper  = m::mock(\stdClass::class);
         $mapper->shouldReceive('get')->andReturn($speaker);
         $mapper->shouldReceive('save');
         $spot = m::mock(Locator::class);
@@ -217,9 +217,9 @@ class SignupControllerTest extends WebTestCase
         $app->shouldReceive('offsetGet')->with('spot')->andReturn($spot);
 
         $request = Request::create('/signup', 'POST', [
-            'email' => 'test@example.com',
+            'email'    => 'test@example.com',
             'password' => 'pa$$w3rd',
-            'coc' => '1',
+            'coc'      => '1',
         ]);
 
         $requestStack = m::mock(\stdClass::class);
@@ -263,38 +263,38 @@ class SignupControllerTest extends WebTestCase
         $app->shouldReceive('offsetGet')->with('session')->andReturn(new Session(new MockFileSessionStorage()));
 
         // Create our URL generator
-        $url = 'http://opencfp/signup';
+        $url           = 'http://opencfp/signup';
         $url_generator = m::mock(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class);
         $url_generator->shouldReceive('generate')->andReturn($url);
         $app->shouldReceive('offsetGet')->with('url_generator')->andReturn($url_generator);
 
         // We need to set up our speaker information
         $form_data = [
-            'formAction' => $url,
-            'first_name' => 'Testy',
-            'last_name' => 'McTesterton',
-            'email' => 'test@opencfp.org',
-            'company' => null,
-            'twitter' => null,
-            'url' => 'https://joind.in/user/abc123',
-            'password' => 'wutwut',
-            'password2' => 'wutwut',
-            'airport' => null,
-            'speaker_info' => null,
-            'speaker_bio' => null,
+            'formAction'     => $url,
+            'first_name'     => 'Testy',
+            'last_name'      => 'McTesterton',
+            'email'          => 'test@opencfp.org',
+            'company'        => null,
+            'twitter'        => null,
+            'url'            => 'https://joind.in/user/abc123',
+            'password'       => 'wutwut',
+            'password2'      => 'wutwut',
+            'airport'        => null,
+            'speaker_info'   => null,
+            'speaker_bio'    => null,
             'transportation' => null,
-            'hotel' => null,
-            'buttonInfo' => 'Create my speaker profile',
-            'agree_coc' => 'agreed',
+            'hotel'          => null,
+            'buttonInfo'     => 'Create my speaker profile',
+            'agree_coc'      => 'agreed',
         ];
 
         // Set our HTMLPurifier we use for validation
-        $config = HTMLPurifier_Config::createDefault();
+        $config   = HTMLPurifier_Config::createDefault();
         $purifier = new HTMLPurifier($config);
         $app->shouldReceive('offsetGet')->with('purifier')->andReturn($purifier);
         $app->shouldReceive('config')->with('application.coc_link')->andReturn('http://www.google.com');
 
-        $user = m::mock(UserInterface::class);
+        $user     = m::mock(UserInterface::class);
         $user->id = 1;
 
         $accounts = m::mock(AccountManagement::class);
@@ -304,7 +304,7 @@ class SignupControllerTest extends WebTestCase
 
         // Create an instance of our database
         $speaker = new \stdClass;
-        $mapper = m::mock(\stdClass::class);
+        $mapper  = m::mock(\stdClass::class);
         $mapper->shouldReceive('get')->andReturn($speaker);
         $mapper->shouldReceive('save');
         $spot = m::mock(Locator::class);
@@ -317,9 +317,9 @@ class SignupControllerTest extends WebTestCase
         $app->shouldReceive('offsetGet')->with(Authentication::class)->andReturn($auth);
 
         $request = Request::create('/signup', 'POST', [
-            'email' => 'test@example.com',
+            'email'    => 'test@example.com',
             'password' => 'pa$$w3rd',
-            'coc' => '1',
+            'coc'      => '1',
         ]);
 
         $requestStack = m::mock(\stdClass::class);

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -24,7 +24,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->app = new Application(BASE_PATH, Environment::testing());
+        $this->app                 = new Application(BASE_PATH, Environment::testing());
         $this->app['session.test'] = true;
         ob_start();
         $this->app->run();
@@ -97,16 +97,16 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
 
         // Get our request object to return expected data
         $talk_data = [
-            'title' => 'Test Title With Ampersand',
+            'title'       => 'Test Title With Ampersand',
             'description' => 'The title should contain this & that',
-            'type' => 'regular',
-            'level' => 'entry',
-            'category' => 'other',
-            'desired' => 0,
-            'slides' => '',
-            'other' => '',
-            'sponsor' => '',
-            'user_id' => $auth->user()->getId(),
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'other',
+            'desired'     => 0,
+            'slides'      => '',
+            'other'       => '',
+            'sponsor'     => '',
+            'user_id'     => $auth->user()->getId(),
         ];
 
         $this->setPost($talk_data);
@@ -147,16 +147,16 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
 
         // Get our request object to return expected data
         $talk_data = [
-            'title' => 'Test Submission',
+            'title'       => 'Test Submission',
             'description' => 'Make sure we can submit before end and not after.',
-            'type' => 'regular',
-            'level' => 'entry',
-            'category' => 'other',
-            'desired' => 0,
-            'slides' => '',
-            'other' => '',
-            'sponsor' => '',
-            'user_id' => $auth->user()->getId(),
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'other',
+            'desired'     => 0,
+            'slides'      => '',
+            'other'       => '',
+            'sponsor'     => '',
+            'user_id'     => $auth->user()->getId(),
         ];
 
         $this->setPost($talk_data);
@@ -206,16 +206,16 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
 
         // Get our request object to return expected data
         $talk_data = [
-            'title' => 'Test Submission',
+            'title'       => 'Test Submission',
             'description' => 'Make sure we can see our own talk.',
-            'type' => 'regular',
-            'level' => 'entry',
-            'category' => 'other',
-            'desired' => 0,
-            'slides' => '',
-            'other' => '',
-            'sponsor' => '',
-            'user_id' => $auth->user()->getId(),
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'other',
+            'desired'     => 0,
+            'slides'      => '',
+            'other'       => '',
+            'sponsor'     => '',
+            'user_id'     => $auth->user()->getId(),
         ];
 
         $this->setPost($talk_data);
@@ -248,7 +248,7 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         $callForProposal = m::mock(CallForProposal::class);
         $callForProposal->shouldReceive('isOpen')->andReturn(false);
         $this->app['callforproposal'] = $callForProposal;
-        $response = $controller->editAction($this->req);
+        $response                     = $controller->editAction($this->req);
 
         $flashMessage = $this->app['session']->get('flash');
 
@@ -324,16 +324,16 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         $this->app['spot']->shouldReceive('first')->andReturn($this->app['spot']);
         $this->app['spot']->shouldReceive('toArray')->andReturn(
             [
-                'user_id' => (int) $this->app[Authentication::class]->user()->getId(),
-                'title' => 'Title of talk to edit',
+                'user_id'     => (int) $this->app[Authentication::class]->user()->getId(),
+                'title'       => 'Title of talk to edit',
                 'description' => 'The Description',
-                'type' => 'regular',
-                'level' => 'entry',
-                'category' => 'other',
-                'desired' => 0,
-                'slides' => '',
-                'other' => '',
-                'sponsor' => '',
+                'type'        => 'regular',
+                'level'       => 'entry',
+                'category'    => 'other',
+                'desired'     => 0,
+                'slides'      => '',
+                'other'       => '',
+                'sponsor'     => '',
             ]
         );
 
@@ -357,17 +357,17 @@ class TalkControllerTest extends \PHPUnit\Framework\TestCase
         $controller->setApplication($this->app);
 
         $talk_data = [
-            'id' => 3,
-            'title' => '',
+            'id'          => 3,
+            'title'       => '',
             'description' => 'This talk is missing its title',
-            'type' => 'regular',
-            'level' => 'entry',
-            'category' => 'other',
-            'desired' => 0,
-            'slides' => '',
-            'other' => '',
-            'sponsor' => '',
-            'user_id' => $this->app[Authentication::class]->user()->getId(),
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'other',
+            'desired'     => 0,
+            'slides'      => '',
+            'other'       => '',
+            'sponsor'     => '',
+            'user_id'     => $this->app[Authentication::class]->user()->getId(),
         ];
 
         $this->setPost($talk_data);

--- a/tests/Http/Form/SignupFormTest.php
+++ b/tests/Http/Form/SignupFormTest.php
@@ -41,10 +41,10 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function formRejectsValidationOnMissingFields()
     {
         $data = [
-            'email' => 'test@domain.com',
+            'email'       => 'test@domain.com',
             'notrequired' => 'test',
         ];
-        $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
+        $form     = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $response = $form->hasRequiredFields();
         $this->assertFalse($response);
     }
@@ -128,7 +128,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function properPasswordsPassValidationAndSanitization($passwd)
     {
         $data = [
-            'password' => $passwd,
+            'password'  => $passwd,
             'password2' => $passwd,
         ];
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
@@ -154,7 +154,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function badPasswordsAreBeingCorrectlyDetected($passwd, $passwd2, $expectedMessage, $expectedResponse)
     {
         $data = [
-            'password' => $passwd,
+            'password'  => $passwd,
             'password2' => $passwd2,
         ];
 
@@ -197,7 +197,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function firstNameIsValidatedCorrectly($firstName, $expectedResponse)
     {
         $data['first_name'] = $firstName;
-        $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
+        $form               = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
 
         $this->assertEquals(
@@ -241,7 +241,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function lastNameIsValidatedCorrectly($lastName, $expectedResponse)
     {
         $data['last_name'] = $lastName;
-        $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
+        $form              = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
 
         $this->assertEquals(
@@ -301,14 +301,14 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function validateAllProvider()
     {
         $baseData = [
-            'email' => 'test@domain.com',
-            'password' => 'xxxxxx',
-            'password2' => 'xxxxxx',
+            'email'      => 'test@domain.com',
+            'password'   => 'xxxxxx',
+            'password2'  => 'xxxxxx',
             'first_name' => 'Tésty',
-            'last_name' => 'McTestèrton',
-            'url' => 'https://joind.in/user/abc123',
+            'last_name'  => 'McTestèrton',
+            'url'        => 'https://joind.in/user/abc123',
         ];
-        $baseDataWithSpeakerInfo = $baseData;
+        $baseDataWithSpeakerInfo                 = $baseData;
         $baseDataWithSpeakerInfo['speaker_info'] = 'Testing speaker info data';
 
         return [
@@ -329,7 +329,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function speakerInfoValidatedCorrectly($speakerInfo, $expectedResponse)
     {
         $data['speaker_info'] = $speakerInfo;
-        $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
+        $form                 = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
 
         $this->assertEquals(
@@ -351,7 +351,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function speakerBioValidatedCorrectly($speakerBio, $expectedResponse)
     {
         $data['speaker_bio'] = $speakerBio;
-        $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
+        $form                = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
         $this->assertEquals(
             $expectedResponse,
@@ -402,55 +402,55 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function sanitizationProvider()
     {
         $badDataIn = [
-            'email' => 'test@domain.com',
-            'password' => 'xxxxxx',
-            'password2' => 'xxxxxx',
+            'email'      => 'test@domain.com',
+            'password'   => 'xxxxxx',
+            'password2'  => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => "<script>alert('XSS')</script>",
+            'last_name'  => "<script>alert('XSS')</script>",
         ];
 
         $badDataOut = [
-            'email' => 'test@domain.com',
-            'password' => 'xxxxxx',
-            'password2' => 'xxxxxx',
+            'email'      => 'test@domain.com',
+            'password'   => 'xxxxxx',
+            'password2'  => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => '',
+            'last_name'  => '',
         ];
 
         $goodDataIn = [
-            'email' => 'test@domain.com',
-            'password' => 'xxxxxx',
-            'password2' => 'xxxxxx',
+            'email'      => 'test@domain.com',
+            'password'   => 'xxxxxx',
+            'password2'  => 'xxxxxx',
             'first_name' => 'Testy',
-            'last_name' => 'McTesterton',
+            'last_name'  => 'McTesterton',
         ];
 
         $goodDataOut = $goodDataIn;
 
         $badSpeakerInfoIn = [
-            'email' => 'test@domain.com',
-            'password' => 'xxxxxx',
-            'password2' => 'xxxxxx',
-            'first_name' => 'Testy',
-            'last_name' => 'McTesterton',
+            'email'        => 'test@domain.com',
+            'password'     => 'xxxxxx',
+            'password2'    => 'xxxxxx',
+            'first_name'   => 'Testy',
+            'last_name'    => 'McTesterton',
             'speaker_info' => '<a href="http://lolcoin.com/redeem">Speaker bio</a>',
         ];
 
         $badSpeakerInfoOut = [
-            'email' => 'test@domain.com',
-            'password' => 'xxxxxx',
-            'password2' => 'xxxxxx',
-            'first_name' => 'Testy',
-            'last_name' => 'McTesterton',
+            'email'        => 'test@domain.com',
+            'password'     => 'xxxxxx',
+            'password2'    => 'xxxxxx',
+            'first_name'   => 'Testy',
+            'last_name'    => 'McTesterton',
             'speaker_info' => '<a href="http://lolcoin.com/redeem">Speaker bio</a>',
         ];
 
         $goodSpeakerInfoIn = [
-            'email' => 'test@domain.com',
-            'password' => 'xxxxxx',
-            'password2' => 'xxxxxx',
-            'first_name' => 'Testy',
-            'last_name' => 'McTesterton',
+            'email'        => 'test@domain.com',
+            'password'     => 'xxxxxx',
+            'password2'    => 'xxxxxx',
+            'first_name'   => 'Testy',
+            'last_name'    => 'McTesterton',
             'speaker_info' => 'Find my bio at http://littlehart.net',
         ];
 

--- a/tests/Http/Form/TalkFormTest.php
+++ b/tests/Http/Form/TalkFormTest.php
@@ -48,22 +48,22 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
     public function hasRequiredProvider()
     {
         $badData = [
-            'title' => 'Bad Data',
+            'title'       => 'Bad Data',
             'description' => 'Hey, why are we missing fields!',
         ];
         $goodData = [
-            'title' => 'Talk Title',
+            'title'       => 'Talk Title',
             'description' => 'Description of our talk',
-            'type' => 'session',
-            'category' => 'development',
-            'level' => 'entry',
-            'slides' => 'http://slideshare.net',
-            'other' => 'Misc comments',
-            'desired' => 1,
-            'sponsor' => 1,
-            'user_id' => 1,
+            'type'        => 'session',
+            'category'    => 'development',
+            'level'       => 'entry',
+            'slides'      => 'http://slideshare.net',
+            'other'       => 'Misc comments',
+            'desired'     => 1,
+            'sponsor'     => 1,
+            'user_id'     => 1,
         ];
-        $extendedData = $goodData;
+        $extendedData          = $goodData;
         $extendedData['extra'] = 'Extra data in $_POST but we ignore it';
 
         return [
@@ -105,14 +105,14 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
     public function hasNoDesiredOrSponsorProvider()
     {
         $goodData = [
-            'title' => 'Talk Title',
+            'title'       => 'Talk Title',
             'description' => 'Description of our talk',
-            'type' => 'session',
-            'category' => 'development',
-            'level' => 'entry',
-            'slides' => 'http://slideshare.net',
-            'other' => 'Misc comments',
-            'user_id' => 1,
+            'type'        => 'session',
+            'category'    => 'development',
+            'level'       => 'entry',
+            'slides'      => 'http://slideshare.net',
+            'other'       => 'Misc comments',
+            'user_id'     => 1,
         ];
 
         return [
@@ -302,7 +302,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
     {
         $validSpeakerInfo = [
             'user_id' => 1,
-            'info' => 'Special speaker info',
+            'info'    => 'Special speaker info',
         ];
 
         return [

--- a/tests/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -33,7 +33,7 @@ class SentryAccountManagementTest extends BaseTestCase
     {
         $this->sut->create('test@example.com', 'secret', [
             'first_name' => 'Test',
-            'last_name' => 'Account',
+            'last_name'  => 'Account',
         ]);
 
         $user = $this->sut->findByLogin('test@example.com');
@@ -46,7 +46,7 @@ class SentryAccountManagementTest extends BaseTestCase
     {
         $user = $this->sut->create('test@example.com', 'secret', [
             'first_name' => 'Test',
-            'last_name' => 'Account',
+            'last_name'  => 'Account',
         ]);
 
         $group = $user->getGroups()[0];
@@ -70,7 +70,7 @@ class SentryAccountManagementTest extends BaseTestCase
     {
         $this->sut->create('test@example.com', 'secret', [
             'first_name' => 'Test',
-            'last_name' => 'Account',
+            'last_name'  => 'Account',
         ]);
 
         $this->assertCount(0, $this->sut->findByRole('Admin'));

--- a/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -17,7 +17,7 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
 
     public function testImplementsIdentityProvider()
     {
-        $sentry = $this->getSentryMock();
+        $sentry            = $this->getSentryMock();
         $speakerRepository = $this->getSpeakerRepositoryMock();
 
         $provider = new SentryIdentityProvider(

--- a/tests/Infrastructure/Auth/SentryTestHelpers.php
+++ b/tests/Infrastructure/Auth/SentryTestHelpers.php
@@ -10,12 +10,12 @@ trait SentryTestHelpers
 {
     public function getSentry()
     {
-        $hasher = new \Cartalyst\Sentry\Hashing\NativeHasher;
-        $userProvider = new \Cartalyst\Sentry\Users\Eloquent\Provider($hasher);
-        $groupProvider = new \Cartalyst\Sentry\Groups\Eloquent\Provider;
+        $hasher           = new \Cartalyst\Sentry\Hashing\NativeHasher;
+        $userProvider     = new \Cartalyst\Sentry\Users\Eloquent\Provider($hasher);
+        $groupProvider    = new \Cartalyst\Sentry\Groups\Eloquent\Provider;
         $throttleProvider = new \Cartalyst\Sentry\Throttling\Eloquent\Provider($userProvider);
-        $session = new SymfonySentrySession(new Session(new MockFileSessionStorage()));
-        $cookie = new \Cartalyst\Sentry\Cookies\NativeCookie([]);
+        $session          = new SymfonySentrySession(new Session(new MockFileSessionStorage()));
+        $cookie           = new \Cartalyst\Sentry\Cookies\NativeCookie([]);
 
         $sentry = new \Cartalyst\Sentry\Sentry(
             $userProvider,

--- a/tests/Provider/SymfonySentrySessionTest.php
+++ b/tests/Provider/SymfonySentrySessionTest.php
@@ -28,7 +28,7 @@ class SymfonySentrySessionTest extends \PHPUnit\Framework\TestCase
 
     public function testPutSetsValue()
     {
-        $key = 'foo';
+        $key   = 'foo';
         $value = 'bar';
 
         $session = $this->getSessionMock();
@@ -52,7 +52,7 @@ class SymfonySentrySessionTest extends \PHPUnit\Framework\TestCase
 
     public function testGetReturnsValue()
     {
-        $key = 'foo';
+        $key   = 'foo';
         $value = 'bar';
 
         $session = $this->getSessionMock();

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -30,7 +30,7 @@ class TestResponse
     public function __construct(Application $app, Response $response)
     {
         $this->baseResponse = $response;
-        $this->app = $app;
+        $this->app          = $app;
     }
 
     public function assertSuccessful()
@@ -88,7 +88,7 @@ class TestResponse
     public function assertFlashContains($flash)
     {
         $fullFlash = $this->app['session']->get('flash');
-        $fullFlash= is_array($fullFlash) ? $fullFlash : [];
+        $fullFlash = is_array($fullFlash) ? $fullFlash : [];
         Assert::assertContains($flash, $fullFlash);
 
         return $this;

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -142,9 +142,9 @@ class WebTestCase extends BaseTestCase
 
     public function isOnlineConference(): self
     {
-        $config = $this->app['config'];
+        $config                                     = $this->app['config'];
         $config['application']['online_conference'] = true;
-        $this->app['config'] = $config;
+        $this->app['config']                        = $config;
         $this->app['twig']->addGlobal('site', $this->app->config('application'));
 
         return $this;

--- a/web/index.php
+++ b/web/index.php
@@ -5,7 +5,7 @@ require_once __DIR__.'/../vendor/autoload.php';
 use OpenCFP\Application;
 use OpenCFP\Environment;
 
-$basePath = realpath(dirname(__DIR__));
+$basePath    = realpath(dirname(__DIR__));
 $environment = Environment::fromEnvironmentVariable();
 
 $app = new Application($basePath, $environment);


### PR DESCRIPTION
This PR

* [x] enables and configures the `binary_operator_spaces` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**binary_operator_spaces** [`@Symfony`]
>
>Binary operators should be surrounded by space as configured.
>
>Configuration options:
>
>* `align_double_arrow` (`false`, `null`, `true`): (deprecated) Whether to apply, remove or ignore double arrows alignment; defaults to `false`
>* `align_equals` (`false`, `null`, `true`): (deprecated) Whether to apply, remove or ignore equals alignment; defaults to `false`
> * `default` (`'align'`, `'align_single_space'`, `'align_single_space_minimal'`, `'single_space'`, `null`): default fix strategy; defaults to `'single_space'`
> * `operators` (`array`): dictionary of binary operator => fix strategy values that differ from the default strategy; defaults to `[]`