### PR TITLE
Refactor: Introduction of the Talk Profile and Talk Handler

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -15,6 +15,7 @@ use OpenCFP\Provider\ImageProcessorProvider;
 use OpenCFP\Provider\ResetEmailerServiceProvider;
 use OpenCFP\Provider\SentryServiceProvider;
 use OpenCFP\Provider\TalkFilterProvider;
+use OpenCFP\Provider\TalkHandlerProvider;
 use OpenCFP\Provider\TalkHelperProvider;
 use OpenCFP\Provider\TalkRatingProvider;
 use OpenCFP\Provider\TwigServiceProvider;
@@ -93,6 +94,7 @@ class Application extends SilexApplication
         $this->register(new HtmlPurifierServiceProvider);
         $this->register(new ImageProcessorProvider);
         $this->register(new ResetEmailerServiceProvider());
+        $this->register(new TalkHandlerProvider());
         $this->register(new TalkHelperProvider());
         $this->register(new TalkRatingProvider());
         $this->register(new TalkFilterProvider());

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -175,11 +175,24 @@ class Talk extends Eloquent
             });
     }
 
-    public function getMetaFor(int $userId): TalkMeta
+    public function getMetaFor(int $userId, bool $create = false)
+    {
+        return $create ? $this->getOrCreateMeta($userId): $this->getOrFailMeta($userId);
+    }
+
+    private function getOrCreateMeta(int $userId)
     {
         return $this->meta()->firstOrCreate([
-           'admin_user_id' => $userId,
-           'talk_id'       => $this->id,
+            'admin_user_id' => $userId,
+            'talk_id'       => $this->id,
+        ]);
+    }
+
+    private function getOrFailMeta(int $userId)
+    {
+        return $this->meta()->firstOrFail([
+            'admin_user_id' => $userId,
+            'talk_id'       => $this->id,
         ]);
     }
 }

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -201,9 +201,9 @@ class Talk extends Eloquent
 
     private function getOrFailMeta(int $userId)
     {
-        return $this->meta()->firstOrFail([
-            'admin_user_id' => $userId,
-            'talk_id'       => $this->id,
-        ]);
+        return $this->meta()
+            ->where('admin_user_id', $userId)
+            ->where('talk_id', $this->id)
+            ->firstOrFail();
     }
 }

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -175,9 +175,20 @@ class Talk extends Eloquent
             });
     }
 
-    public function getMetaFor(int $userId, bool $create = false)
+    /**
+     * Gets the meta object of the current talk, with a specific Admin.
+     *
+     * @param int  $userId
+     * @param bool $willCreate on true it will create a new model if it doesn't exists, on false
+     *                         it will throw an error.
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     *
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function getMetaFor(int $userId, bool $willCreate = false)
     {
-        return $create ? $this->getOrCreateMeta($userId): $this->getOrFailMeta($userId);
+        return $willCreate ? $this->getOrCreateMeta($userId): $this->getOrFailMeta($userId);
     }
 
     private function getOrCreateMeta(int $userId)

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -174,4 +174,12 @@ class Talk extends Eloquent
                 }
             });
     }
+
+    public function getMetaFor(int $userId): TalkMeta
+    {
+        return $this->meta()->firstOrCreate([
+           'admin_user_id' => $userId,
+           'talk_id'       => $this->id,
+        ]);
+    }
 }

--- a/classes/Domain/Services/TalkFormat.php
+++ b/classes/Domain/Services/TalkFormat.php
@@ -8,5 +8,5 @@ interface TalkFormat
 {
     public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true): Collection;
 
-    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true): array;
+    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true);
 }

--- a/classes/Domain/Services/TalkFormat.php
+++ b/classes/Domain/Services/TalkFormat.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Collection;
 
 interface TalkFormat
 {
-    public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true): Collection;
+    public function formatList(Collection $talkCollection, int $adminUserId, bool $userData = true): Collection;
 
-    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true);
+    public function createdFormattedOutput($talk, int $adminUserId, bool $userData = true);
 }

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -3,7 +3,6 @@
 namespace OpenCFP\Domain\Talk;
 
 use Illuminate\Support\Collection;
-use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Services\TalkFormat;
 
 class TalkFormatter implements TalkFormat
@@ -21,7 +20,7 @@ class TalkFormatter implements TalkFormat
     {
         return $talkCollection
             ->map(function ($talk) use ($admin_user_id, $userData) {
-                return $this->createdFormattedOutput($talk, $admin_user_id, $userData);
+                return new TalkProfile($talk, $admin_user_id);
             });
     }
 
@@ -32,82 +31,10 @@ class TalkFormatter implements TalkFormat
      * @param int   $admin_user_id
      * @param bool  $userData      grab the speaker data or not
      *
-     * @return array
+     * @return TalkProfile
      */
-    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true): array
+    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true)
     {
-        if ($talk->favorites) {
-            foreach ($talk->favorites as $favorite) {
-                if ($favorite->admin_user_id == $admin_user_id) {
-                    $talk->favorite = 1;
-                }
-            }
-        }
-        $meta = $this->getTalkMeta($talk, $admin_user_id);
-
-        $output = [
-            'id'          => $talk->id,
-            'title'       => $talk->title,
-            'type'        => $talk->type,
-            'category'    => $talk->category,
-            'created_at'  => $talk->created_at,
-            'selected'    => $talk->selected,
-            'favorite'    => $talk->favorite,
-            'meta'        => $meta,
-            'description' => $talk->description,
-            'slides'      => $talk->slides,
-            'other'       => $talk->other,
-            'level'       => $talk->level,
-            'desired'     => $talk->desired,
-            'sponsor'     => $talk->sponsor,
-        ];
-
-        if ($talk->speaker && $userData) {
-            $output['user'] = [
-                'id'         => $talk->speaker->id,
-                'first_name' => $talk->speaker->first_name,
-                'last_name'  => $talk->speaker->last_name,
-            ];
-
-            $output += [
-                'speaker_id'             => $talk->speaker->id,
-                'speaker_first_name'     => $talk->speaker->first_name,
-                'speaker_last_name'      => $talk->speaker->last_name,
-                'speaker_email'          => $talk->speaker->email,
-                'speaker_company'        => $talk->speaker->company,
-                'speaker_twitter'        => $talk->speaker->twitter,
-                'speaker_airport'        => $talk->speaker->airport,
-                'speaker_hotel'          => $talk->speaker->hotel,
-                'speaker_transportation' => $talk->speaker->transportation,
-                'speaker_info'           => $talk->speaker->info,
-                'speaker_bio'            => $talk->speaker->bio,
-            ];
-        }
-
-        if ($talk->total_rating) {
-            $output['total_rating'] = $talk->total_rating;
-            $output['review_count'] = $talk->review_count;
-        }
-
-        return $output;
-    }
-
-    /**
-     * Grabs the related meta information of the talk, or 0's when there is none
-     *
-     * @param mixed $talk          Talk we want to get the meta of, both entity and model work.
-     * @param int   $admin_user_id user ID of the admin
-     *
-     * @return TalkMeta
-     */
-    protected function getTalkMeta($talk, int $admin_user_id): TalkMeta
-    {
-        $meta = TalkMeta::where('talk_id', $talk->id)->where('admin_user_id', $admin_user_id)->first();
-
-        if ($meta instanceof TalkMeta) {
-            return $meta;
-        }
-
-        return new TalkMeta(['rating' => 0, 'viewed' => 0]);
+        return new TalkProfile($talk, $admin_user_id);
     }
 }

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -11,16 +11,16 @@ class TalkFormatter implements TalkFormat
      * Iterates over a collection of DBAL objects and returns a formatted result set
      *
      * @param Collection $talkCollection Collection of Talks
-     * @param int        $admin_user_id
+     * @param int        $adminUserId
      * @param bool       $userData
      *
      * @return Collection
      */
-    public function formatList(Collection $talkCollection, int $admin_user_id, bool $userData = true): Collection
+    public function formatList(Collection $talkCollection, int $adminUserId, bool $userData = true): Collection
     {
         return $talkCollection
-            ->map(function ($talk) use ($admin_user_id, $userData) {
-                return new TalkProfile($talk, $admin_user_id);
+            ->map(function ($talk) use ($adminUserId, $userData) {
+                return new TalkProfile($talk, $adminUserId);
             });
     }
 
@@ -28,13 +28,13 @@ class TalkFormatter implements TalkFormat
      * Iterates over DBAL objects and returns a formatted result set
      *
      * @param mixed $talk
-     * @param int   $admin_user_id
-     * @param bool  $userData      grab the speaker data or not
+     * @param int   $adminUserId
+     * @param bool  $userData    grab the speaker data or not
      *
      * @return TalkProfile
      */
-    public function createdFormattedOutput($talk, int $admin_user_id, bool $userData = true)
+    public function createdFormattedOutput($talk, int $adminUserId, bool $userData = true)
     {
-        return new TalkProfile($talk, $admin_user_id);
+        return new TalkProfile($talk, $adminUserId);
     }
 }

--- a/classes/Domain/Talk/TalkHandler.php
+++ b/classes/Domain/Talk/TalkHandler.php
@@ -2,6 +2,13 @@
 
 namespace OpenCFP\Domain\Talk;
 
+use OpenCFP\Domain\Model\Favorite;
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\TalkComment;
+use OpenCFP\Domain\Services\IdentityProvider;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingStrategy;
+
 class TalkHandler
 {
     /**
@@ -9,35 +16,106 @@ class TalkHandler
      */
     private $talk;
 
-    public function create()
-    {
+    /**
+     * @var int
+     */
+    private $userId;
+
+    /**
+     * @var TalkRatingStrategy
+     */
+    private $ratingStrategy;
+
+    public function __construct(
+        IdentityProvider $identityProvider,
+        TalkRatingStrategy $ratingStrategy
+    ) {
+        $this->userId         = (int) $identityProvider->getCurrentUser()->id;
+        $this->ratingStrategy = $ratingStrategy;
     }
 
-    public function update()
+    /**
+     * This function is used to dynamically set the Talk to deal with, after the class is initialized by its provider.
+     *
+     * @param Talk $talk
+     *
+     * @return $this
+     */
+    public function with(Talk $talk)
     {
+        $this->talk = $talk;
+
+        return $this;
     }
 
-    public function delete()
+    public function commentOn(string $message): bool
     {
+        TalkComment::create([
+           'user_id'  => $this->userId,
+            'talk_id' => $this->talk->id,
+            'message' => $message,
+        ]);
+
+        return true;
     }
 
-    public function commentOn(string $message)
+    public function select(bool $selected = true): bool
     {
+        $this->talk->selected = $selected;
+
+        return $this->talk->save();
     }
 
-    public function select()
+    public function favorite(bool $create = true): bool
     {
+        return $create ? $this->createFavorite() : $this->deleteFavorite();
     }
 
-    public function favorite()
+    private function createFavorite(): bool
     {
+        Favorite::firstOrCreate([
+            'user_id' => $this->userId,
+            'talk_id' => $this->talk->id,
+        ]);
+
+        return true;
     }
 
-    public function rate($rating)
+    private function deleteFavorite(): bool
     {
+        try {
+            Favorite::findOrFail([
+                'user_id' => $this->userId,
+                'talk_id' => $this->talk->id,
+            ])->delete();
+
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
-    public function view()
+    public function rate($rating): bool
     {
+        try {
+            $this->ratingStrategy->rate($this->talk->id, $rating);
+
+            return true;
+        } catch (TalkRatingException $e) {
+            return false;
+        }
+    }
+
+    public function view(): bool
+    {
+        try {
+            $meta = $this->talk
+                ->getMetaFor($this->userId, true);
+            $meta->viewed = 1;
+
+            return $meta->save();
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 }

--- a/classes/Domain/Talk/TalkHandler.php
+++ b/classes/Domain/Talk/TalkHandler.php
@@ -165,4 +165,9 @@ class TalkHandler
 
         return false;
     }
+
+    public function getProfile()
+    {
+        return new TalkProfile($this->talk, $this->userId);
+    }
 }

--- a/classes/Domain/Talk/TalkHandler.php
+++ b/classes/Domain/Talk/TalkHandler.php
@@ -111,10 +111,12 @@ class TalkHandler
 
     private function createFavoriteForCurrentUser(): bool
     {
-        Favorite::firstOrCreate([
-            'admin_user_id' => $this->userId,
-            'talk_id'       => $this->talk->id,
-        ]);
+        $this->talk
+            ->favorites()
+            ->firstOrCreate([
+                'admin_user_id' => $this->userId,
+                'talk_id'       => $this->talk->id,
+            ]);
 
         return true;
     }
@@ -122,8 +124,10 @@ class TalkHandler
     private function clearFavoriteOfCurrentUser(): bool
     {
         try {
-            $favorite = Favorite::where('admin_user_id', $this->userId)
-                ->where('talk_id', $this->talk->id)->first();
+            $favorite = $this->talk->favorites()
+                ->where('talk_id', $this->talk->id)
+                ->where('admin_user_id', $this->userId)
+                ->first();
             if ($favorite instanceof Favorite) {
                 $favorite->delete();
             }

--- a/classes/Domain/Talk/TalkHandler.php
+++ b/classes/Domain/Talk/TalkHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OpenCFP\Domain\Talk;
+
+class TalkHandler
+{
+    /**
+     * @var Talk
+     */
+    private $talk;
+
+    public function create()
+    {
+    }
+
+    public function update()
+    {
+    }
+
+    public function delete()
+    {
+    }
+
+    public function commentOn(string $message)
+    {
+    }
+
+    public function select()
+    {
+    }
+
+    public function favorite()
+    {
+    }
+
+    public function rate($rating)
+    {
+    }
+
+    public function view()
+    {
+    }
+}

--- a/classes/Domain/Talk/TalkProfile.php
+++ b/classes/Domain/Talk/TalkProfile.php
@@ -4,9 +4,13 @@ namespace OpenCFP\Domain\Talk;
 
 use Illuminate\Support\Collection;
 use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 
+/**
+ * This class is a read only version of a Talk, to be used in the views
+ *
+ * When initiated without an ID the rating, viewed and favorite functions will return default values
+ */
 class TalkProfile
 {
     /**
@@ -16,22 +20,20 @@ class TalkProfile
 
     private $userId;
 
-    public function __construct(
-        IdentityProvider $identityProvider
-    ) {
-        $this->userId = (int) $identityProvider->getCurrentUser()->id;
-    }
-
-    public function with(Talk $talk)
+    public function __construct(Talk $talk, int $userId = 0)
     {
-        $this->talk = $talk;
-
-        return $this;
+        $this->talk   = $talk;
+        $this->userId = $userId;
     }
 
     public function getSpeaker(): SpeakerProfile
     {
-        return new SpeakerProfile($this->talk->speaker->first());
+        return new SpeakerProfile($this->talk->speaker);
+    }
+
+    public function getId()
+    {
+        return $this->talk->id;
     }
 
     public function getTitle()
@@ -105,7 +107,7 @@ class TalkProfile
         }
     }
 
-    public function isViewed(): bool
+    public function isViewedByMe(): bool
     {
         try {
             return $this->talk
@@ -125,5 +127,10 @@ class TalkProfile
         } catch (\Exception $e) {
             return false;
         }
+    }
+
+    public function getOtherTalks()
+    {
+        return $this->talk->speaker->getOtherTalks($this->talk->id);
     }
 }

--- a/classes/Domain/Talk/TalkProfile.php
+++ b/classes/Domain/Talk/TalkProfile.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace OpenCFP\Domain\Talk;
+
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Speaker\SpeakerProfile;
+
+class TalkProfile
+{
+    /**
+     * @var Talk
+     */
+    private $talk;
+
+    private $userId;
+
+    public function __construct($talk, int $userId)
+    {
+        if ($talk instanceof Talk) {
+            $this->talk = $talk;
+        }
+        if (is_int($talk)) {
+            $this->talk   = Talk::findOrFail($talk);
+        }
+        $this->userId = $userId;
+    }
+
+    public function getSpeaker(): SpeakerProfile
+    {
+        return new SpeakerProfile($this->talk->speaker->first());
+    }
+
+    public function getTitle()
+    {
+        return $this->talk->title;
+    }
+
+    public function getDescription()
+    {
+        return $this->talk->description;
+    }
+
+    public function getOther()
+    {
+        return $this->talk->other;
+    }
+
+    public function getType()
+    {
+        return $this->talk->type;
+    }
+
+    public function getLevel()
+    {
+        return $this->talk->level;
+    }
+
+    public function getCategory()
+    {
+        return $this->talk->category;
+    }
+
+    public function getSlides()
+    {
+        return $this->talk->slides;
+    }
+
+    public function isDesired(): bool
+    {
+        return $this->talk->desired == 1;
+    }
+
+    public function isSponsor(): bool
+    {
+        return $this->talk->sponsor ==1;
+    }
+
+    public function isFavorite(): bool
+    {
+        return $this->talk->favorite ==1;
+    }
+
+    public function isSelected(): bool
+    {
+        return $this->talk->selected ==1;
+    }
+
+    public function getComments()
+    {
+        return $this->talk->comments()->get();
+    }
+
+    public function getRating()
+    {
+        return $this->talk
+            ->meta()
+            ->where('admin_user_id', $this->userId)
+            ->first()
+            ->rating;
+    }
+
+    public function isViewed(): bool
+    {
+        return $this->talk
+            ->meta()
+            ->where('admin_user_id', $this->userId)
+            ->first()
+            ->viewed == 1;
+    }
+}

--- a/classes/Domain/Talk/TalkProfile.php
+++ b/classes/Domain/Talk/TalkProfile.php
@@ -17,11 +17,16 @@ class TalkProfile
     private $userId;
 
     public function __construct(
-        Talk $talk,
         IdentityProvider $identityProvider
     ) {
-        $this->talk   = $talk;
         $this->userId = (int) $identityProvider->getCurrentUser()->id;
+    }
+
+    public function with(Talk $talk)
+    {
+        $this->talk = $talk;
+
+        return $this;
     }
 
     public function getSpeaker(): SpeakerProfile

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -2,15 +2,12 @@
 
 namespace OpenCFP\Http\Controller\Admin;
 
-use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Domain\Model\TalkComment;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\Pagination;
-use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
-use OpenCFP\Domain\Services\TalkRating\TalkRatingStrategy;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Domain\Talk\TalkFilter;
+use OpenCFP\Domain\Talk\TalkHandler;
 use OpenCFP\Http\Controller\BaseController;
 use OpenCFP\Http\Controller\FlashableTrait;
 use Symfony\Component\HttpFoundation\Request;
@@ -103,19 +100,9 @@ class TalksController extends BaseController
 
     public function rateAction(Request $req)
     {
-        /** @var TalkRatingStrategy $talkRatingStrategy */
-        $talkRatingStrategy = $this->service(TalkRatingStrategy::class);
-
-        try {
-            $talk_rating = (int) $req->get('rating');
-            $talk_id     = (int) $req->get('id');
-
-            $talkRatingStrategy->rate($talk_id, $talk_rating);
-        } catch (TalkRatingException $e) {
-            return false;
-        }
-
-        return true;
+        return $this->service(TalkHandler::class)
+            ->grabTalk((int) $req->get('id'))
+            ->rate((int) $req->get('rating'));
     }
 
     /**
@@ -127,29 +114,9 @@ class TalksController extends BaseController
      */
     public function favoriteAction(Request $req)
     {
-        $admin_user_id = $this->service(Authentication::class)->userId();
-        $talkId        = (int) $req->get('id');
-
-        if ($req->get('delete') !== null) {
-            // Delete the record that matches
-            $favorite = Favorite::where('admin_user_id', $admin_user_id)
-                ->where('talk_id', $talkId)
-                ->first();
-            if ($favorite instanceof  Favorite) {
-                $favorite->delete();
-
-                return true;
-            }
-
-            return false;
-        }
-
-        Favorite::firstOrCreate([
-            'admin_user_id' => $admin_user_id,
-            'talk_id'       => $talkId,
-        ]);
-
-        return true;
+        return $this->service(TalkHandler::class)
+            ->grabTalk((int) $req->get('id'))
+            ->setFavorite($req->get('delete') == null);
     }
 
     /**
@@ -161,26 +128,19 @@ class TalksController extends BaseController
      */
     public function selectAction(Request $req)
     {
-        $talk = Talk::find($req->get('id'));
-        if ($talk instanceof Talk) {
-            $talk->selected = $req->get('delete') == true ? 0 :1;
-            $talk->save();
-
-            return true;
-        }
-
-        return false;
+        return $this->service(TalkHandler::class)
+            ->grabTalk((int) $req->get('id'))
+            ->select($req->get('delete') != true);
     }
 
     public function commentCreateAction(Request $req)
     {
-        $talk_id = (int) $req->get('id');
-        
-        TalkComment::create([
-            'talk_id' => $talk_id,
-            'user_id' => $this->service(Authentication::class)->userId(),
-            'message' => $req->get('comment'),
-        ]);
+        $talkId = (int) $req->get('id');
+
+        /** @var TalkHandler $handler */
+        $this->service(TalkHandler::class)
+            ->grabTalk($talkId)
+            ->commentOn($req->get('comment'));
 
         $this->service('session')->set('flash', [
                 'type'  => 'success',
@@ -188,6 +148,6 @@ class TalksController extends BaseController
                 'ext'   => 'Comment Added!',
             ]);
 
-        return $this->app->redirect($this->url('admin_talk_view', ['id' => $talk_id]));
+        return $this->app->redirect($this->url('admin_talk_view', ['id' => $talkId]));
     }
 }

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -2,7 +2,6 @@
 
 namespace OpenCFP\Http\Controller\Reviewer;
 
-use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Talk\TalkFilter;

--- a/classes/Provider/TalkHandlerProvider.php
+++ b/classes/Provider/TalkHandlerProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenCFP\Provider;
+
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingStrategy;
+use OpenCFP\Domain\Talk\TalkHandler;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class TalkHandlerProvider implements ServiceProviderInterface
+{
+    public function register(Container $app)
+    {
+        $app[TalkHandler::class] = function ($app) {
+            return new TalkHandler($app[Authentication::class], $app[TalkRatingStrategy::class]);
+        };
+    }
+}

--- a/resources/views/admin/index.twig
+++ b/resources/views/admin/index.twig
@@ -54,7 +54,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.user.first_name }} {{ talk.user.last_name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>
@@ -62,9 +62,9 @@
                     </div>
                 </div>
                 <div>
-                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up {% if talk.meta.rating == 1 %}text-green-dark{% endif %}"></i></a>
-                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down {% if talk.meta.rating == -1 %}text-red-dark{% endif %}"></i></a>
-                    <a href="#" id="talk-favorite-{{ talk.id }}" class="js-talk-favorite" data-id="{{ talk.id }}" title="Favorite!"><i class="fa fa-star {% if talk.favorite == 1 %}text-orange-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up {% if talk.rating == 1 %}text-green-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down {% if talk.rating == -1 %}text-red-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-favorite-{{ talk.id }}" class="js-talk-favorite" data-id="{{ talk.id }}" title="Favorite!"><i class="fa fa-star {% if talk.myFavorite == 1 %}text-orange-dark{% endif %}"></i></a>
                     <a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}" title="Select this talk"><i class="fa fa-check-square {% if talk.selected == 1 %}text-indigo-dark{% endif %}"></i></a>
                 </div>
             </div>

--- a/resources/views/admin/talks/index.twig
+++ b/resources/views/admin/talks/index.twig
@@ -43,7 +43,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.user.first_name }} {{ talk.user.last_name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>
@@ -51,9 +51,9 @@
                     </div>
                 </div>
                 <div>
-                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up {% if talk.meta.rating == 1 %}text-green-dark{% endif %}"></i></a>
-                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down {% if talk.meta.rating == -1 %}text-red-dark{% endif %}"></i></a>
-                    <a href="#" id="talk-favorite-{{ talk.id }}" class="js-talk-favorite" data-id="{{ talk.id }}" title="Favorite!"><i class="fa fa-star {% if talk.favorite == 1 %}text-orange-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up {% if talk.rating == 1 %}text-green-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down {% if talk.rating == -1 %}text-red-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-favorite-{{ talk.id }}" class="js-talk-favorite" data-id="{{ talk.id }}" title="Favorite!"><i class="fa fa-star {% if talk.myFavorite == 1 %}text-orange-dark{% endif %}"></i></a>
                     <a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}" title="Select this talk"><i class="fa fa-check-square {% if talk.selected == 1 %}text-indigo-dark{% endif %}"></i></a>
                 </div>
             </div>

--- a/resources/views/admin/talks/view.twig
+++ b/resources/views/admin/talks/view.twig
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between">
         <div>
             <h2 class="mb-2">
-                {{ talk.title|raw }} <span class="text-grey-dark">&mdash; {{ speaker.name }}</span>
+                {{ talk.title|raw }} <span class="text-grey-dark">&mdash; {{ talk.speaker.name }}</span>
             </h2>
             {% if talk.slides is defined and talk.slides is not empty %}
                 <div><i class="fa fa-television mr-1"></i> <a class="hover:text-brand" href="{{ talk.slides }}">{{ talk.slides }}</a></div>
@@ -21,9 +21,9 @@
 
             {% if talk.desired or talk.sponsor %}<span class="mr-3 border-r border-grey"></span>{% endif %}
 
-            <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating mr-3" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up admin-icon{% if talk_meta.rating == 1 %} text-green-dark{% endif %}"></i></a>
-            <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating mr-3" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down admin-icon{% if talk_meta.rating == -1 %} text-red-dark{% endif %}"></i></a>
-            <a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}" title="Select this talk"><i class="fa fa-check-square admin-icon{% if talk.selected == 1 %} text-indigo-dark{% endif %}"></i></a>
+            <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating mr-3" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up admin-icon{% if talk.rating == 1 %} text-green-dark{% endif %}"></i></a>
+            <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating mr-3" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down admin-icon{% if talk.rating == -1 %} text-red-dark{% endif %}"></i></a>
+            <a href="#" id="talk-select-{{ talk.id }}" class="js-talk-select" data-id="{{ talk.id }}" title="Select this talk"><i class="fa fa-check-square admin-icon{% if talk.selected == true %} text-indigo-dark{% endif %}"></i></a>
         </div>
     </div>
 
@@ -36,19 +36,19 @@
             {% endif %}
         </div>
         <div>
-            {% if otherTalks | length > 0 %}
+            {% if talk.otherTalks | length > 0 %}
                 <h3><i class="fa fa-bullhorn"></i> Other Talks...</h3>
-                {% for talk in otherTalks %}
+                {% for talk in talk.otherTalks %}
                     <p><a class="text-brand underline" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title }}</a></p>
                 {% endfor %}
             {% endif %}
         </div>
     </div>
 
-    {% if comments is defined and comments|length > 0 %}
+    {% if talk.comments and talk.comments|length > 0 %}
         <h3 class="my-4"><i class="fa fa-comments"></i> Comments</h3>
 
-        {% for comment in comments %}
+        {% for comment in talk.comments %}
             {% set user = comment.user.toArray %}
             <div class="flex text-sm mt-4">
                 <div>

--- a/resources/views/reviewer/index.twig
+++ b/resources/views/reviewer/index.twig
@@ -54,7 +54,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.user.first_name }} {{ talk.user.last_name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>
@@ -62,8 +62,8 @@
                     </div>
                 </div>
                 <div>
-                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up {% if talk.meta.rating == 1 %}text-green-dark{% endif %}"></i></a>
-                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down {% if talk.meta.rating == -1 %}text-red-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up {% if talk.rating == 1 %}text-green-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down {% if talk.rating == -1 %}text-red-dark{% endif %}"></i></a>
                 </div>
             </div>
         {% endfor %}

--- a/resources/views/reviewer/talks/index.twig
+++ b/resources/views/reviewer/talks/index.twig
@@ -43,7 +43,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.user.first_name }} {{ talk.user.last_name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>
@@ -51,8 +51,8 @@
                     </div>
                 </div>
                 <div>
-                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up {% if talk.meta.rating == 1 %}text-green-dark{% endif %}"></i></a>
-                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down {% if talk.meta.rating == -1 %}text-red-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up {% if talk.rating == 1 %}text-green-dark{% endif %}"></i></a>
+                    <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down {% if talk.rating == -1 %}text-red-dark{% endif %}"></i></a>
                 </div>
             </div>
         {% endfor %}

--- a/resources/views/reviewer/talks/view.twig
+++ b/resources/views/reviewer/talks/view.twig
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between">
         <div>
             <h2 class="mb-2">
-                {{ talk.title|raw }} {% if speaker.isAllowedToSee('name') %}<span class="text-grey-dark">&mdash; {{ speaker.name }}</span> {% endif %}
+                {{ talk.title|raw }} {% if talk.speaker.isAllowedToSee('name') %}<span class="text-grey-dark">&mdash; {{ talk.speaker.name }}</span> {% endif %}
             </h2>
             {% if talk.slides is defined and talk.slides is not empty %}
                 <div><i class="fa fa-television mr-1"></i> <a class="hover:text-brand" href="{{ talk.slides }}">{{ talk.slides }}</a></div>
@@ -21,8 +21,8 @@
 
             {% if talk.desired or talk.sponsor %}<span class="mr- border-r border-grey"></span>{% endif %}
 
-            <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating mr-3" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up admin-icon{% if talk_meta.rating == 1 %} text-green-dark{% endif %}"></i></a>
-            <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating mr-3" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down admin-icon{% if talk_meta.rating == -1 %} text-red-dark{% endif %}"></i></a>
+            <a href="#" id="talk-upvote-{{ talk.id }}" class="js-talk-rating mr-3" data-id="{{ talk.id }}" data-rating="1" title="I want to see this talk"><i class="fa fa-thumbs-up admin-icon{% if talk.rating == 1 %} text-green-dark{% endif %}"></i></a>
+            <a href="#" id="talk-downvote-{{ talk.id }}" class="js-talk-rating mr-3" data-id="{{ talk.id }}" data-rating="-1" title="I don't want to see this talk"><i class="fa fa-thumbs-down admin-icon{% if talk.rating == -1 %} text-red-dark{% endif %}"></i></a>
         </div>
     </div>
 
@@ -35,19 +35,21 @@
             {% endif %}
         </div>
         <div>
-            {% if otherTalks | length > 0 %}
+            {% if talk.otherTalks | length > 0 %}
                 <h3><i class="fa fa-bullhorn"></i> Other Talks...</h3>
-                {% for talk in otherTalks %}
+                {% for talk in talk.otherTalks %}
                     <p><a class="text-brand underline" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title }}</a></p>
                 {% endfor %}
             {% endif %}
         </div>
     </div>
 
-    {% if comments is defined and comments|length > 0 %}
+    {% if talk.comments and talk.comments|length > 0 %}
         <h3 class="my-4"><i class="fa fa-comments"></i> Comments</h3>
 
-        {% for comment in comments %}
+        {% for comment in talk.comments %}
+            {% set user = comment.user.toArray %}
+
             <div class="flex text-sm mt-4">
                 <div>
                     <img class="w-16 mr-4 rounded" src="{{ comment.user.photo_path ? '/uploads/' ~ comment.user.photo_path : '/assets/img/dummyphoto.jpg' }}">

--- a/tests/Domain/Services/TalkFormatterTest.php
+++ b/tests/Domain/Services/TalkFormatterTest.php
@@ -32,10 +32,10 @@ class TalkFormatterTest extends BaseTestCase
 
         $format =$formatter->createdFormattedOutput($talk->first(), 1);
 
-        $this->assertEquals('One talk to rule them all', $format['title']);
-        $this->assertEquals('api', $format['category']);
-        $this->assertEquals(0, $format['meta']->rating);
-        $this->assertEquals(0, $format['meta']->viewed);
+        $this->assertEquals('One talk to rule them all', $format->getTitle());
+        $this->assertEquals('api', $format->getCategory());
+        $this->assertEquals(0, $format->getRating());
+        $this->assertEquals(0, $format->isViewedByMe());
     }
 
     /**
@@ -49,8 +49,8 @@ class TalkFormatterTest extends BaseTestCase
         // Now to see if the meta gets put in correctly
         $secondFormat =$formatter->createdFormattedOutput($talk->first(), 2);
 
-        $this->assertEquals(1, $secondFormat['meta']->rating);
-        $this->assertEquals(1, $secondFormat['meta']->viewed);
+        $this->assertEquals(1, $secondFormat->getRating());
+        $this->assertEquals(1, $secondFormat->isViewedByMe());
     }
 
     /**

--- a/tests/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Domain/Talk/TalkHandlerTest.php
@@ -9,6 +9,7 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
 use OpenCFP\Domain\Services\TalkRating\TalkRatingStrategy;
 use OpenCFP\Domain\Talk\TalkHandler;
+use OpenCFP\Domain\Talk\TalkProfile;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\RefreshDatabase;
 
@@ -110,6 +111,18 @@ class TalkHandlerTest extends BaseTestCase
     /**
      * @test
      */
+    public function favoriteReturnsFalseWhenDeleteErrors()
+    {
+        $talk = Mockery::mock(Talk::class);
+        $talk->shouldReceive('favorites')->andThrow(\Exception::class);
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $talkHandler->with($talk);
+        $this->assertFalse($talkHandler->setFavorite(false));
+    }
+
+    /**
+     * @test
+     */
     public function rateReturnsTrueOnSuccess()
     {
         $talk        = self::$talk;
@@ -203,5 +216,19 @@ class TalkHandlerTest extends BaseTestCase
         $talkHandler->grabTalk(45678);
 
         $this->assertFalse($talkHandler->view());
+    }
+
+    /**
+     * @test
+     */
+    public function getProfileReturnsTalkProfile()
+    {
+        $talk        = self::$talk;
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $talkHandler->with($talk);
+        $profile = $talkHandler->getProfile();
+        $this->assertInstanceOf(TalkProfile::class, $profile);
+        //Check the talk got set correctly in the profile.
+        $this->assertEquals($talk->title, $profile->getTitle());
     }
 }

--- a/tests/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Domain/Talk/TalkHandlerTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace OpenCFP\Test\Domain\Talk;
+
+use Mockery;
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Model\TalkComment;
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
+use OpenCFP\Domain\Services\TalkRating\TalkRatingStrategy;
+use OpenCFP\Domain\Talk\TalkHandler;
+use OpenCFP\Test\BaseTestCase;
+use OpenCFP\Test\RefreshDatabase;
+
+class TalkHandlerTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    private static $talk;
+
+    private $authentication;
+    private $ratingSystem;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::$talk = factory(Talk::class, 1)->create(['selected' => 0])->first();
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+        $auth     = Mockery::mock(Authentication::class);
+        $auth->shouldReceive('userId')->andReturn(1);
+        $this->authentication = $auth;
+        $ratingSystem         = Mockery::mock(TalkRatingStrategy::class);
+        $ratingSystem->shouldReceive('rate');
+        $this->ratingSystem = $ratingSystem;
+    }
+
+    /**
+     * @test
+     */
+    public function commentOnSetsNewComment()
+    {
+        $talk        = self::$talk;
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $talkHandler->with($talk);
+        $this->assertTrue($talkHandler->commentOn('Nice Talk!'));
+        //Check if its set correctly in DB
+        $comment = TalkComment::first();
+        $this->assertSame('Nice Talk!', $comment->message);
+        $this->assertSame($talk->id, $comment->talk_id);
+        $this->assertSame(1, $comment->user_id);
+    }
+
+    /**
+     * @test
+     */
+    public function selectSelectsTalk()
+    {
+        $talk        = self::$talk;
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $talkHandler->with($talk);
+        $this->assertEquals(0, $talk->selected);
+
+        $this->assertTrue($talkHandler->select());
+        $this->assertEquals(1, $talk->selected);
+
+        $this->assertTrue($talkHandler->select(false));
+        $this->assertEquals(0, $talk->selected);
+    }
+
+    /**
+     * @test
+     */
+    public function favoriteCreatesAndDeletesFavorites()
+    {
+        $talk        = self::$talk;
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $talkHandler->with($talk);
+
+        //Check we have no favorites on this talk.
+        $this->assertCount(0, $talk->favorites()->get());
+        $this->assertTrue($talkHandler->setFavorite());
+        //The handler should have favorited the talk now.
+        $favorite = $talk->favorites()->get();
+        $this->assertCount(1, $favorite);
+        $this->assertEquals(1, $favorite->first()->admin_user_id);
+        
+        //Calling favorite again doesn't do anything
+        $this->assertTrue($talkHandler->setFavorite());
+        $favoriteAgain = $talk->favorites()->get();
+        $this->assertCount(1, $favoriteAgain);
+        $this->assertEquals(1, $favoriteAgain->first()->admin_user_id);
+
+        //Now to delete the favorite
+        $this->assertTrue($talkHandler->setFavorite(false));
+        //The handler should have deleted the favorite of the talk now.
+        $favoriteNoMore = $talk->favorites()->get();
+        $this->assertCount(0, $favoriteNoMore);
+
+        //Trying to remove it again doesn't do anything funky.
+        $this->assertTrue($talkHandler->setFavorite(false));
+        //The handler should have deleted the favorite of the talk now.
+        $favoriteStillGone = $talk->favorites()->get();
+        $this->assertCount(0, $favoriteStillGone);
+    }
+
+    /**
+     * @test
+     */
+    public function rateReturnsTrueOnSuccess()
+    {
+        $talk        = self::$talk;
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $talkHandler->with($talk);
+
+        // We aren't testing the rating system here, thats its own thing.
+        $this->assertTrue($talkHandler->rate(1));
+    }
+
+    /**
+     * @test
+     */
+    public function rateReturnsFalseOnError()
+    {
+        $talk           = self::$talk;
+        $ratingSystem   = Mockery::mock(TalkRatingStrategy::class);
+        $ratingSystem->shouldReceive('rate')->andThrow(TalkRatingException::class);
+        $talkHandler = new TalkHandler($this->authentication, $ratingSystem);
+        $talkHandler->with($talk);
+
+        // We aren't testing the rating system here, thats its own thing.
+        $this->assertFalse($talkHandler->rate(1));
+    }
+
+    /**
+     * @test
+     */
+    public function viewWillSetTheTalkToViewed()
+    {
+        $talk        = $talk = Mockery::mock(Talk::class)->makePartial();
+        $talk->shouldReceive('getMetaFor')->andReturnSelf();
+        $talk->shouldReceive('save')->andReturn(true);
+        $talk->viewed = 0;
+        $talkHandler  = new TalkHandler($this->authentication, $this->ratingSystem);
+        $talkHandler->with($talk);
+
+        $this->assertTrue($talkHandler->view());
+        $this->assertEquals(1, $talk->viewed);
+        //Calling it again doesn't do anything funky
+        $this->assertTrue($talkHandler->view());
+        $this->assertEquals(1, $talk->viewed);
+    }
+
+    /**
+     * @test
+     */
+    public function viewedWillReturnFalseOnError()
+    {
+        $talk        = $talk = Mockery::mock(Talk::class)->makePartial();
+        $talk->shouldReceive('getMetaFor')->andThrow(\Exception::class);
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $talkHandler->with($talk);
+
+        $this->assertFalse($talkHandler->view());
+        $this->assertNotEquals(1, $talk->viewed);
+    }
+
+    /**
+     * @test
+     */
+    public function allFunctionsReturnFalseWhenNoTalkSet()
+    {
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $this->assertFalse($talkHandler->commentOn('blabla'));
+        $this->assertFalse($talkHandler->select(true));
+        $this->assertFalse($talkHandler->select(false));
+        $this->assertFalse($talkHandler->setFavorite(true));
+        $this->assertFalse($talkHandler->setFavorite(false));
+        $this->assertFalse($talkHandler->rate(0));
+        $this->assertFalse($talkHandler->rate(5876987));
+        $this->assertFalse($talkHandler->view());
+    }
+
+    /**
+     * @test
+     */
+    public function grabTalkSetsTalkWithId()
+    {
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $this->assertInstanceOf(TalkHandler::class, $talkHandler->grabTalk((int) self::$talk->id));
+        $this->assertTrue($talkHandler->hasTalk());
+    }
+
+    /**
+     * @test
+     */
+    public function grabTalkGivesNoErrorsWhenWrongID()
+    {
+        $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
+        $talkHandler->grabTalk(45678);
+
+        $this->assertFalse($talkHandler->view());
+    }
+}

--- a/tests/Domain/Talk/TalkProfileTest.php
+++ b/tests/Domain/Talk/TalkProfileTest.php
@@ -2,11 +2,8 @@
 
 namespace OpenCFP\Test\Domain\Talk;
 
-use Cartalyst\Sentry\Users\UserInterface;
 use Illuminate\Support\Collection;
-use Mockery;
 use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Domain\Talk\TalkProfile;
 use OpenCFP\Test\BaseTestCase;
@@ -21,8 +18,6 @@ class TalkProfileTest extends BaseTestCase
      */
     private static $talk;
 
-    private $identity;
-
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
@@ -34,25 +29,23 @@ class TalkProfileTest extends BaseTestCase
         ])->first();
     }
 
-    public function setUp()
-    {
-        parent::setUp();
-        $user     = Mockery::mock(UserInterface::class);
-        $user->id = 1;
-        $provider = Mockery::mock(IdentityProvider::class);
-        $provider->shouldReceive('getCurrentUser')->andReturn($user);
-        $this->identity = $provider;
-    }
-
     /**
      * @test
      */
     public function getSpeakerReturnsSpeakerProfile()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $talkProfile->with(self::$talk);
-        $speaker = $talkProfile->getSpeaker();
+        $talkProfile = new TalkProfile(self::$talk);
+        $speaker     = $talkProfile->getSpeaker();
         $this->assertInstanceOf(SpeakerProfile::class, $speaker);
+    }
+
+    /**
+     * @test
+     */
+    public function getIdReturnsId()
+    {
+        $talkProfile = new TalkProfile(self::$talk);
+        $this->assertEquals(self::$talk->id, $talkProfile->getId());
     }
 
     /**
@@ -60,8 +53,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function getTitleReturnsTitle()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $this->assertSame(self::$talk->title, $talkProfile->with(self::$talk)->getTitle());
+        $talkProfile = new TalkProfile(self::$talk);
+        $this->assertSame(self::$talk->title, $talkProfile->getTitle());
     }
 
     /**
@@ -69,8 +62,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function getDescriptionReturnsDescription()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $this->assertSame(self::$talk->description, $talkProfile->with(self::$talk)->getDescription());
+        $talkProfile = new TalkProfile(self::$talk);
+        $this->assertSame(self::$talk->description, $talkProfile->getDescription());
     }
 
     /**
@@ -78,8 +71,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function getOtherReturnsOther()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $this->assertSame(self::$talk->other, $talkProfile->with(self::$talk)->getOther());
+        $talkProfile = new TalkProfile(self::$talk);
+        $this->assertSame(self::$talk->other, $talkProfile->getOther());
     }
 
     /**
@@ -87,8 +80,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function getTypeReturnsType()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $this->assertSame(self::$talk->type, $talkProfile->with(self::$talk)->getType());
+        $talkProfile = new TalkProfile(self::$talk);
+        $this->assertSame(self::$talk->type, $talkProfile->getType());
     }
 
     /**
@@ -96,8 +89,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function getLevelReturnsLevel()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $this->assertSame(self::$talk->level, $talkProfile->with(self::$talk)->getLevel());
+        $talkProfile = new TalkProfile(self::$talk);
+        $this->assertSame(self::$talk->level, $talkProfile->getLevel());
     }
 
     /**
@@ -105,8 +98,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function getCategoryReturnsCategory()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $this->assertSame(self::$talk->category, $talkProfile->with(self::$talk)->getCategory());
+        $talkProfile = new TalkProfile(self::$talk);
+        $this->assertSame(self::$talk->category, $talkProfile->getCategory());
     }
 
     /**
@@ -114,8 +107,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function getSlidesReturnsSlides()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $this->assertSame(self::$talk->slides, $talkProfile->with(self::$talk)->getSlides());
+        $talkProfile = new TalkProfile(self::$talk);
+        $this->assertSame(self::$talk->slides, $talkProfile->getSlides());
     }
 
     /**
@@ -123,9 +116,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function isDesiredReturnsBool()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $talkProfile->with(self::$talk);
-        $isDesired = $talkProfile->isDesired();
+        $talkProfile = new TalkProfile(self::$talk);
+        $isDesired   = $talkProfile->isDesired();
         $this->assertFalse($isDesired);
     }
 
@@ -134,9 +126,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function isSponsorReturnsBool()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $talkProfile->with(self::$talk);
-        $isSponsor = $talkProfile->isSponsor();
+        $talkProfile = new TalkProfile(self::$talk);
+        $isSponsor   = $talkProfile->isSponsor();
         $this->assertTrue($isSponsor);
     }
 
@@ -145,8 +136,7 @@ class TalkProfileTest extends BaseTestCase
      */
     public function isSpeakerFavoriteReturnsBool()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $talkProfile->with(self::$talk);
+        $talkProfile       = new TalkProfile(self::$talk);
         $isSpeakerFavorite = $talkProfile->isSpeakerFavorite();
         $this->assertTrue($isSpeakerFavorite);
     }
@@ -156,9 +146,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function isSelectedReturnsBool()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $talkProfile->with(self::$talk);
-        $isSelected = $talkProfile->isSelected();
+        $talkProfile = new TalkProfile(self::$talk);
+        $isSelected  = $talkProfile->isSelected();
         $this->assertFalse($isSelected);
     }
 
@@ -167,9 +156,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function getCommentsReturnsComments()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $talkProfile->with(self::$talk);
-        $comments = $talkProfile->getComments();
+        $talkProfile = new TalkProfile(self::$talk);
+        $comments    = $talkProfile->getComments();
         $this->assertInstanceOf(Collection::class, $comments);
         //The talk has no comments so it returns 0.
         $this->assertCount(0, $comments);
@@ -180,8 +168,7 @@ class TalkProfileTest extends BaseTestCase
      */
     public function getRatingReturnsZeroWhenNoRatingIsSetByUser()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $talkProfile->with(self::$talk);
+        $talkProfile = new TalkProfile(self::$talk);
         $this->assertSame(0, $talkProfile->getRating());
     }
 
@@ -190,9 +177,8 @@ class TalkProfileTest extends BaseTestCase
      */
     public function isViewedReturnsFalseWhenNoMetaIsSetForUser()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $talkProfile->with(self::$talk);
-        $this->assertFalse($talkProfile->isViewed());
+        $talkProfile = new TalkProfile(self::$talk);
+        $this->assertFalse($talkProfile->isViewedByMe());
     }
 
     /**
@@ -200,8 +186,7 @@ class TalkProfileTest extends BaseTestCase
      */
     public function isMyFavoriteReturnsFalseWhenNoFavoriteSet()
     {
-        $talkProfile = new TalkProfile($this->identity);
-        $talkProfile->with(self::$talk);
+        $talkProfile = new TalkProfile(self::$talk);
         $this->assertFalse($talkProfile->isMyFavorite());
     }
 }

--- a/tests/Domain/Talk/TalkProfileTest.php
+++ b/tests/Domain/Talk/TalkProfileTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace OpenCFP\Test\Domain\Talk;
+
+use Cartalyst\Sentry\Users\UserInterface;
+use Illuminate\Support\Collection;
+use Mockery;
+use OpenCFP\Domain\Model\Talk;
+use OpenCFP\Domain\Services\IdentityProvider;
+use OpenCFP\Domain\Speaker\SpeakerProfile;
+use OpenCFP\Domain\Talk\TalkProfile;
+use OpenCFP\Test\BaseTestCase;
+use OpenCFP\Test\RefreshDatabase;
+
+class TalkProfileTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var Talk
+     */
+    private static $talk;
+
+    private $identity;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::$talk = factory(Talk::class, 1)->create([
+            'desired'  => 0,
+            'sponsor'  => 1,
+            'favorite' => 1,
+            'selected' => 0,
+        ])->first();
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+        $user     = Mockery::mock(UserInterface::class);
+        $user->id = 1;
+        $provider = Mockery::mock(IdentityProvider::class);
+        $provider->shouldReceive('getCurrentUser')->andReturn($user);
+        $this->identity = $provider;
+    }
+
+    /**
+     * @test
+     */
+    public function getSpeakerReturnsSpeakerProfile()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $talkProfile->with(self::$talk);
+        $speaker = $talkProfile->getSpeaker();
+        $this->assertInstanceOf(SpeakerProfile::class, $speaker);
+    }
+
+    /**
+     * @test
+     */
+    public function getTitleReturnsTitle()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $this->assertSame(self::$talk->title, $talkProfile->with(self::$talk)->getTitle());
+    }
+
+    /**
+     * @test
+     */
+    public function getDescriptionReturnsDescription()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $this->assertSame(self::$talk->description, $talkProfile->with(self::$talk)->getDescription());
+    }
+
+    /**
+     * @test
+     */
+    public function getOtherReturnsOther()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $this->assertSame(self::$talk->other, $talkProfile->with(self::$talk)->getOther());
+    }
+
+    /**
+     * @test
+     */
+    public function getTypeReturnsType()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $this->assertSame(self::$talk->type, $talkProfile->with(self::$talk)->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function getLevelReturnsLevel()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $this->assertSame(self::$talk->level, $talkProfile->with(self::$talk)->getLevel());
+    }
+
+    /**
+     * @test
+     */
+    public function getCategoryReturnsCategory()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $this->assertSame(self::$talk->category, $talkProfile->with(self::$talk)->getCategory());
+    }
+
+    /**
+     * @test
+     */
+    public function getSlidesReturnsSlides()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $this->assertSame(self::$talk->slides, $talkProfile->with(self::$talk)->getSlides());
+    }
+
+    /**
+     * @test
+     */
+    public function isDesiredReturnsBool()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $talkProfile->with(self::$talk);
+        $isDesired = $talkProfile->isDesired();
+        $this->assertFalse($isDesired);
+    }
+
+    /**
+     * @test
+     */
+    public function isSponsorReturnsBool()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $talkProfile->with(self::$talk);
+        $isSponsor = $talkProfile->isSponsor();
+        $this->assertTrue($isSponsor);
+    }
+
+    /**
+     * @test
+     */
+    public function isSpeakerFavoriteReturnsBool()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $talkProfile->with(self::$talk);
+        $isSpeakerFavorite = $talkProfile->isSpeakerFavorite();
+        $this->assertTrue($isSpeakerFavorite);
+    }
+
+    /**
+     * @test
+     */
+    public function isSelectedReturnsBool()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $talkProfile->with(self::$talk);
+        $isSelected = $talkProfile->isSelected();
+        $this->assertFalse($isSelected);
+    }
+
+    /**
+     * @test
+     */
+    public function getCommentsReturnsComments()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $talkProfile->with(self::$talk);
+        $comments = $talkProfile->getComments();
+        $this->assertInstanceOf(Collection::class, $comments);
+        //The talk has no comments so it returns 0.
+        $this->assertCount(0, $comments);
+    }
+
+    /**
+     * @test
+     */
+    public function getRatingReturnsZeroWhenNoRatingIsSetByUser()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $talkProfile->with(self::$talk);
+        $this->assertSame(0, $talkProfile->getRating());
+    }
+
+    /**
+     * @test
+     */
+    public function isViewedReturnsFalseWhenNoMetaIsSetForUser()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $talkProfile->with(self::$talk);
+        $this->assertFalse($talkProfile->isViewed());
+    }
+
+    /**
+     * @test
+     */
+    public function isMyFavoriteReturnsFalseWhenNoFavoriteSet()
+    {
+        $talkProfile = new TalkProfile($this->identity);
+        $talkProfile->with(self::$talk);
+        $this->assertFalse($talkProfile->isMyFavorite());
+    }
+}

--- a/tests/Http/Controller/Reviewer/DashboardControllerTest.php
+++ b/tests/Http/Controller/Reviewer/DashboardControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Test\Http\Controller\Admin;
+namespace OpenCFP\Test\Http\Controller\Reviewer;
 
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Test\RefreshDatabase;


### PR DESCRIPTION
This PR adds the talk profile and talk handler to the project.

The talk profile is the talk version of the speaker profile, and is intended to pass to the views, so those can grab all the data they need from it.

The Talk Handler is responsible for all 'meta' actions on a talk. So it doesn't do deleting/creating etc. But it is responsible for making comments, selecting, favoriting, rating and viewing talks.

I'm pretty sure the names of these objects need improving, so feedback on that, or anything else, is welcome.