### PR TITLE
Feature: Limit speaker information reviewers can see

### DIFF
--- a/classes/Domain/Speaker/NotAllowedException.php
+++ b/classes/Domain/Speaker/NotAllowedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace OpenCFP\Domain\Speaker;
+
+class NotAllowedException extends \Exception
+{
+}

--- a/classes/Domain/Speaker/NotAllowedException.php
+++ b/classes/Domain/Speaker/NotAllowedException.php
@@ -4,4 +4,8 @@ namespace OpenCFP\Domain\Speaker;
 
 class NotAllowedException extends \Exception
 {
+    public static function notAllowedToView(string $property)
+    {
+        return new self(sprintf('Not allowed to view %s. Hidden property', $property));
+    }
 }

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -17,9 +17,31 @@ class SpeakerProfile
      */
     protected $speaker;
 
-    public function __construct($speaker)
+    /**
+     * @var array
+     */
+    private $hiddenProperties;
+
+    /**
+     * @param $speaker
+     * @param array $hiddenProperties This is a blacklist, telling the view what fields it isn't allowed to show.
+     */
+    public function __construct(User $speaker, array $hiddenProperties = [])
     {
-        $this->speaker = $speaker;
+        $this->speaker          = $speaker;
+        $this->hiddenProperties = $hiddenProperties;
+    }
+
+    public function isAllowedToSee(string $property): bool
+    {
+        return !in_array($property, $this->hiddenProperties);
+    }
+
+    private function assertAllowedToSee(string $property)
+    {
+        if (! $this->isAllowedToSee($property)) {
+            throw new NotAllowedException(ucfirst($property) .' is a hidden property.');
+        }
     }
 
     public function needsProfile(): bool
@@ -34,61 +56,85 @@ class SpeakerProfile
      */
     public function getTalks()
     {
+        $this->assertAllowedToSee('talks');
+
         return $this->speaker->talks;
     }
 
     public function getName(): string
     {
+        $this->assertAllowedToSee('name');
+
         return $this->speaker->first_name . ' ' . $this->speaker->last_name;
     }
 
     public function getEmail()
     {
+        $this->assertAllowedToSee('email');
+
         return $this->speaker->email;
     }
 
     public function getCompany()
     {
+        $this->assertAllowedToSee('company');
+
         return $this->speaker->company ?: null;
     }
 
     public function getTwitter()
     {
+        $this->assertAllowedToSee('twitter');
+
         return $this->speaker->twitter;
     }
 
     public function getUrl()
     {
+        $this->assertAllowedToSee('url');
+
         return $this->speaker->url;
     }
 
     public function getInfo()
     {
+        $this->assertAllowedToSee('info');
+
         return $this->speaker->info;
     }
 
     public function getBio()
     {
+        $this->assertAllowedToSee('bio');
+
         return $this->speaker->bio;
     }
 
     public function getTransportation()
     {
+        $this->assertAllowedToSee('transportation');
+
         return $this->speaker->transportation == '1';
     }
 
     public function getHotel()
     {
+        $this->assertAllowedToSee('hotel');
+
         return $this->speaker->hotel;
     }
 
     public function getAirport()
     {
+        $this->assertAllowedToSee('airport');
+
         return $this->speaker->airport;
     }
 
     public function getPhoto()
     {
+        $this->assertAllowedToSee('photo');
+
         return $this->speaker->photo_path;
     }
 

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -40,7 +40,7 @@ class SpeakerProfile
     private function assertAllowedToSee(string $property)
     {
         if (! $this->isAllowedToSee($property)) {
-            throw new NotAllowedException(ucfirst($property) .' is a hidden property.');
+            throw NotAllowedException::notAllowedToView($property);
         }
     }
 

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -45,7 +45,7 @@ class SpeakersController extends BaseController
 
         $talks        = $speakerDetails->talks()->get()->toArray();
         $templateData = [
-            'speaker'    => new SpeakerProfile($speakerDetails),
+            'speaker'    => new SpeakerProfile($speakerDetails, $this->app->config('reviewer.users')?: []),
             'talks'      => $talks,
             'photo_path' => '/uploads/',
             'page'       => $req->get('page'),

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -84,7 +84,7 @@ class TalksController extends BaseController
         $templateData = [
             'talk'       => $talk->toArray(),
             'talk_meta'  => $talkMeta,
-            'speaker'    => new SpeakerProfile($speaker),
+            'speaker'    => new SpeakerProfile($speaker, $this->app->config('reviewer.users') ?: []),
             'otherTalks' => $otherTalks,
             'comments'   => $talk->comments()->get(),
         ];

--- a/config/development.dist.yml
+++ b/config/development.dist.yml
@@ -67,3 +67,7 @@ security:
       form_forgot:
         csrf_parameter: _csrf_security_token
         csrf_token_id: forgot_password
+
+reviewer:
+  users:
+    -

--- a/config/production.dist.yml
+++ b/config/production.dist.yml
@@ -67,3 +67,7 @@ security:
       form_forgot:
         csrf_parameter: _csrf_security_token
         csrf_token_id: forgot_password
+
+reviewer:
+  users:
+    -

--- a/resources/views/reviewer/speaker/view.twig
+++ b/resources/views/reviewer/speaker/view.twig
@@ -5,12 +5,13 @@
         <img class="w-16 h-16 mr-4 rounded-full" src="{{ speaker.photo ? '/uploads/' ~ speaker.photo : '/assets/img/dummyphoto.jpg' }}">
         <div>
             <h1 class="-mt-2">
-                {{ speaker.name }}
+                {% if speaker.isAllowedToSee('name') %}{{ speaker.name }}{% else %}Unknown Speaker{% endif %}
             </h1>
+
             <div>
-                {% if speaker.company %}<span class="mr-3"><i class="fa fa-building"></i> {{ speaker.company }}</span>{% endif %}
-                {% if speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="https://twitter.com/{{ speaker.twitter }}"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
-                {% if speaker.email %}<span class="mr-3"><i class="fa fa-envelope"></i> {{ speaker.email }}</span>{% endif %}
+                {% if speaker.isAllowedToSee('company') and speaker.company %}<span class="mr-3"><i class="fa fa-building"></i> {{ speaker.company }}</span>{% endif %}
+                {% if speaker.isAllowedToSee('twitter') and speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="https://twitter.com/{{ speaker.twitter }}"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
+                {% if speaker.isAllowedToSee('email') and speaker.email %}<span class="mr-3"><i class="fa fa-envelope"></i> {{ speaker.email }}</span>{% endif %}
             </div>
         </div>
     </div>
@@ -18,7 +19,7 @@
     <div class="flex">
         <div class="w-1/2 mr-4">
             <h3><i class="fa fa-file-text-o"></i> Speaker Bio</h3>
-            {{ speaker.bio|striptags|markdown }}
+            {% if speaker.isAllowedToSee('bio') %}{{ speaker.bio|striptags|markdown }} {% endif %}
         </div>
         <div class="w-1/2">
             {% if talks | length > 0 %}
@@ -31,11 +32,11 @@
 
             {% if site.online_conference == false %}
                 <h3 class="mt-3">Other Information</h3>
-                <strong>Need Transportation:</strong> {% if speaker.transportation == '1' %} Yes {% else %} No {% endif %}<br />
-                <strong>Need Hotel:</strong> {% if speaker.hotel == '1' %} Yes {% else %} No {% endif %}
+                {% if speaker.isAllowedToSee('transportation') %}<strong>Need Transportation:</strong> {% if speaker.transportation == '1' %} Yes {% else %} No {% endif %}<br /> {% endif %}
+                {% if speaker.isAllowedToSee('hotel') %}<strong>Need Hotel:</strong> {% if speaker.hotel == '1' %} Yes {% else %} No {% endif %} {% endif %}
             {% endif %}
 
-            {% if speaker.info is not empty %}
+            {% if speaker.isAllowedToSee('info') and  speaker.info is not empty %}
                 <h3>Additional Notes</h3>
                 <p>{{ speaker.info }}</p>
             {% endif %}

--- a/resources/views/reviewer/talks/view.twig
+++ b/resources/views/reviewer/talks/view.twig
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between">
         <div>
             <h2 class="mb-2">
-                {{ talk.title|raw }} <span class="text-grey-dark">&mdash; {{ speaker.name }}</span>
+                {{ talk.title|raw }} {% if speaker.isAllowedToSee('name') %}<span class="text-grey-dark">&mdash; {{ speaker.name }}</span> {% endif %}
             </h2>
             {% if talk.slides is defined and talk.slides is not empty %}
                 <div><i class="fa fa-television mr-1"></i> <a class="hover:text-brand" href="{{ talk.slides }}">{{ talk.slides }}</a></div>


### PR DESCRIPTION
This PR adds the option to limit what information the reviewers can see about speakers. 

By adding entries to the new config option they can blacklist things the reviewer isn't allowed to see. This would make it possible to open up reviewing to a bigger audience, while keeping private information away from them.

Follows #566 
Related to #485, #415.