### PR TITLE
Set return types on model relations

### DIFF
--- a/classes/Domain/Model/Favorite.php
+++ b/classes/Domain/Model/Favorite.php
@@ -2,6 +2,8 @@
 
 namespace OpenCFP\Domain\Model;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
 class Favorite extends Eloquent
 {
     protected $table = 'favorites';
@@ -9,7 +11,7 @@ class Favorite extends Eloquent
     const CREATED_AT = 'created';
     const UPDATED_AT = null;
 
-    public function talk()
+    public function talk(): BelongsTo
     {
         return $this->belongsTo(Talk::class, 'talk_id');
     }

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -3,6 +3,8 @@
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * Class Talk
@@ -20,22 +22,22 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class Talk extends Eloquent
 {
-    public function speaker()
+    public function speaker(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
     }
 
-    public function favorites()
+    public function favorites(): HasMany
     {
         return $this->hasMany(Favorite::class, 'talk_id');
     }
 
-    public function comments()
+    public function comments(): HasMany
     {
         return $this->hasMany(TalkComment::class);
     }
 
-    public function meta()
+    public function meta(): HasMany
     {
         return $this->hasMany(TalkMeta::class, 'talk_id');
     }

--- a/classes/Domain/Model/TalkComment.php
+++ b/classes/Domain/Model/TalkComment.php
@@ -2,6 +2,8 @@
 
 namespace OpenCFP\Domain\Model;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
 class TalkComment extends Eloquent
 {
     protected $table = 'talk_comments';
@@ -9,12 +11,12 @@ class TalkComment extends Eloquent
     const CREATED_AT = 'created';
     const UPDATED_AT = null;
 
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
-    public function talk()
+    public function talk(): BelongsTo
     {
         return $this->belongsTo(Talk::class);
     }

--- a/classes/Domain/Model/TalkMeta.php
+++ b/classes/Domain/Model/TalkMeta.php
@@ -2,6 +2,8 @@
 
 namespace OpenCFP\Domain\Model;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
 class TalkMeta extends Eloquent
 {
     protected $table = 'talk_meta';
@@ -17,12 +19,12 @@ class TalkMeta extends Eloquent
         'viewed' => self::DEFAULT_VIEWED,
     ];
 
-    public function talk()
+    public function talk(): BelongsTo
     {
         return $this->belongsTo(Talk::class, 'talk_id');
     }
 
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'admin_user_id');
     }

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -3,21 +3,22 @@
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 
 class User extends Eloquent
 {
-    public function talks()
+    public function talks(): HasMany
     {
         return $this->hasMany(Talk::class);
     }
 
-    public function comments()
+    public function comments(): HasMany
     {
         return $this->hasMany(TalkComment::class);
     }
 
-    public function meta()
+    public function meta(): HasMany
     {
         return $this->hasMany(TalkMeta::class, 'admin_user_id');
     }

--- a/tests/Domain/Model/TalkMetaTest.php
+++ b/tests/Domain/Model/TalkMetaTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OpenCFP\Test\Domain\Model;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\TalkMeta;
+use OpenCFP\Domain\Model\User;
+use OpenCFP\Test\BaseTestCase;
+use OpenCFP\Test\RefreshDatabase;
+
+class TalkMetaTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var TalkMeta
+     */
+    private static $meta;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::$meta = factory(TalkMeta::class, 1)->create()->first();
+    }
+
+    /**
+     * @test
+     */
+    public function talkRelationWorks()
+    {
+        $talk = self::$meta->talk();
+        $this->assertInstanceOf(BelongsTo::class, $talk);
+        $this->assertInstanceOf(Talk::class, $talk->first());
+    }
+
+    /**
+     * @test
+     */
+    public function userRelationWorks()
+    {
+        $user = self::$meta->user();
+        $this->assertInstanceOf(BelongsTo::class, $user);
+        $this->assertInstanceOf(User::class, $user->first());
+    }
+}

--- a/tests/Domain/Model/UserTest.php
+++ b/tests/Domain/Model/UserTest.php
@@ -2,7 +2,10 @@
 
 namespace OpenCFP\Test\Domain\Model;
 
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\TalkComment;
+use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\RefreshDatabase;
@@ -23,6 +26,36 @@ class UserTest extends BaseTestCase
     {
         parent::setUpBeforeClass();
         self::$user = self::makeKnownUsers();
+    }
+
+    /**
+     * @test
+     */
+    public function talksRelationWorks()
+    {
+        $talk = self::$user->talks();
+        $this->assertInstanceOf(HasMany::class, $talk);
+        $this->assertInstanceOf(Talk::class, $talk->first());
+    }
+
+    /**
+     * @test
+     */
+    public function commentRelationWorks()
+    {
+        $comment = self::$user->comments();
+        $this->assertInstanceOf(HasMany::class, $comment);
+        $this->assertInstanceOf(TalkComment::class, $comment->first());
+    }
+
+    /**
+     * @test
+     */
+    public function metaRelationWorks()
+    {
+        $meta = self::$user->meta();
+        $this->assertInstanceOf(HasMany::class, $meta);
+        $this->assertInstanceOf(TalkMeta::class, $meta->first());
     }
 
     /**
@@ -88,6 +121,7 @@ class UserTest extends BaseTestCase
             'last_name'  => 'de Vries',
         ], $userInfo));
         self::giveUserThreeTalks($user);
+        self::giveUserRelations($user);
 
         User::create(array_merge([
             'email'      => 'speaker@cfp.org',
@@ -147,6 +181,23 @@ class UserTest extends BaseTestCase
             'level'       => 'entry',
             'category'    => 'api',
 
+        ]);
+    }
+
+    public static function giveUserRelations(User $user)
+    {
+        $userId = $user->id;
+
+        TalkComment::create([
+            'user_id' => $userId,
+            'talk_id' => 893,
+            'message' => 'Oh hi Mark.',
+        ]);
+        TalkMeta::create([
+            'admin_user_id' => $userId,
+            'talk_id'       => 893,
+            'rating'        => 1,
+            'viewed'        => 0,
         ]);
     }
 }


### PR DESCRIPTION
This PR adds the return types to our model relationships, adding a bit more assurance that they are correct (e.g. missing return types).

Follows #610