### PR TITLE
Enhancement: Add new response asserts

### DIFF
--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -4,6 +4,7 @@ namespace OpenCFP\Test;
 
 use OpenCFP\Application;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -90,6 +91,21 @@ class TestResponse
         $fullFlash = $this->app['session']->get('flash');
         $fullFlash= is_array($fullFlash) ? $fullFlash : [];
         Assert::assertContains($flash, $fullFlash);
+
+        return $this;
+    }
+
+    public function assertNoFlashSet()
+    {
+        Assert::assertNull($this->app['session']->get('flash'));
+
+        return $this;
+    }
+
+    public function assertTargetURLContains(string$targetUrl)
+    {
+        Assert::assertInstanceOf(RedirectResponse::class, $this->baseResponse);
+        Assert::assertContains($targetUrl, $this->baseResponse->getTargetUrl());
 
         return $this;
     }


### PR DESCRIPTION
This PR adds two new test asserts to improve the test suite

* [x] Assert No Flash Set, which checks that there is no flash set
* [x] Assert Target Url Contains, which checks if the target url of the redirect matches the given (sub) string

The assert target url contains method makes sure it is a redirect response first, since the getTargetUrl method isn't part of the normal response object.

Somewhat related to #599, since this should help improve tests