### PR TITLE
Refactor: Talk Filter 

### DIFF
--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -4,6 +4,20 @@ namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * Class Talk
+ *
+ * @package OpenCFP\Domain\Model
+ *
+ * @method Builder recent(int $limit=10)
+ * @method Builder selected()
+ * @method Builder notViewedBy(int $userId)
+ * @method Builder notRatedBy(int $userId)
+ * @method Builder topRated()
+ * @method Builder ratedPlusOneBy(int $userId)
+ * @method Builder viewedBy(int $userId)
+ * @method Builder favoritedBy(int $userId)
+ */
 class Talk extends Eloquent
 {
     public function speaker()
@@ -94,5 +108,68 @@ class Talk extends Eloquent
                     throw new \Exception('Unable to delete all meta info');
                 }
             });
+    }
+
+    public function scopeSelected(Builder $query): Builder
+    {
+        return $query
+            ->where('selected', 1);
+    }
+
+    public function scopeViewedBy(Builder $query, int $userId): Builder
+    {
+        return $query
+            ->whereHas('meta', function (Builder $query) use ($userId) {
+                $query
+                    ->where('admin_user_id', $userId)
+                    ->where('viewed', 1);
+            });
+    }
+
+    public function scopeFavoritedBy(Builder $query, int $userId): Builder
+    {
+        return $query
+            ->whereHas('favorites', function (Builder $query) use ($userId) {
+                $query->where('admin_user_id', $userId);
+            });
+    }
+
+    public function scopeRatedPlusOneBy(Builder $query, int $userId): Builder
+    {
+        return $query
+            ->whereHas('meta', function (Builder $query) use ($userId) {
+                $query
+                   ->where('admin_user_id', $userId)
+                   ->where('rating', 1);
+            });
+    }
+
+    public function scopeNotRatedBy(Builder $query, int $userId): Builder
+    {
+        return $query
+            ->whereDoesntHave('meta', function (Builder $query) use ($userId) {
+                $query
+                    ->where('admin_user_id', $userId)
+                    ->where('rating', '!=', 0);
+            });
+    }
+
+    public function scopeNotViewedBy(Builder $query, int $userId): Builder
+    {
+        return $query
+            ->whereDoesntHave('meta', function (Builder $query) use ($userId) {
+                $query
+                    ->where('admin_user_id', $userId)
+                    ->where('viewed', 0);
+            });
+    }
+
+    public function scopeTopRated(Builder $query): Builder
+    {
+        return $query->selectRaw('talks.*, sum(m.rating) as total')
+            ->join('talk_meta as m', 'talks.id', '=', 'm.talk_id')
+            ->groupBy('m.talk_id')
+            ->havingRaw('total > 0')
+            ->orderBy('total', 'desc');
     }
 }

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -11,7 +11,7 @@ class TalkFilter
      *
      * @var array
      */
-    protected $order_by_whitelist = [
+    protected $orderByWhiteList = [
         'created_at',
         'title',
         'type',
@@ -33,7 +33,7 @@ class TalkFilter
         $this->talk      = $talk;
     }
 
-    public function getTalks(int $admin_user_id, $filter= null, $options = []): array
+    public function getTalks(int $adminUserId, $filter = null, $options = []): array
     {
         // Merge options with default options
         $options = $this->getSortOptions(
@@ -44,13 +44,13 @@ class TalkFilter
             ]
         );
 
-        $talks = $this->getFilteredTalks($admin_user_id, $filter)
+        $talks = $this->getFilteredTalks($adminUserId, $filter)
             ->orderBy($options['order_by'], $options['sort'])->get();
 
-        return $this->formatter->formatList($talks, $admin_user_id)->toArray();
+        return $this->formatter->formatList($talks, $adminUserId)->toArray();
     }
 
-    public function getFilteredTalks(int $admin_user_id, $filter = null)
+    public function getFilteredTalks(int $adminUserId, $filter = null)
     {
         if ($filter === null) {
             return $this->talk;
@@ -60,22 +60,22 @@ class TalkFilter
                 return $this->talk->selected();
 
             case 'notviewed':
-                return $this->talk->notViewedBy($admin_user_id);
+                return $this->talk->notViewedBy($adminUserId);
 
             case 'notrated':
-                return $this->talk->notRatedBy($admin_user_id);
+                return $this->talk->notRatedBy($adminUserId);
 
             case 'toprated':
                 return $this->talk->topRated();
 
             case 'plusone':
-                return $this->talk->ratedPlusOneBy($admin_user_id);
+                return $this->talk->ratedPlusOneBy($adminUserId);
 
             case 'viewed':
-                return $this->talk->viewedBy($admin_user_id);
+                return $this->talk->viewedBy($adminUserId);
 
             case 'favorited':
-                return $this->talk->favoritedBy($admin_user_id);
+                return $this->talk->favoritedBy($adminUserId);
 
             default:
                 return $this->talk;
@@ -92,7 +92,7 @@ class TalkFilter
      */
     protected function getSortOptions(array $options, array $defaultOptions)
     {
-        if (!isset($options['order_by']) || !in_array($options['order_by'], $this->order_by_whitelist)) {
+        if (!isset($options['order_by']) || !in_array($options['order_by'], $this->orderByWhiteList)) {
             $options['order_by'] = $defaultOptions['order_by'];
         }
 

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -2,63 +2,104 @@
 
 namespace OpenCFP\Domain\Talk;
 
-use OpenCFP\Domain\Entity\Talk;
-use Spot\Locator;
+use OpenCFP\Domain\Model\Talk;
 
 class TalkFilter
 {
-    /** @var \OpenCFP\Domain\Entity\Mapper\Talk  */
-    private $talk_mapper;
-    
-    public function __construct(Locator $spot)
+    /**
+     * Column Sort By White List
+     *
+     * @var array
+     */
+    protected $order_by_whitelist = [
+        'created_at',
+        'title',
+        'type',
+        'category',
+    ];
+
+    /**
+     * @var Talk
+     */
+    private $talk;
+    /**
+     * @var TalkFormatter
+     */
+    private $formatter;
+
+    public function __construct(TalkFormatter $talkFormatter, Talk $talk)
     {
-        $this->talk_mapper = $spot->mapper(Talk::class);
+        $this->formatter = $talkFormatter;
+        $this->talk = $talk;
     }
 
-    public function getFilteredTalks($admin_user_id, $filter = null, $options = [])
+    public function getTalks($admin_user_id, $filter= null, $options = []): array
+    {
+        // Merge options with default options
+        $options = $this->getSortOptions(
+            $options,
+            [
+                'order_by' => 'created_at',
+                'sort' => 'ASC',
+            ]
+        );
+
+        $talks = $this->getFilteredTalks($admin_user_id, $filter)
+            ->orderBy($options['order_by'], $options['sort'])->get();
+
+        return $this->formatter->formatList($talks, $admin_user_id)->toArray();
+    }
+
+    public function getFilteredTalks($admin_user_id, $filter = null)
     {
         if ($filter === null) {
-            return $this->talk_mapper->getAllPagerFormatted($admin_user_id, $options);
+            return $this->talk;
         }
-
         switch (strtolower($filter)) {
             case 'selected':
-                return $this->talk_mapper->getSelected($admin_user_id, $options);
-
-                break;
+                return $this->talk->selected();
 
             case 'notviewed':
-                return $this->talk_mapper->getNotViewedByUserId($admin_user_id, $options);
-
-                break;
+                return $this->talk->notViewedBy($admin_user_id);
 
             case 'notrated':
-                return $this->talk_mapper->getNotRatedByUserId($admin_user_id, $options);
-
-                break;
+                return $this->talk->notRatedBy($admin_user_id);
 
             case 'toprated':
-                return $this->talk_mapper->getTopRatedByUserId($admin_user_id, $options);
-
-                break;
+                return $this->talk->topRated();
 
             case 'plusone':
-                return $this->talk_mapper->getPlusOneByUserId($admin_user_id, $options);
-
-                break;
+                return $this->talk->ratedPlusOneBy($admin_user_id);
 
             case 'viewed':
-                return $this->talk_mapper->getViewedByUserId($admin_user_id, $options);
-
-                break;
+                return $this->talk->viewedBy($admin_user_id);
 
             case 'favorited':
-                return $this->talk_mapper->getFavoritesByUserId($admin_user_id, $options);
-
-                break;
+                return $this->talk->favoritedBy($admin_user_id);
 
             default:
-                return $this->talk_mapper->getAllPagerFormatted($admin_user_id, $options);
+                return $this->talk;
         }
+    }
+
+    /**
+     * Get sorting options, order_by and sort direction
+     *
+     * @param array $options        Sorting Options to Apply
+     * @param array $defaultOptions Default Sorting Options
+     *
+     * @return array
+     */
+    protected function getSortOptions(array $options, array $defaultOptions)
+    {
+        if (!isset($options['order_by']) || !in_array($options['order_by'], $this->order_by_whitelist)) {
+            $options['order_by'] = $defaultOptions['order_by'];
+        }
+
+        if (!isset($options['sort']) || !in_array($options['sort'], ['ASC', 'DESC'])) {
+            $options['sort'] = $defaultOptions['sort'];
+        }
+
+        return array_merge($defaultOptions, $options);
     }
 }

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -33,7 +33,7 @@ class TalkFilter
         $this->talk      = $talk;
     }
 
-    public function getTalks($admin_user_id, $filter= null, $options = []): array
+    public function getTalks(int $admin_user_id, $filter= null, $options = []): array
     {
         // Merge options with default options
         $options = $this->getSortOptions(
@@ -50,7 +50,7 @@ class TalkFilter
         return $this->formatter->formatList($talks, $admin_user_id)->toArray();
     }
 
-    public function getFilteredTalks($admin_user_id, $filter = null)
+    public function getFilteredTalks(int $admin_user_id, $filter = null)
     {
         if ($filter === null) {
             return $this->talk;

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -30,7 +30,7 @@ class TalkFilter
     public function __construct(TalkFormatter $talkFormatter, Talk $talk)
     {
         $this->formatter = $talkFormatter;
-        $this->talk = $talk;
+        $this->talk      = $talk;
     }
 
     public function getTalks($admin_user_id, $filter= null, $options = []): array
@@ -40,7 +40,7 @@ class TalkFilter
             $options,
             [
                 'order_by' => 'created_at',
-                'sort' => 'ASC',
+                'sort'     => 'ASC',
             ]
         );
 

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -30,7 +30,7 @@ class TalksController extends BaseController
             'sort'     => $req->get('sort'),
         ];
 
-        $pager_formatted_talks = $this->service(TalkFilter::class)->getTalks(
+        $formattedTalks = $this->service(TalkFilter::class)->getTalks(
             $admin_user_id,
             $req->get('filter'),
             $options
@@ -38,7 +38,8 @@ class TalksController extends BaseController
 
         // Set up our page stuff
         $per_page   = (int) $req->get('per_page') ?: 20;
-        $pagerfanta = new Pagination($pager_formatted_talks, $per_page);
+        $pagerfanta = new Pagination($formattedTalks, $per_page);
+
         $pagerfanta->setCurrentPage($req->get('page'));
         $pagination = $pagerfanta->createView('/admin/talks?', $req->query->all());
 
@@ -47,7 +48,7 @@ class TalksController extends BaseController
             'talks'        => $pagerfanta->getFanta(),
             'page'         => $pagerfanta->getCurrentPage(),
             'current_page' => $req->getRequestUri(),
-            'totalRecords' => count($pager_formatted_talks),
+            'totalRecords' => count($formattedTalks),
             'filter'       => $req->get('filter'),
             'per_page'     => $per_page,
             'sort'         => $req->get('sort'),

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -30,7 +30,7 @@ class TalksController extends BaseController
             'sort'     => $req->get('sort'),
         ];
 
-        $pager_formatted_talks = $this->service(TalkFilter::class)->getFilteredTalks(
+        $pager_formatted_talks = $this->service(TalkFilter::class)->getTalks(
             $admin_user_id,
             $req->get('filter'),
             $options

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -23,14 +23,14 @@ class TalksController extends BaseController
             'sort'     => $req->get('sort'),
         ];
 
-        $pager_formatted_talks = $this->service(TalkFilter::class)->getTalks(
+        $formattedTalks = $this->service(TalkFilter::class)->getTalks(
             $reviewerId,
             $req->get('filter'),
             $options
         );
 
         $per_page   = (int) $req->get('per_page') ?: 20;
-        $pagerfanta = new Pagination($pager_formatted_talks, $per_page);
+        $pagerfanta = new Pagination($formattedTalks, $per_page);
         $pagerfanta->setCurrentPage($req->get('page'));
         $pagination = $pagerfanta->createView('/reviewer/talks?', $req->query->all());
 
@@ -39,7 +39,7 @@ class TalksController extends BaseController
             'talks'        => $pagerfanta->getFanta(),
             'page'         => $pagerfanta->getCurrentPage(),
             'current_page' => $req->getRequestUri(),
-            'totalRecords' => count($pager_formatted_talks),
+            'totalRecords' => count($formattedTalks),
             'filter'       => $req->get('filter'),
             'per_page'     => $per_page,
             'sort'         => $req->get('sort'),

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -23,7 +23,7 @@ class TalksController extends BaseController
             'sort'     => $req->get('sort'),
         ];
 
-        $pager_formatted_talks = $this->service(TalkFilter::class)->getFilteredTalks(
+        $pager_formatted_talks = $this->service(TalkFilter::class)->getTalks(
             $reviewerId,
             $req->get('filter'),
             $options

--- a/classes/Provider/TalkFilterProvider.php
+++ b/classes/Provider/TalkFilterProvider.php
@@ -2,7 +2,9 @@
 
 namespace OpenCFP\Provider;
 
+use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Talk\TalkFilter;
+use OpenCFP\Domain\Talk\TalkFormatter;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
@@ -10,8 +12,8 @@ class TalkFilterProvider implements ServiceProviderInterface
 {
     public function register(Container $app)
     {
-        $app[TalkFilter::class] = function ($app) {
-            return new TalkFilter($app['spot']);
+        $app[TalkFilter::class] = function () {
+            return new TalkFilter(new TalkFormatter(), new Talk());
         };
     }
 }

--- a/tests/Domain/Model/Interaction/TalkTest.php
+++ b/tests/Domain/Model/Interaction/TalkTest.php
@@ -103,4 +103,32 @@ class TalkTest extends BaseTestCase
 
         $this->assertTrue($talk->delete());
     }
+
+    /**
+     * @test
+     */
+    public function favoritedByOnlyReturnsFavoritedTalks()
+    {
+        factory(Favorite::class, 2)->create(['admin_user_id' => 8]);
+        factory(Talk::class, 2)->create();
+        $favoritedBy = Talk::favoritedBy(8)->get();
+        $this->assertCount(2, $favoritedBy);
+        $favoritedByOther = Talk::favoritedBy(5)->get();
+        $this->assertCount(0, $favoritedByOther);
+    }
+
+    /**
+     * @test
+     */
+    public function ratedPlusOneByOnlyReturnsPlusOneRatedTalks()
+    {
+        factory(TalkMeta::class, 1)->create(['admin_user_id' => 8, 'rating' => 1]);
+        factory(TalkMeta::class, 1)->create(['admin_user_id' => 8, 'rating' => 0]);
+        factory(TalkMeta::class, 1)->create(['admin_user_id' => 8, 'rating' => -1]);
+
+        $ratedPlusOneBy = Talk::ratedPlusOneBy(8)->get();
+        $this->assertCount(1, $ratedPlusOneBy);
+        $ratedPlusOneByOther = Talk::ratedPlusOneBy(2)->get();
+        $this->assertCount(0, $ratedPlusOneByOther);
+    }
 }

--- a/tests/Domain/Model/Interaction/TalkTest.php
+++ b/tests/Domain/Model/Interaction/TalkTest.php
@@ -103,32 +103,4 @@ class TalkTest extends BaseTestCase
 
         $this->assertTrue($talk->delete());
     }
-
-    /**
-     * @test
-     */
-    public function favoritedByOnlyReturnsFavoritedTalks()
-    {
-        factory(Favorite::class, 2)->create(['admin_user_id' => 8]);
-        factory(Talk::class, 2)->create();
-        $favoritedBy = Talk::favoritedBy(8)->get();
-        $this->assertCount(2, $favoritedBy);
-        $favoritedByOther = Talk::favoritedBy(5)->get();
-        $this->assertCount(0, $favoritedByOther);
-    }
-
-    /**
-     * @test
-     */
-    public function ratedPlusOneByOnlyReturnsPlusOneRatedTalks()
-    {
-        factory(TalkMeta::class, 1)->create(['admin_user_id' => 8, 'rating' => 1]);
-        factory(TalkMeta::class, 1)->create(['admin_user_id' => 8, 'rating' => 0]);
-        factory(TalkMeta::class, 1)->create(['admin_user_id' => 8, 'rating' => -1]);
-
-        $ratedPlusOneBy = Talk::ratedPlusOneBy(8)->get();
-        $this->assertCount(1, $ratedPlusOneBy);
-        $ratedPlusOneByOther = Talk::ratedPlusOneBy(2)->get();
-        $this->assertCount(0, $ratedPlusOneByOther);
-    }
 }

--- a/tests/Domain/Model/Interaction/UserTest.php
+++ b/tests/Domain/Model/Interaction/UserTest.php
@@ -18,6 +18,8 @@ class UserTest extends BaseTestCase
     {
         $user = factory(User::class, 1)->create()->first();
 
+        $this->assertCount(1, User::all());
+
         $this->assertTrue($user->delete());
         $this->assertCount(0, User::all());
     }

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -115,68 +115,67 @@ class TalkTest extends BaseTestCase
         $this->assertCount(2, $topRated);
     }
 
-
     protected static function setUpTalksForTests()
     {
         $talk = Talk::create([
-            'user_id' => 7,
-            'title' => 'talks title',
+            'user_id'     => 7,
+            'title'       => 'talks title',
             'description' => 'Long description',
-            'type' => '',
-            'level' => 'entry',
-            'category' => 'api',
-            'selected' => 0,
+            'type'        => '',
+            'level'       => 'entry',
+            'category'    => 'api',
+            'selected'    => 0,
         ]);
 
         $talkTwo =Talk::create([
-            'user_id' => 7,
-            'title' => 'talks title NO 2',
+            'user_id'     => 7,
+            'title'       => 'talks title NO 2',
             'description' => 'Long description',
-            'type' => 'regular',
-            'level' => 'entry',
-            'category' => 'api',
-            'selected' => 1,
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'api',
+            'selected'    => 1,
 
         ]);
 
         Talk::create([
-            'user_id' => 7,
-            'title' => 'talks title NO 3',
+            'user_id'     => 7,
+            'title'       => 'talks title NO 3',
             'description' => 'Long description',
-            'type' => 'regular',
-            'level' => 'entry',
-            'category' => 'api',
-            'selected' => 0,
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'api',
+            'selected'    => 0,
         ]);
 
         TalkMeta::create([
             'admin_user_id' => 1,
-            'talk_id' => $talk->id,
-            'rating' => 0,
-            'viewed' => 1,
+            'talk_id'       => $talk->id,
+            'rating'        => 0,
+            'viewed'        => 1,
         ]);
 
         TalkMeta::create([
             'admin_user_id' => 1,
-            'talk_id' => $talkTwo->id,
-            'rating' => 1,
-            'viewed' => 1,
+            'talk_id'       => $talkTwo->id,
+            'rating'        => 1,
+            'viewed'        => 1,
         ]);
         TalkMeta::create([
             'admin_user_id' => 2,
-            'talk_id' => $talkTwo->id,
-            'rating' => 1,
-            'viewed' => 0,
+            'talk_id'       => $talkTwo->id,
+            'rating'        => 1,
+            'viewed'        => 0,
         ]);
         TalkMeta::create([
             'admin_user_id' => 8,
-            'talk_id' => $talk->id,
-            'rating' => 1,
-            'viewed' => 0,
+            'talk_id'       => $talk->id,
+            'rating'        => 1,
+            'viewed'        => 0,
         ]);
         Favorite::create([
             'admin_user_id' => 1,
-            'talk_id' => $talk->id,
+            'talk_id'       => $talk->id,
         ]);
     }
 }

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -4,7 +4,6 @@ namespace OpenCFP\Test\Domain\Model;
 
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
-use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\RefreshDatabase;
 
@@ -20,7 +19,7 @@ class TalkTest extends BaseTestCase
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        $talks = factory(Talk::class, 2)->create();
+        $talks = factory(Talk::class, 2)->create(['selected' => 1]);
         factory(TalkMeta::class, 1)->create(['admin_user_id' => 2, 'talk_id' => $talks->first()->id]);
         self::$talks = $talks;
     }
@@ -35,29 +34,21 @@ class TalkTest extends BaseTestCase
     /**
      * @test
      */
-    public function createFormattedOutputWorksWithNoMeta()
+    public function selectedOnlyReturnsSelectedTalks()
     {
-        $talk      = self::$talks;
-        $formatter = new TalkFormatter();
-        $format    =$formatter->createdFormattedOutput($talk->first(), 1);
 
-        $this->assertEquals(self::$talks->first()->title, $format['title']);
-        $this->assertEquals(0, $format['meta']->rating);
-        $this->assertEquals(0, $format['meta']->viewed);
+        $selected = Talk::selected()->get();
+        $this->assertCount(2, $selected);
     }
 
     /**
      * @test
      */
-    public function createFormattedOutputWorksWithMeta()
+    public function viewedByOnlyReturnsViewedTalks()
     {
-        $talk = self::$talks;
-
-        // Now to see if the meta gets put in correctly
-        $talkFormatter = new TalkFormatter();
-        $secondFormat  =$talkFormatter->createdFormattedOutput($talk->first(), 2);
-
-        $this->assertEquals(1, $secondFormat['meta']->rating);
-        $this->assertEquals(1, $secondFormat['meta']->viewed);
+        $viewedBy = Talk::viewedBy(2)->get();
+        $this->assertCount(1, $viewedBy);
+        $viewedByOther = Talk::viewedBy(5)->get();
+        $this->assertCount(0, $viewedByOther);
     }
 }

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -36,7 +36,6 @@ class TalkTest extends BaseTestCase
      */
     public function selectedOnlyReturnsSelectedTalks()
     {
-
         $selected = Talk::selected()->get();
         $this->assertCount(2, $selected);
     }

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Test\Domain\Model;
 
+use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Test\BaseTestCase;
@@ -14,14 +15,10 @@ class TalkTest extends BaseTestCase
 {
     use RefreshDatabase;
 
-    private static $talks;
-
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        $talks = factory(Talk::class, 2)->create(['selected' => 1]);
-        factory(TalkMeta::class, 1)->create(['admin_user_id' => 2, 'talk_id' => $talks->first()->id]);
-        self::$talks = $talks;
+        self::setUpTalksForTests();
     }
 
     /** @test */
@@ -37,7 +34,8 @@ class TalkTest extends BaseTestCase
     public function selectedOnlyReturnsSelectedTalks()
     {
         $selected = Talk::selected()->get();
-        $this->assertCount(2, $selected);
+        $this->assertCount(1, $selected);
+        $this->assertEquals('talks title NO 2', $selected->first()->title);
     }
 
     /**
@@ -45,9 +43,140 @@ class TalkTest extends BaseTestCase
      */
     public function viewedByOnlyReturnsViewedTalks()
     {
-        $viewedBy = Talk::viewedBy(2)->get();
-        $this->assertCount(1, $viewedBy);
-        $viewedByOther = Talk::viewedBy(5)->get();
+        $viewedBy = Talk::viewedBy(1)->get();
+        $this->assertCount(2, $viewedBy);
+
+        $viewedByOther = Talk::viewedBy(25)->get();
         $this->assertCount(0, $viewedByOther);
+    }
+
+    /**
+     * @test
+     */
+    public function favoritedByOnlyReturnsFavoritedTalks()
+    {
+        $favorited = Talk::favoritedBy(1)->get();
+
+        $this->assertCount(1, $favorited);
+        $this->assertEquals('talks title', $favorited->first()->title);
+
+        $favoritedByOther = Talk::viewedBy(25)->get();
+        $this->assertCount(0, $favoritedByOther);
+    }
+
+    /**
+     * @test
+     */
+    public function ratedPlusOneByReturnsPlusOneRatedTalks()
+    {
+        $ratedPlusOne = Talk::ratedPlusOneBy(1)->get();
+
+        $this->assertCount(1, $ratedPlusOne);
+        $this->assertEquals('talks title NO 2', $ratedPlusOne->first()->title);
+
+        $ratedPlusOneByOther = Talk::ratedPlusOneBy(25)->get();
+        $this->assertCount(0, $ratedPlusOneByOther);
+    }
+
+    /**
+     * @test
+     */
+    public function notRatedByReturnsTalksNotRatedOrRatedZero()
+    {
+        $notRated = Talk::notRatedBy(1)->get();
+        $this->assertCount(2, $notRated);
+
+        $notRatedByUserTwo = Talk::notRatedBy(25)->get();
+        $this->assertCount(3, $notRatedByUserTwo);
+    }
+
+    /**
+     * @test
+     */
+    public function notViewedByReturnsTalksNotViewed()
+    {
+        $notViewed = Talk::notViewedBy(1)->get();
+
+        $this->assertCount(1, $notViewed);
+        $this->assertEquals('talks title NO 3', $notViewed->first()->title);
+
+        $notViewedByOther = Talk::notViewedBy(2)->get();
+
+        $this->assertCount(3, $notViewedByOther);
+    }
+
+    /**
+     * @test
+     */
+    public function topRatedSortsOnBestRatings()
+    {
+        $topRated = Talk::topRated()->get();
+        $this->assertEquals('talks title NO 2', $topRated->first()->title);
+        $this->assertCount(2, $topRated);
+    }
+
+
+    protected static function setUpTalksForTests()
+    {
+        $talk = Talk::create([
+            'user_id' => 7,
+            'title' => 'talks title',
+            'description' => 'Long description',
+            'type' => '',
+            'level' => 'entry',
+            'category' => 'api',
+            'selected' => 0,
+        ]);
+
+        $talkTwo =Talk::create([
+            'user_id' => 7,
+            'title' => 'talks title NO 2',
+            'description' => 'Long description',
+            'type' => 'regular',
+            'level' => 'entry',
+            'category' => 'api',
+            'selected' => 1,
+
+        ]);
+
+        Talk::create([
+            'user_id' => 7,
+            'title' => 'talks title NO 3',
+            'description' => 'Long description',
+            'type' => 'regular',
+            'level' => 'entry',
+            'category' => 'api',
+            'selected' => 0,
+        ]);
+
+        TalkMeta::create([
+            'admin_user_id' => 1,
+            'talk_id' => $talk->id,
+            'rating' => 0,
+            'viewed' => 1,
+        ]);
+
+        TalkMeta::create([
+            'admin_user_id' => 1,
+            'talk_id' => $talkTwo->id,
+            'rating' => 1,
+            'viewed' => 1,
+        ]);
+        TalkMeta::create([
+            'admin_user_id' => 2,
+            'talk_id' => $talkTwo->id,
+            'rating' => 1,
+            'viewed' => 0,
+        ]);
+        TalkMeta::create([
+            'admin_user_id' => 8,
+            'talk_id' => $talk->id,
+            'rating' => 1,
+            'viewed' => 0,
+        ]);
+        Favorite::create([
+            'admin_user_id' => 1,
+            'talk_id' => $talk->id,
+        ]);
     }
 }

--- a/tests/Domain/Model/UserTest.php
+++ b/tests/Domain/Model/UserTest.php
@@ -124,9 +124,10 @@ class UserTest extends BaseTestCase
             'user_id'     => $userId,
             'title'       => 'talks title',
             'description' => 'Long description',
-            'type'        => '',
+            'type'        => 'regular',
             'level'       => 'entry',
             'category'    => 'api',
+
         ]);
 
         Talk::create([
@@ -145,6 +146,7 @@ class UserTest extends BaseTestCase
             'type'        => 'regular',
             'level'       => 'entry',
             'category'    => 'api',
+
         ]);
     }
 }

--- a/tests/Domain/Model/UserTest.php
+++ b/tests/Domain/Model/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Test\Domain\Model;
 
+use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\RefreshDatabase;
@@ -13,12 +14,15 @@ class UserTest extends BaseTestCase
 {
     use RefreshDatabase;
 
-    private static $users;
+    /**
+     * @var User
+     */
+    private static $user;
 
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        self::$users = self::makeKnownUsers();
+        self::$user = self::makeKnownUsers();
     }
 
     /**
@@ -39,6 +43,37 @@ class UserTest extends BaseTestCase
         $this->assertCount(1, User::search('Hunter')->get());
     }
 
+    /**
+     * @test
+     */
+    public function getOtherTalksReturnsAllTalksByDefault()
+    {
+        $talks = self::$user->getOtherTalks();
+
+        $this->assertCount(3, $talks);
+    }
+
+    /**
+     * @test
+     */
+    public function getOtherTalksReturnsOtherTalksCorrectly()
+    {
+        $talks = self::$user->getOtherTalks(1);
+
+        $this->assertCount(2, $talks);
+    }
+
+    /**
+     * @test
+     */
+    public function getOtherTalksReturnsNothingWhenUserHasNoTalks()
+    {
+        $user  = User::where('first_name', 'Vries')->get()->first();
+        $talks = $user->getOtherTalks();
+
+        $this->assertCount(0, $talks);
+    }
+
     private static function makeKnownUsers()
     {
         $userInfo = [
@@ -47,11 +82,12 @@ class UserTest extends BaseTestCase
             'has_made_profile' => 1,
         ];
 
-        User::create(array_merge([
+        $user = User::create(array_merge([
             'email'      => 'henk@example.com',
             'first_name' => 'Henk',
             'last_name'  => 'de Vries',
         ], $userInfo));
+        self::giveUserThreeTalks($user);
 
         User::create(array_merge([
             'email'      => 'speaker@cfp.org',
@@ -76,5 +112,39 @@ class UserTest extends BaseTestCase
             'first_name' => 'Gon',
             'last_name'  => 'Freecss',
         ], $userInfo));
+
+        return $user;
+    }
+
+    public static function giveUserThreeTalks(User $user)
+    {
+        $userId = $user->id;
+
+        Talk::create([
+            'user_id'     => $userId,
+            'title'       => 'talks title',
+            'description' => 'Long description',
+            'type'        => '',
+            'level'       => 'entry',
+            'category'    => 'api',
+        ]);
+
+        Talk::create([
+            'user_id'     => $userId,
+            'title'       => 'talks title NO 2',
+            'description' => 'Long description',
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'api',
+        ]);
+
+        Talk::create([
+            'user_id'     => $userId,
+            'title'       => 'talks title NO 3',
+            'description' => 'Long description',
+            'type'        => 'regular',
+            'level'       => 'entry',
+            'category'    => 'api',
+        ]);
     }
 }

--- a/tests/Domain/Talk/TalkFilterTest.php
+++ b/tests/Domain/Talk/TalkFilterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace OpenCFP\Test\Domain\Talk;
+
+use Mockery;
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Talk\TalkFilter;
+use OpenCFP\Domain\Talk\TalkFormatter;
+use OpenCFP\Test\BaseTestCase;
+
+class TalkFilterTest extends BaseTestCase
+{
+    protected $talk;
+
+    protected $formatter;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->talk      = Mockery::mock(Talk::class);
+        $this->formatter = Mockery::mock(TalkFormatter::class);
+    }
+
+    /**
+     * @test
+     */
+    public function getFilteredTalksWithoutAFilterReturnsTheTalksObject()
+    {
+        $filter = new TalkFilter(new TalkFormatter(), $this->talk);
+        $talk   = $filter->getFilteredTalks(1);
+        $this->assertEquals($this->talk, $talk);
+    }
+
+    /**
+     * @test
+     */
+    public function getFilteredTalksWithANonsenseFilterReturnsTheTalkObject()
+    {
+        $filter = new TalkFilter(new TalkFormatter(), $this->talk);
+        $talk   = $filter->getFilteredTalks(1, 'secrets');
+        $this->assertEquals($this->talk, $talk);
+    }
+
+    /**
+     * @test
+     */
+    public function getFilteredTalksWithWronglyCasedFilterWorksCorrectly()
+    {
+        $this->talk->shouldReceive('selected')->andReturn('gotSelected');
+        $filter = new TalkFilter(new TalkFormatter(), $this->talk);
+        $talk   = $filter->getFilteredTalks(1, 'selEcteD');
+        $this->assertEquals('gotSelected', $talk);
+    }
+
+    /**
+     * @test
+     */
+    public function getFilteredTalksWithNormalCasedFilterWorksCorrectly()
+    {
+        $this->talk->shouldReceive('topRated')->andReturn('gotTopRated');
+        $filter = new TalkFilter(new TalkFormatter(), $this->talk);
+        $talk   = $filter->getFilteredTalks(1, 'toprated');
+        $this->assertEquals('gotTopRated', $talk);
+    }
+
+    /**
+     * @test
+     */
+    public function getFilteredTalksWorksWithOtherOptions()
+    {
+        $this->talk->shouldReceive('notRatedBy')->andReturn('gotnotrated');
+        $this->talk->shouldReceive('ratedPlusOneBy')->andReturn('gotplusone');
+        $this->talk->shouldReceive('viewedBy')->andReturn('gotviewed');
+        $this->talk->shouldReceive('favoritedBy')->andReturn('gotfavorited');
+        $filter = new TalkFilter(new TalkFormatter(), $this->talk);
+        $talk   = $filter->getFilteredTalks(1, 'notrated');
+        $this->assertEquals('gotnotrated', $talk);
+        $talk = $filter->getFilteredTalks(1, 'plusone');
+        $this->assertEquals('gotplusone', $talk);
+        $talk = $filter->getFilteredTalks(1, 'viewed');
+        $this->assertEquals('gotviewed', $talk);
+        $talk = $filter->getFilteredTalks(1, 'favorited');
+        $this->assertEquals('gotfavorited', $talk);
+    }
+
+    /**
+     * @test
+     */
+    public function getTalksAttemptsToFormatTheTalks()
+    {
+        $this->talk->shouldReceive('notViewedBy->orderBy->get')->andReturn(collect());
+        $this->formatter->shouldReceive('formatList')->andReturn(collect(['Got an Array']));
+
+        $filter = new TalkFilter($this->formatter, $this->talk);
+
+        $return = $filter->getTalks(1, 'notviewed');
+
+        $this->assertContains('Got an Array', $return);
+    }
+}

--- a/tests/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Http/Controller/Reviewer/TalksControllerTest.php
@@ -2,10 +2,7 @@
 
 namespace OpenCFP\Test\Http\Controller\Reviewer;
 
-use Mockery;
 use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Domain\Talk\TalkFilter;
-use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Test\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
@@ -26,11 +23,10 @@ class TalksControllerTest extends WebTestCase
      */
     public function indexActionWorksNormally()
     {
-        $this->makeTalks();
         $this->asReviewer()
             ->get('/reviewer/talks')
             ->assertSee('<h2 class="headline">Submitted Talks</h2>')
-            ->assertSee('title="I want to see this talk')
+            ->assertSee(self::$talks->first()->title)
             ->assertNotSee('Recent Talks')
             ->assertSuccessful();
     }
@@ -81,14 +77,5 @@ class TalksControllerTest extends WebTestCase
             ->post('/reviewer/talks/' . $talk->id . '/rate', ['rating' => 8])
             ->assertNotSee('1')
             ->assertSuccessful();
-    }
-
-    protected function makeTalks()
-    {
-        $formatter = new TalkFormatter();
-        $toReturn  = $formatter->formatList(self::$talks, 1);
-        $filter    = Mockery::mock(TalkFilter::class);
-        $filter->shouldReceive('getFilteredTalks')->andReturn($toReturn->toArray());
-        $this->swap(TalkFilter::class, $filter);
     }
 }


### PR DESCRIPTION
This PR changes the TalkFilter class to use Illuminate. To do so it does the following

* [x] Add a bunch of new scopes
* [x] Move the sorting options to the TalkFilter
* [x] Add tests

Related to #577.

If this and #601 get merged pretty much all of Spot has been removed from usage within the project, except for the API
