### PR TITLE
Refactor: Talk controller to use Illuminate

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -16,6 +16,7 @@ use OpenCFP\Provider\ResetEmailerServiceProvider;
 use OpenCFP\Provider\SentryServiceProvider;
 use OpenCFP\Provider\SpotServiceProvider;
 use OpenCFP\Provider\TalkFilterProvider;
+use OpenCFP\Provider\TalkHelperProvider;
 use OpenCFP\Provider\TalkRatingProvider;
 use OpenCFP\Provider\TwigServiceProvider;
 use OpenCFP\Provider\YamlConfigDriver;
@@ -95,6 +96,7 @@ class Application extends SilexApplication
         $this->register(new SpotServiceProvider);
         $this->register(new ImageProcessorProvider);
         $this->register(new ResetEmailerServiceProvider());
+        $this->register(new TalkHelperProvider());
         $this->register(new TalkRatingProvider());
         $this->register(new TalkFilterProvider());
 

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -207,12 +207,6 @@ class TalkController extends BaseController
             'short' => 'Error',
             'ext' => implode('<br>', $form->getErrorMessages()),
         ]);
-
-        $this->service('session')->set('flash', [
-            'type' => 'error',
-            'short' => 'Error',
-            'ext' => implode('<br>', $form->getErrorMessages()),
-        ]);
         $data['flash'] = $this->service('session')->get('flash');
 
         return $this->render('talk/create.twig', $data);
@@ -220,6 +214,18 @@ class TalkController extends BaseController
 
     public function updateAction(Request $req)
     {
+        if (! $this->service('callforproposal')->isOpen()) {
+            $this->service('session')->set(
+                'flash',
+                [
+                    'type' => 'error',
+                    'short' => 'Read Only',
+                    'ext' => 'You cannot edit talks once the call for papers has ended', ]
+            );
+
+            return $this->app->redirect($this->url('talk_view', ['id' => $req->get('id')]));
+        }
+
         $user = $this->service(Authentication::class)->user();
 
         $request_data = [

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -21,67 +21,14 @@ class TalkController extends BaseController
      */
     private function getTalkForm($requestData): TalkForm
     {
-        $helper = $this->service(TalkHelper::class);
+        $helper  = $this->service(TalkHelper::class);
         $options = [
-            'categories' => $this->getTalkCategories(),
-            'levels'     => $this->getTalkLevels(),
-            'types'      => $this->getTalkTypes(),
+            'categories' => $helper->getTalkCategories(),
+            'levels'     => $helper->getTalkLevels(),
+            'types'      => $helper->getTalkTypes(),
         ];
 
         return new TalkForm($requestData, $this->service('purifier'), $options);
-    }
-    
-    private function getTalkCategories()
-    {
-        $categories = $this->app->config('talk.categories');
-        
-        if ($categories === null) {
-            $categories = [
-                'api'               => 'APIs (REST, SOAP, etc.)',
-                'continuousdelivery'=> 'Continuous Delivery',
-                'database'          => 'Database',
-                'development'       => 'Development',
-                'devops'            => 'Devops',
-                'framework'         => 'Framework',
-                'ibmi'              => 'IBMi',
-                'javascript'        => 'JavaScript',
-                'security'          => 'Security',
-                'testing'           => 'Testing',
-                'uiux'              => 'UI/UX',
-                'other'             => 'Other',
-            ];
-        }
-        
-        return $categories;
-    }
-
-    private function getTalkTypes()
-    {
-        $types = $this->app->config('talk.types');
-
-        if ($types === null) {
-            $types = [
-                'regular'  => 'Regular',
-                'tutorial' => 'Tutorial',
-            ];
-        }
-
-        return $types;
-    }
-
-    private function getTalkLevels()
-    {
-        $levels = $this->app->config('talk.levels');
-
-        if ($levels === null) {
-            $levels = [
-                'entry'    => 'Entry level',
-                'mid'      => 'Mid-level',
-                'advanced' => 'Advanced',
-            ];
-        }
-
-        return $levels;
     }
 
     /**
@@ -97,8 +44,8 @@ class TalkController extends BaseController
         $speakers = $this->service('application.speakers');
 
         try {
-            $id   = filter_var($req->get('id'), FILTER_VALIDATE_INT);
-            $talk = $speakers->getTalk($id);
+            $talkId   = (int) $req->get('id');
+            $talk     = $speakers->getTalk($talkId);
         } catch (NotAuthorizedException $e) {
             return $this->redirectTo('dashboard');
         }
@@ -108,9 +55,7 @@ class TalkController extends BaseController
 
     public function editAction(Request $req)
     {
-        $id      = $req->get('id');
-        $talk_id = filter_var($id, FILTER_VALIDATE_INT);
-
+        $talkId      = (int) $req->get('id');
         // You can only edit talks while the CfP is open
         // This will redirect to "view" the talk in a read-only template
         if (! $this->service('callforproposal')->isOpen()) {
@@ -137,21 +82,21 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
         $helper = $this->service(TalkHelper::class);
-        $data = [
+        $data   = [
             'formAction'     => $this->url('talk_update'),
-            'talkCategories' => $this->getTalkCategories(),
-            'talkTypes'      => $this->getTalkTypes(),
-            'talkLevels'     => $this->getTalkLevels(),
-            'id'             => $talk_id,
-            'title'          => html_entity_decode($talk_info['title']),
-            'description'    => html_entity_decode($talk_info['description']),
-            'type'           => $talk_info['type'],
-            'level'          => $talk_info['level'],
-            'category'       => $talk_info['category'],
-            'desired'        => $talk_info['desired'],
-            'slides'         => $talk_info['slides'],
-            'other'          => $talk_info['other'],
-            'sponsor'        => $talk_info['sponsor'],
+            'talkCategories' => $helper->getTalkCategories(),
+            'talkTypes'      => $helper->getTalkTypes(),
+            'talkLevels'     => $helper->getTalkLevels(),
+            'id'             => $talkId,
+            'title'          => html_entity_decode($talk['title']),
+            'description'    => html_entity_decode($talk['description']),
+            'type'           => $talk['type'],
+            'level'          => $talk['level'],
+            'category'       => $talk['category'],
+            'desired'        => $talk['desired'],
+            'slides'         => $talk['slides'],
+            'other'          => $talk['other'],
+            'sponsor'        => $talk['sponsor'],
             'buttonInfo'     => 'Update my talk!',
         ];
 
@@ -177,9 +122,9 @@ class TalkController extends BaseController
 
         $data = [
             'formAction'     => $this->url('talk_create'),
-            'talkCategories' => $this->getTalkCategories(),
-            'talkTypes'      => $this->getTalkTypes(),
-            'talkLevels'     => $this->getTalkLevels(),
+            'talkCategories' => $helper->getTalkCategories(),
+            'talkTypes'      => $helper->getTalkTypes(),
+            'talkLevels'     => $helper->getTalkLevels(),
             'title'          => $req->get('title'),
             'description'    => $req->get('description'),
             'type'           => $req->get('type'),
@@ -229,9 +174,9 @@ class TalkController extends BaseController
         $form->sanitize();
 
         if ($form->validateAll()) {
-            $sanitizedData = $form->getCleanData();
+            $sanitizedData            = $form->getCleanData();
             $sanitizedData['user_id'] =  (int) $user->getId();
-            $talk = Talk::create($sanitizedData);
+            $talk                     = Talk::create($sanitizedData);
 
             $this->service('session')->set('flash', [
                 'type'  => 'success',
@@ -248,9 +193,9 @@ class TalkController extends BaseController
 
         $data = [
             'formAction'     => $this->url('talk_create'),
-            'talkCategories' => $this->getTalkCategories(),
-            'talkTypes'      => $this->getTalkTypes(),
-            'talkLevels'     => $this->getTalkLevels(),
+            'talkCategories' => $helper->getTalkCategories(),
+            'talkTypes'      => $helper->getTalkTypes(),
+            'talkLevels'     => $helper->getTalkLevels(),
             'title'          => $req->get('title'),
             'description'    => $req->get('description'),
             'type'           => $req->get('type'),
@@ -279,9 +224,9 @@ class TalkController extends BaseController
             $this->service('session')->set(
                 'flash',
                 [
-                    'type' => 'error',
+                    'type'  => 'error',
                     'short' => 'Read Only',
-                    'ext' => 'You cannot edit talks once the call for papers has ended', ]
+                    'ext'   => 'You cannot edit talks once the call for papers has ended', ]
             );
 
             return $this->app->redirect($this->url('talk_view', ['id' => $req->get('id')]));
@@ -307,14 +252,14 @@ class TalkController extends BaseController
         $form->sanitize();
 
         if ($form->validateAll()) {
-            $sanitizedData = $form->getCleanData();
+            $sanitizedData            = $form->getCleanData();
             $sanitizedData['user_id'] =(int) $user->getId();
             
             if (Talk::find((int) $sanitizedData['id'])->update($sanitizedData)) {
                 $this->service('session')->set('flash', [
-                    'type' => 'success',
+                    'type'  => 'success',
                     'short' => 'Success',
-                    'ext' => 'Successfully saved talk.',
+                    'ext'   => 'Successfully saved talk.',
                 ]);
 
                 // send email to speaker showing submission
@@ -328,9 +273,9 @@ class TalkController extends BaseController
 
         $data = [
             'formAction'     => $this->url('talk_update'),
-            'talkCategories' => $this->getTalkCategories(),
-            'talkTypes'      => $this->getTalkTypes(),
-            'talkLevels'     => $this->getTalkLevels(),
+            'talkCategories' => $helper->getTalkCategories(),
+            'talkTypes'      => $helper->getTalkTypes(),
+            'talkLevels'     => $helper->getTalkLevels(),
             'id'             => $req->get('id'),
             'title'          => $req->get('title'),
             'description'    => $req->get('description'),
@@ -399,7 +344,7 @@ class TalkController extends BaseController
         ];
 
         try {
-            $mailer = $this->service('mailer');
+            $mailer  = $this->service('mailer');
             $message = new Swift_Message();
 
             $message->setTo($email);

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -4,102 +4,40 @@ namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Application\NotAuthorizedException;
 use OpenCFP\Application\Speakers;
+use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Http\Form\TalkForm;
-use Silex\Application;
-use Spot\Locator;
+use OpenCFP\Http\View\TalkHelper;
 use Swift_Message;
 use Symfony\Component\HttpFoundation\Request;
 use Twig_Environment;
 
 class TalkController extends BaseController
 {
-    use FlashableTrait;
-
     /**
-     * @param $request_data
+     * @param $requestData
      *
      * @return TalkForm
      */
-    private function getTalkForm($request_data)
+    private function getTalkForm($requestData): TalkForm
     {
+        $helper = $this->service(TalkHelper::class);
         $options = [
-            'categories' => $this->getTalkCategories(),
-            'levels' => $this->getTalkLevels(),
-            'types' => $this->getTalkTypes(),
+            'categories' => $helper->getTalkCategories(),
+            'levels' => $helper->getTalkLevels(),
+            'types' => $helper->getTalkTypes(),
         ];
-        $form = new TalkForm($request_data, $this->service('purifier'), $options);
 
-        return $form;
-    }
-    
-    private function getTalkCategories()
-    {
-        $categories = $this->app->config('talk.categories');
-        
-        if ($categories === null) {
-            $categories = [
-                'api' => 'APIs (REST, SOAP, etc.)',
-                'continuousdelivery'=> 'Continuous Delivery',
-                'database'=> 'Database',
-                'development'=> 'Development',
-                'devops' => 'Devops',
-                'framework' => 'Framework',
-                'ibmi' => 'IBMi',
-                'javascript' => 'JavaScript',
-                'security' => 'Security',
-                'testing' => 'Testing',
-                'uiux' => 'UI/UX',
-                'other' => 'Other',
-            ];
-        }
-        
-        return $categories;
+        return new TalkForm($requestData, $this->service('purifier'), $options);
     }
 
-    private function getTalkTypes()
-    {
-        $types = $this->app->config('talk.types');
-
-        if ($types === null) {
-            $types = [
-                'regular' => 'Regular',
-                'tutorial' => 'Tutorial',
-            ];
-        }
-
-        return $types;
-    }
-
-    private function getTalkLevels()
-    {
-        $levels = $this->app->config('talk.levels');
-
-        if ($levels === null) {
-            $levels = [
-                'entry' => 'Entry level',
-                'mid' => 'Mid-level',
-                'advanced' => 'Advanced',
-            ];
-        }
-
-        return $levels;
-    }
-
-    /**
-     * Controller action for viewing a specific talk
-     *
-     * @param Request $req
-     *
-     * @return mixed
-     */
     public function viewAction(Request $req)
     {
         /* @var Speakers $speakers */
         $speakers = $this->service('application.speakers');
 
         try {
-            $id = filter_var($req->get('id'), FILTER_VALIDATE_INT);
+            $id = (int) $req->get('id');
             $talk = $speakers->getTalk($id);
         } catch (NotAuthorizedException $e) {
             return $this->redirectTo('dashboard');
@@ -108,17 +46,9 @@ class TalkController extends BaseController
         return $this->render('talk/view.twig', compact('id', 'talk'));
     }
 
-    /**
-     * Controller action for displaying the form to edit an existing talk
-     *
-     * @param Request $req
-     *
-     * @return mixed
-     */
     public function editAction(Request $req)
     {
-        $id = $req->get('id');
-        $talk_id = filter_var($id, FILTER_VALIDATE_INT);
+        $talk_id = (int) $req->get('id');
 
         // You can only edit talks while the CfP is open
         // This will redirect to "view" the talk in a read-only template
@@ -138,23 +68,19 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $user = $this->service(Authentication::class)->user();
+        $userId = $this->service(Authentication::class)->userId();
 
-        /* @var Locator $spot */
-        $spot = $this->service('spot');
+        $talk_info = Talk::find($talk_id);
 
-        $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $talk_info = $talk_mapper->where(['id' => $talk_id])->execute()->first()->toArray();
-
-        if ($talk_info['user_id'] !== (int) $user->getId()) {
+        if (!$talk_info instanceof Talk || (int) $talk_info['user_id'] !== $userId) {
             return $this->redirectTo('dashboard');
         }
-
+        $helper = $this->service(TalkHelper::class);
         $data = [
             'formAction' => $this->url('talk_update'),
-            'talkCategories' => $this->getTalkCategories(),
-            'talkTypes' => $this->getTalkTypes(),
-            'talkLevels' => $this->getTalkLevels(),
+            'talkCategories' => $helper->getTalkCategories(),
+            'talkTypes' => $helper->getTalkTypes(),
+            'talkLevels' => $helper->getTalkLevels(),
             'id' => $talk_id,
             'title' => html_entity_decode($talk_info['title']),
             'description' => html_entity_decode($talk_info['description']),
@@ -171,13 +97,6 @@ class TalkController extends BaseController
         return $this->render('talk/edit.twig', $data);
     }
 
-    /**
-     * Action for displaying the form to create a new talk
-     *
-     * @param Request $req
-     *
-     * @return mixed
-     */
     public function createAction(Request $req)
     {
         // You can only create talks while the CfP is open
@@ -193,11 +112,13 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
+        $helper = $this->service(TalkHelper::class);
+
         $data = [
             'formAction' => $this->url('talk_create'),
-            'talkCategories' => $this->getTalkCategories(),
-            'talkTypes' => $this->getTalkTypes(),
-            'talkLevels' => $this->getTalkLevels(),
+            'talkCategories' => $helper->getTalkCategories(),
+            'talkTypes' => $helper->getTalkTypes(),
+            'talkLevels' => $helper->getTalkLevels(),
             'title' => $req->get('title'),
             'description' => $req->get('description'),
             'type' => $req->get('type'),
@@ -213,14 +134,6 @@ class TalkController extends BaseController
         return $this->render('talk/create.twig', $data);
     }
 
-    /**
-     * Controller action the processes the POST request to try and create
-     * a new talk
-     *
-     * @param Request $req
-     *
-     * @return mixed
-     */
     public function processCreateAction(Request $req)
     {
         // You can only create talks while the CfP is open
@@ -253,36 +166,11 @@ class TalkController extends BaseController
 
         $form = $this->getTalkForm($request_data);
         $form->sanitize();
-        $isValid = $form->validateAll();
 
-        if ($isValid) {
+        if ($form->validateAll()) {
             $sanitized_data = $form->getCleanData();
-
-            /* @var Locator $spot */
-            $spot = $this->service('spot');
-
-            $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-            $data = [
-                'title' => $sanitized_data['title'],
-                'description' => $sanitized_data['description'],
-                'type' => $sanitized_data['type'],
-                'level' => $sanitized_data['level'],
-                'category' => $sanitized_data['category'],
-                'desired' => $sanitized_data['desired'],
-                'slides' => $sanitized_data['slides'],
-                'other' => $sanitized_data['other'],
-                'sponsor' => $sanitized_data['sponsor'],
-                'user_id' => (int) $user->getId(),
-            ];
-
-            $talk = $talk_mapper->build($data);
-
-            try {
-                $talk_mapper->save($talk, ['relations' => true]);
-            } catch (\Exception $e) {
-                echo $e->getMessage();
-                die();
-            }
+            $sanitized_data['user_id'] =  (int) $user->getId();
+            $talk = Talk::create($sanitized_data);
 
             $this->service('session')->set('flash', [
                 'type' => 'success',
@@ -291,16 +179,17 @@ class TalkController extends BaseController
             ]);
 
             // send email to speaker showing submission
-            $this->sendSubmitEmail($this->app, $user->getLogin(), $talk->get('id'));
+            $this->sendSubmitEmail($user->getLogin(), (int) $talk->id);
 
             return $this->redirectTo('dashboard');
         }
+        $helper = $this->service(TalkHelper::class);
 
         $data = [
             'formAction' => $this->url('talk_create'),
-            'talkCategories' => $this->getTalkCategories(),
-            'talkTypes' => $this->getTalkTypes(),
-            'talkLevels' => $this->getTalkLevels(),
+            'talkCategories' => $helper->getTalkCategories(),
+            'talkTypes' => $helper->getTalkTypes(),
+            'talkLevels' => $helper->getTalkLevels(),
             'title' => $req->get('title'),
             'description' => $req->get('description'),
             'type' => $req->get('type'),
@@ -324,7 +213,7 @@ class TalkController extends BaseController
             'short' => 'Error',
             'ext' => implode('<br>', $form->getErrorMessages()),
         ]);
-        $data['flash'] = $this->getFlash($this->app);
+        $data['flash'] = $this->service('session')->get('flash');
 
         return $this->render('talk/create.twig', $data);
     }
@@ -349,59 +238,31 @@ class TalkController extends BaseController
 
         $form = $this->getTalkForm($request_data);
         $form->sanitize();
-        $isValid = $form->validateAll();
 
-        if ($isValid) {
+        if ($form->validateAll()) {
             $sanitized_data = $form->getCleanData();
+            $sanitized_data['user_id'] =(int) $user->getId();
+            
+            if (Talk::find((int) $sanitized_data['id'])->update($sanitized_data)) {
+                $this->service('session')->set('flash', [
+                    'type' => 'success',
+                    'short' => 'Success',
+                    'ext' => 'Successfully saved talk.',
+                ]);
 
-            /* @var Locator $spot */
-            $spot = $this->service('spot');
-            $talk_mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-            $data = [
-                'id' => (int) $sanitized_data['id'],
-                'title' => $sanitized_data['title'],
-                'description' => $sanitized_data['description'],
-                'type' => $sanitized_data['type'],
-                'level' => $sanitized_data['level'],
-                'category' => $sanitized_data['category'],
-                'desired' => $sanitized_data['desired'],
-                'slides' => $sanitized_data['slides'],
-                'other' => $sanitized_data['other'],
-                'sponsor' => $sanitized_data['sponsor'],
-                'user_id' => (int) $user->getId(),
-                'updated_at' => new \DateTime(),
-            ];
+                // send email to speaker showing submission
+                $this->sendSubmitEmail($user->getLogin(), (int) $sanitized_data['id']);
 
-            $talk = $talk_mapper->get($data['id']);
-
-            foreach ($data as $field => $value) {
-                $talk->$field = $value;
+                return $this->redirectTo('dashboard');
             }
-
-            try {
-                $talk_mapper->save($talk, ['relations' => true]);
-            } catch (\Exception $e) {
-                echo $e->getMessage();
-                die();
-            }
-
-            $this->service('session')->set('flash', [
-                'type' => 'success',
-                'short' => 'Success',
-                'ext' => 'Successfully saved talk.',
-            ]);
-
-            // send email to speaker showing submission
-            $this->sendSubmitEmail($this->app, $user->getLogin(), $talk->get('id'));
-
-            return $this->redirectTo('dashboard');
         }
+        $helper = $this->service(TalkHelper::class);
 
         $data = [
             'formAction' => $this->url('talk_update'),
-            'talkCategories' => $this->getTalkCategories(),
-            'talkTypes' => $this->getTalkTypes(),
-            'talkLevels' => $this->getTalkLevels(),
+            'talkCategories' => $helper->getTalkCategories(),
+            'talkTypes' => $helper->getTalkTypes(),
+            'talkLevels' => $helper->getTalkLevels(),
             'id' => $req->get('id'),
             'title' => $req->get('title'),
             'description' => $req->get('description'),
@@ -421,50 +282,44 @@ class TalkController extends BaseController
             'ext' => implode('<br>', $form->getErrorMessages()),
         ]);
 
-        $data['flash'] = $this->getFlash($this->app);
+        $data['flash'] = $this->service('session')->get('flash');
 
         return $this->render('talk/edit.twig', $data);
     }
 
-    public function deleteAction(Request $req, Application $app)
+    public function deleteAction(Request $req)
     {
         // You can only delete talks while the CfP is open
         if (! $this->service('callforproposal')->isOpen()) {
-            return $app->json(['delete' => 'no']);
+            return $this->app->json(['delete' => 'no']);
         }
 
-        $user = $this->service(Authentication::class)->user();
-        $talk_mapper = $app['spot']->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $talk = $talk_mapper->get($req->get('tid'));
+        $userId = $this->service(Authentication::class)->userId();
+        $talk = Talk::find($req->get('tid'), ['user_id']);
 
-        if ($talk->user_id !== (int) $user->getId()) {
-            return $app->json(['delete' => 'no']);
+        if ((int) $talk->user_id !==  $userId) {
+            return $this->app->json(['delete' => 'no']);
         }
 
-        $talk_mapper->delete($talk);
+        $talk->delete();
 
-        return $app->json(['delete' => 'ok']);
+        return $this->app->json(['delete' => 'ok']);
     }
 
     /**
      * Method that sends an email when a talk is created
      *
-     * @param Application $app
-     * @param string      $email
-     * @param int         $talk_id
+     * @param string $email
+     * @param int    $talk_id
      *
      * @return mixed
      */
-    protected function sendSubmitEmail(Application $app, $email, $talk_id)
+    protected function sendSubmitEmail(string $email, int $talk_id)
     {
-        /* @var Locator $spot */
-        $spot = $app['spot'];
-
-        $mapper = $spot->mapper(\OpenCFP\Domain\Entity\Talk::class);
-        $talk = $mapper->get($talk_id);
+        $talk = Talk::find($talk_id, ['title']);
 
         /* @var Twig_Environment $twig */
-        $twig = $app['twig'];
+        $twig = $this->service('twig');
 
         // Build our email that we will send
         $template = $twig->loadTemplate('emails/talk_submit.twig');
@@ -476,7 +331,7 @@ class TalkController extends BaseController
         ];
 
         try {
-            $mailer = $app['mailer'];
+            $mailer = $this->service('mailer');
             $message = new Swift_Message();
 
             $message->setTo($email);

--- a/classes/Http/View/TalkHelper.php
+++ b/classes/Http/View/TalkHelper.php
@@ -44,18 +44,18 @@ class TalkHelper
 
         if ($categories === null) {
             $categories = [
-                'api' => 'APIs (REST, SOAP, etc.)',
+                'api'               => 'APIs (REST, SOAP, etc.)',
                 'continuousdelivery'=> 'Continuous Delivery',
-                'database'=> 'Database',
-                'development'=> 'Development',
-                'devops' => 'Devops',
-                'framework' => 'Framework',
-                'ibmi' => 'IBMi',
-                'javascript' => 'JavaScript',
-                'security' => 'Security',
-                'testing' => 'Testing',
-                'uiux' => 'UI/UX',
-                'other' => 'Other',
+                'database'          => 'Database',
+                'development'       => 'Development',
+                'devops'            => 'Devops',
+                'framework'         => 'Framework',
+                'ibmi'              => 'IBMi',
+                'javascript'        => 'JavaScript',
+                'security'          => 'Security',
+                'testing'           => 'Testing',
+                'uiux'              => 'UI/UX',
+                'other'             => 'Other',
             ];
         }
 
@@ -82,7 +82,7 @@ class TalkHelper
 
         if ($types === null) {
             $types = [
-                'regular' => 'Regular',
+                'regular'  => 'Regular',
                 'tutorial' => 'Tutorial',
             ];
         }
@@ -110,8 +110,8 @@ class TalkHelper
 
         if ($levels === null) {
             $levels = [
-                'entry' => 'Entry level',
-                'mid' => 'Mid-level',
+                'entry'    => 'Entry level',
+                'mid'      => 'Mid-level',
                 'advanced' => 'Advanced',
             ];
         }

--- a/classes/Http/View/TalkHelper.php
+++ b/classes/Http/View/TalkHelper.php
@@ -37,6 +37,30 @@ class TalkHelper
         $this->levels = $levels;
         $this->types = $types;
     }
+    
+    public function getTalkCategories()
+    {
+        $categories = $this->categories;
+
+        if ($categories === null) {
+            $categories = [
+                'api' => 'APIs (REST, SOAP, etc.)',
+                'continuousdelivery'=> 'Continuous Delivery',
+                'database'=> 'Database',
+                'development'=> 'Development',
+                'devops' => 'Devops',
+                'framework' => 'Framework',
+                'ibmi' => 'IBMi',
+                'javascript' => 'JavaScript',
+                'security' => 'Security',
+                'testing' => 'Testing',
+                'uiux' => 'UI/UX',
+                'other' => 'Other',
+            ];
+        }
+
+        return $categories;
+    }
 
     /**
      * @param $category
@@ -52,6 +76,20 @@ class TalkHelper
         return $category;
     }
 
+    public function getTalkTypes()
+    {
+        $types = $this->types;
+
+        if ($types === null) {
+            $types = [
+                'regular' => 'Regular',
+                'tutorial' => 'Tutorial',
+            ];
+        }
+
+        return $types;
+    }
+
     /**
      * @param $type
      *
@@ -64,6 +102,21 @@ class TalkHelper
         }
 
         return $type;
+    }
+
+    public function getTalkLevels()
+    {
+        $levels = $this->levels;
+
+        if ($levels === null) {
+            $levels = [
+                'entry' => 'Entry level',
+                'mid' => 'Mid-level',
+                'advanced' => 'Advanced',
+            ];
+        }
+
+        return $levels;
     }
 
     /**

--- a/classes/Provider/TalkHelperProvider.php
+++ b/classes/Provider/TalkHelperProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OpenCFP\Provider;
+
+use OpenCFP\Http\View\TalkHelper;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class TalkHelperProvider implements ServiceProviderInterface
+{
+    public function register(Container $app)
+    {
+        $app[TalkHelper::class] =  function ($app) {
+            return new TalkHelper(
+                $app->config('talk.categories'),
+                $app->config('talk.levels'),
+                $app->config('talk.types')
+            );
+        };
+    }
+}

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -58,11 +58,7 @@ class TwigServiceProvider implements ServiceProviderInterface
 
             $twig->addGlobal(
                 'talkHelper',
-                new TalkHelper(
-                    $app->config('talk.categories'),
-                    $app->config('talk.levels'),
-                    $app->config('talk.types')
-                )
+                $this->app[TalkHelper::class]
             );
 
             return $twig;

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -33,7 +33,7 @@ class TalkControllerTest extends WebTestCase
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        $talk = factory(Talk::class, 1)->create()->first();
+        $talk       = factory(Talk::class, 1)->create()->first();
         self::$user = $talk->speaker->first();
         self::$talk = $talk;
     }
@@ -55,15 +55,12 @@ class TalkControllerTest extends WebTestCase
         $talk_data = [
             'title'       => 'Test Title With Ampersand',
             'description' => 'The title should contain this & that',
-<           'type'        => 'regular',
+            'type'        => 'regular',
             'level'       => 'entry',
             'category'    => 'other',
             'desired'     => 0,
-            'slides'      => '',
-            'other'       => '',
-            'sponsor'     => '',
-            'user_id'     => $auth->user()->getId(),
->       ];
+            'user_id'     => 1,
+        ];
 
         $this->asLoggedInSpeaker(1)
             ->callForPapersIsOpen()


### PR DESCRIPTION
This PR Updates the Talk Controller

* [x] Moves some helper functions into the TalkHelper class, and makes a provider for that
* [x] Removes spot usage, and uses Illuminate
* [x] Reduces code duplication in the controller
* [x] Fixes an issues where during some steps there was no check if the CFP was open or not
* [x] Updates and adds tests for the controller

Related to #506.
