### PR TITLE
Enhancement: Set up infection testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ deployment.xml
 /web/.htaccess
 phinx.yml
 /phpunit.xml
+infection-log.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ $ make test
 
 to run all the tests.
 
+Run 
+```
+$ make infection
+```
+to run [infection tests](https://infection.github.io/guide/)
+
 ## Fixing Code Style issues
 
 Run

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ database: composer
 test: composer database
 	vendor/bin/phpunit
 
+infection: composer database
+	vendor/bin/infection
+

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,11 @@
+{
+    "timeout": 15,
+    "source": {
+        "directories": [
+            "classes"
+        ]
+    },
+    "logs": {
+        "text": "infection-log.txt"
+    }
+}


### PR DESCRIPTION
This PR sets up infection testing. Run ```vendor/bin/infection``` to start up the tests or ```make infection```.
These tests take quite some time to run, so i haven't added them to travis. I've added the results of my run for those interested

Follows #599.

## Results
858 mutations were generated:
     403 mutants were killed
     370 mutants were not covered by tests
      72 covered mutants were not detected
      13 time outs were encountered

Metrics:
         Mutation Score Indicator (MSI): 48%
         Mutation Code Coverage: 57%
         Covered Code MSI: 85%

[infection-log.txt](https://github.com/opencfp/opencfp/files/1470975/infection-log.txt)