### PR TITLE
Fix: remove RandomLib/Factory reference

### DIFF
--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -27,7 +27,6 @@ use OpenCFP\Infrastructure\Persistence\IlluminateSpeakerRepository;
 use OpenCFP\Infrastructure\Persistence\IlluminateTalkRepository;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use RandomLib\Factory;
 
 class ApplicationServiceProvider implements ServiceProviderInterface
 {
@@ -84,8 +83,8 @@ class ApplicationServiceProvider implements ServiceProviderInterface
             return new Airport;
         };
 
-        $app['security.random'] = function ($app) {
-            return new PseudoRandomStringGenerator(new Factory());
+        $app['security.random'] = function () {
+            return new PseudoRandomStringGenerator();
         };
 
         $app['oauth.resource'] = function ($app) {


### PR DESCRIPTION
This PR removes the old dependency reference from the security.random, which
would cause the uploading of profile images to break.

Follows #579 .

