### PR TITLE
Refactor: Move the UserInterface up to our own namespace

### DIFF
--- a/classes/Domain/Services/AccountManagement.php
+++ b/classes/Domain/Services/AccountManagement.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Domain\Services;
 
-use Cartalyst\Sentry\Users\UserInterface;
+use OpenCFP\Infrastructure\Auth\UserInterface;
 
 interface AccountManagement
 {

--- a/classes/Domain/Services/Authentication.php
+++ b/classes/Domain/Services/Authentication.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Domain\Services;
 
-use Cartalyst\Sentry\Users\UserInterface;
+use OpenCFP\Infrastructure\Auth\UserInterface;
 
 interface Authentication
 {

--- a/classes/Infrastructure/Auth/RoleAccess.php
+++ b/classes/Infrastructure/Auth/RoleAccess.php
@@ -26,7 +26,7 @@ class RoleAccess implements UserAccess
         }
 
         $user = $auth->user();
-        if (!$user->hasPermission($role)) {
+        if (!$user->hasAccess($role)) {
             return $app->redirect('/dashboard');
         }
     }

--- a/classes/Infrastructure/Auth/SentryAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentryAccountManagement.php
@@ -4,7 +4,6 @@ namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;
 use Cartalyst\Sentry\Users\UserAlreadyActivatedException;
-use Cartalyst\Sentry\Users\UserInterface;
 use OpenCFP\Domain\Services\AccountManagement;
 
 class SentryAccountManagement implements AccountManagement
@@ -21,12 +20,12 @@ class SentryAccountManagement implements AccountManagement
 
     public function findById($userId): UserInterface
     {
-        return $this->sentry->findUserById($userId);
+        return new User($this->sentry->findUserById($userId));
     }
 
     public function findByLogin($email): UserInterface
     {
-        return $this->sentry->findUserByLogin($email);
+        return new User($this->sentry->findUserByLogin($email));
     }
 
     public function findByRole($role): array
@@ -47,12 +46,12 @@ class SentryAccountManagement implements AccountManagement
             $this->sentry->findGroupByName('Speakers')
         );
 
-        return $user;
+        return new User($user);
     }
 
     public function activate($email)
     {
-        $user = $this->findByLogin($email);
+        $user = $this->findByLogin($email)->getUser();
         $code = $user->getActivationCode();
 
         try {
@@ -64,14 +63,14 @@ class SentryAccountManagement implements AccountManagement
 
     public function promoteTo($email, $role = 'Admin')
     {
-        $this->findByLogin($email)->addGroup(
+        $this->findByLogin($email)->getUser()->addGroup(
             $this->sentry->findGroupByName($role)
         );
     }
 
     public function demoteFrom($email, $role = 'Admin')
     {
-        $this->findByLogin($email)->removeGroup(
+        $this->findByLogin($email)->getUser()->removeGroup(
             $this->sentry->findGroupByName($role)
         );
     }

--- a/classes/Infrastructure/Auth/SentryAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentryAccountManagement.php
@@ -20,12 +20,12 @@ class SentryAccountManagement implements AccountManagement
 
     public function findById($userId): UserInterface
     {
-        return new User($this->sentry->findUserById($userId));
+        return new SentryUser($this->sentry->findUserById($userId));
     }
 
     public function findByLogin($email): UserInterface
     {
-        return new User($this->sentry->findUserByLogin($email));
+        return new SentryUser($this->sentry->findUserByLogin($email));
     }
 
     public function findByRole($role): array
@@ -46,7 +46,7 @@ class SentryAccountManagement implements AccountManagement
             $this->sentry->findGroupByName('Speakers')
         );
 
-        return new User($user);
+        return new SentryUser($user);
     }
 
     public function activate($email)

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -52,7 +52,7 @@ class SentryAuthentication implements Authentication
             throw new NotAuthenticatedException();
         }
 
-        return new User($user);
+        return new SentryUser($user);
     }
 
     public function userId(): int

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -3,7 +3,6 @@
 namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;
-use Cartalyst\Sentry\Users\UserInterface;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\AuthenticationException;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
@@ -53,7 +52,7 @@ class SentryAuthentication implements Authentication
             throw new NotAuthenticatedException();
         }
 
-        return $user;
+        return new User($user);
     }
 
     public function userId(): int

--- a/classes/Infrastructure/Auth/SentryUser.php
+++ b/classes/Infrastructure/Auth/SentryUser.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Infrastructure\Auth;
 
-class User implements UserInterface
+class SentryUser implements UserInterface
 {
     /**
      * @var \Cartalyst\Sentry\Users\UserInterface

--- a/classes/Infrastructure/Auth/User.php
+++ b/classes/Infrastructure/Auth/User.php
@@ -92,4 +92,14 @@ class User implements UserInterface
     {
         return $this->user->attemptResetPassword($resetCode, $newPassword);
     }
+
+    /**
+     * This is the dirty hack to allow Promote to and Demote from to work their normal way.
+     *
+     * @return \Cartalyst\Sentry\Users\UserInterface
+     */
+    public function getUser(): \Cartalyst\Sentry\Users\UserInterface
+    {
+        return $this->user;
+    }
 }

--- a/classes/Infrastructure/Auth/User.php
+++ b/classes/Infrastructure/Auth/User.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace OpenCFP\Infrastructure\Auth;
+
+class User implements UserInterface
+{
+    /**
+     * @var \Cartalyst\Sentry\Users\UserInterface
+     */
+    private $user;
+
+    public function __construct(\Cartalyst\Sentry\Users\UserInterface $user)
+    {
+        $this->user= $user;
+    }
+
+    /**
+     * Retrieves the user's Id
+     *
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->user->getId();
+    }
+
+    /**
+     * Retrieves the users login (email)
+     *
+     * @return string
+     */
+    public function getLogin(): string
+    {
+        return $this->user->getLogin();
+    }
+
+    /**
+     * @param $permissions
+     *
+     * @return mixed
+     */
+    public function hasAccess($permissions)
+    {
+        return $this->user->hasAccess($permissions);
+    }
+
+    /**
+     * Checks if the given matches the current password.
+     *
+     * @param string $password
+     *
+     * @return bool
+     */
+    public function checkPassword(string $password): bool
+    {
+        return $this->user->checkPassword($password);
+    }
+
+    /**
+     * Checks if the provided user reset password code is
+     * valid without actually resetting the password.
+     *
+     * @param string $resetCode
+     *
+     * @return bool
+     */
+    public function checkResetPasswordCode(string $resetCode): bool
+    {
+        return $this->user->checkResetPasswordCode($resetCode);
+    }
+
+    /**
+     * Get a reset password code for the given user.
+     *
+     * @return string
+     */
+    public function getResetPasswordCode(): string
+    {
+        return $this->user->getResetPasswordCode();
+    }
+
+    /**
+     * Attempts to reset a user's password by matching
+     * the reset code generated with the user's.
+     *
+     * @param string $resetCode
+     * @param string $newPassword
+     *
+     * @return bool
+     */
+    public function attemptResetPassword($resetCode, $newPassword): bool
+    {
+        return $this->user->attemptResetPassword($resetCode, $newPassword);
+    }
+}

--- a/classes/Infrastructure/Auth/UserInterface.php
+++ b/classes/Infrastructure/Auth/UserInterface.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace OpenCFP\Infrastructure\Auth;
+
+/**
+ * This interface is intended to be used as a representation of a user.
+ *
+ * It should serve as a bridge to allow switching between Sentry and Sentinel
+ */
+interface UserInterface
+{
+    /**
+     * Retrieves the user's Id
+     *
+     * @return int
+     */
+    public function getId(): int;
+
+    /**
+     * Retrieves the users login (email)
+     *
+     * @return string
+     */
+    public function getLogin(): string;
+
+    /**
+     * @param $permissions
+     *
+     * @return mixed
+     */
+    public function hasAccess($permissions);
+
+    /**
+     * Checks if the given matches the current password.
+     *
+     * @param string $password
+     *
+     * @return bool
+     */
+    public function checkPassword(string $password): bool;
+
+    /**
+     * Checks if the provided user reset password code is
+     * valid without actually resetting the password.
+     *
+     * @param string $resetCode
+     *
+     * @return bool
+     */
+    public function checkResetPasswordCode(string $resetCode): bool;
+
+    /**
+     * Get a reset password code for the given user.
+     *
+     * @return string
+     */
+    public function getResetPasswordCode(): string;
+
+    /**
+     * Attempts to reset a user's password by matching
+     * the reset code generated with the user's.
+     *
+     * @param string $resetCode
+     * @param string $newPassword
+     *
+     * @return bool
+     */
+    public function attemptResetPassword($resetCode, $newPassword): bool;
+}

--- a/tests/Console/AdminPromoteCommandTest.php
+++ b/tests/Console/AdminPromoteCommandTest.php
@@ -2,10 +2,10 @@
 
 namespace OpenCFP\Test\Console;
 
-use Cartalyst\Sentry\Users\UserInterface;
 use Mockery;
 use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Environment;
+use OpenCFP\Infrastructure\Auth\UserInterface;
 
 /**
  * Class AdminPromoteTest

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -2,12 +2,12 @@
 
 namespace OpenCFP\Test\Console;
 
-use Cartalyst\Sentry\Users\UserInterface;
 use Mockery;
 use OpenCFP\Console\Application;
 use OpenCFP\Console\Command;
 use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Environment;
+use OpenCFP\Infrastructure\Auth\UserInterface;
 use Symfony\Component\Console;
 
 /**

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -2,10 +2,10 @@
 
 namespace OpenCFP\Test\Http\Controller\Admin;
 
-use Cartalyst\Sentry\Users\UserInterface;
 use Mockery;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\AccountManagement;
+use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -2,10 +2,10 @@
 
 namespace OpenCFP\Test\Http\Controller;
 
-use Cartalyst\Sentry\Users\UserInterface;
 use Mockery as m;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
+use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\Util\Faker\GeneratorTrait;
 use OpenCFP\Test\WebTestCase;
 

--- a/tests/Http/Controller/ForgotControllerTest.php
+++ b/tests/Http/Controller/ForgotControllerTest.php
@@ -2,11 +2,11 @@
 
 namespace OpenCFP\Test\Http\Controller;
 
-use Cartalyst\Sentry\Users\UserInterface;
 use Mockery as m;
 use OpenCFP\Application;
 use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Environment;
+use OpenCFP\Infrastructure\Auth\UserInterface;
 
 /**
  * Class ForgotControllerTest

--- a/tests/Infrastructure/Auth/RoleAccessTest.php
+++ b/tests/Infrastructure/Auth/RoleAccessTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace OpenCFP\Test\Http\Controller\Admin;
+namespace OpenCFP\Test\Infrastructure\Auth;
 
-use Cartalyst\Sentry\Users\UserInterface;
 use Mockery;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Infrastructure\Auth\RoleAccess;
+use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -23,7 +23,7 @@ class RoleAccessTest extends WebTestCase
     public function testReturnsFalseIfCheckSucceededButUserHasNoAdminPermission()
     {
         $user = Mockery::mock(UserInterface::class);
-        $user->shouldReceive('hasPermission')->with('admin')->andReturn(false);
+        $user->shouldReceive('hasAccess')->with('admin')->andReturn(false);
 
         $auth = Mockery::mock(Authentication::class);
         $auth->shouldReceive('check')->andReturn(true);
@@ -36,7 +36,7 @@ class RoleAccessTest extends WebTestCase
     public function testReturnsNothingIfCheckSucceededAndUserHasAdminPermission()
     {
         $user = Mockery::mock(UserInterface::class);
-        $user->shouldReceive('hasPermission')->with('admin')->andReturn(true);
+        $user->shouldReceive('hasAccess')->with('admin')->andReturn(true);
 
         $auth = Mockery::mock(Authentication::class);
         $auth->shouldReceive('check')->andReturn(true);

--- a/tests/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -38,7 +38,7 @@ class SentryAccountManagementTest extends BaseTestCase
 
         $user = $this->sut->findByLogin('test@example.com');
 
-        $this->assertEquals('Test Account', "{$user->first_name} {$user->last_name}");
+        $this->assertEquals('Test Account', "{$user->getUser()->first_name} {$user->getUser()->last_name}");
     }
 
     /** @test */
@@ -49,20 +49,18 @@ class SentryAccountManagementTest extends BaseTestCase
             'last_name'  => 'Account',
         ]);
 
-        $group = $user->getGroups()[0];
-        
-        $this->assertEquals('Speakers', $group->getName());
+        $this->assertTrue($user->hasAccess('users'));
     }
 
     /** @test */
     public function can_activate_user()
     {
         $user = $this->sut->create('test@example.com', 'secret');
-        $this->assertFalse($user->isActivated());
+        $this->assertFalse($user->getUser()->isActivated());
 
         $this->sut->activate('test@example.com');
 
-        $this->assertTrue($this->sut->findByLogin('test@example.com')->isActivated());
+        $this->assertTrue($this->sut->findByLogin('test@example.com')->getUser()->isActivated());
     }
 
     /** @test */

--- a/tests/Infrastructure/Auth/SentryAuthenticationTest.php
+++ b/tests/Infrastructure/Auth/SentryAuthenticationTest.php
@@ -5,7 +5,7 @@ namespace OpenCFP\Test\Infrastructure\Auth;
 use OpenCFP\Infrastructure\Auth\SentryAccountManagement;
 use OpenCFP\Infrastructure\Auth\SentryAuthentication;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\DataBaseInteraction;
 
 /**
  * Class SentryAuthenticationTest
@@ -15,7 +15,7 @@ use OpenCFP\Test\RefreshDatabase;
  */
 class SentryAuthenticationTest extends BaseTestCase
 {
-    use RefreshDatabase;
+    use DataBaseInteraction;
     use SentryTestHelpers;
 
     /**
@@ -35,7 +35,9 @@ class SentryAuthenticationTest extends BaseTestCase
         $this->sut = new SentryAuthentication($this->getSentry());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function existing_user_can_authenticate()
     {
         $this->sut->authenticate('test@example.com', 'secret');
@@ -44,5 +46,34 @@ class SentryAuthenticationTest extends BaseTestCase
         $user = $this->sut->user();
 
         $this->assertEquals('test@example.com', $user->getLogin());
+    }
+
+    /**
+     * @test
+     */
+    public function userIdWorks()
+    {
+        $this->sut->authenticate('test@example.com', 'secret');
+        $this->assertSame(1, $this->sut->userId());
+    }
+
+    /**
+     * @test
+     */
+    public function checkWorks()
+    {
+        $this->assertFalse($this->sut->check());
+        $this->sut->authenticate('test@example.com', 'secret');
+        $this->assertTrue($this->sut->check());
+    }
+
+    /**
+     * @test
+     */
+    public function guestWorks()
+    {
+        $this->assertTrue($this->sut->guest());
+        $this->sut->authenticate('test@example.com', 'secret');
+        $this->assertFalse($this->sut->guest());
     }
 }

--- a/tests/Infrastructure/Auth/SentryUserTest.php
+++ b/tests/Infrastructure/Auth/SentryUserTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace OpenCFP\Test\Infrastructure\Auth;
+
+use OpenCFP\Domain\Model\User;
+use OpenCFP\Infrastructure\Auth\SentryAccountManagement;
+use OpenCFP\Infrastructure\Auth\SentryUser;
+use OpenCFP\Infrastructure\Auth\UserInterface;
+use OpenCFP\Test\BaseTestCase;
+use OpenCFP\Test\DataBaseInteraction;
+
+/**
+ * @covers \OpenCFP\Infrastructure\Auth\SentryUser
+ */
+class SentryUserTest extends BaseTestCase
+{
+    use DataBaseInteraction;
+    use SentryTestHelpers;
+
+    /**
+     * @var SentryAccountManagement
+     */
+    private $sut;
+
+    /**
+     * @var SentryUser
+     */
+    private $user;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->sut = new SentryAccountManagement($this->getSentry());
+        $this->sut->create('test@example.com', 'secret', [
+            'first_name' => 'Test',
+            'last_name'  => 'Account',
+        ]);
+        $this->user = $this->sut->findByLogin('test@example.com');
+    }
+
+    /**
+     * This test is more so to make sure the rest of the tests are testing the right thing.
+     *
+     * @test
+     */
+    public function weHaveTheRightUser()
+    {
+        $this->assertInstanceOf(UserInterface::class, $this->user);
+    }
+
+    /**
+     * @test
+     */
+    public function getIdWorks()
+    {
+        $this->assertSame(1, $this->user->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function getLoginWorks()
+    {
+        $this->assertSame('test@example.com', $this->user->getLogin());
+    }
+
+    /**
+     * @test
+     */
+    public function hasAccessWorks()
+    {
+        $this->assertSame(false, $this->user->hasAccess('admin'));
+        $this->assertSame(false, $this->user->hasAccess('reviewer'));
+        $this->assertSame(true, $this->user->hasAccess('users'));
+        $this->assertSame(false, $this->user->hasAccess('blablabla'));
+    }
+
+    /**
+     * @tests
+     */
+    public function checkPasswordWorks()
+    {
+        $this->assertTrue($this->user->checkPassword('secret'));
+    }
+
+    /**
+     * @test
+     */
+    public function checkResetPasswordCodeWorks()
+    {
+        $this->assertFalse($this->user->checkResetPasswordCode('aasdfhd'));
+
+        //Manualy insert a password code into the db
+        $user                      = User::where('email', 'test@example.com')->first();
+        $user->reset_password_code = 'hello123';
+        $user->save();
+        //Get the user again, since we updated the database.
+        $resetCodeUser = $this->sut->findByLogin('test@example.com');
+        $this->assertTrue($resetCodeUser->checkResetPasswordCode('hello123'));
+    }
+
+    /**
+     * @test
+     */
+    public function getResetPassWordCodeWorks()
+    {
+        //Set up a reset code in the database
+        $user                      = User::where('email', 'test@example.com')->first();
+        $user->reset_password_code = 'hello123';
+        $user->save();
+        $resetCodeUser = $this->sut->findByLogin('test@example.com');
+        $this->assertTrue($resetCodeUser->checkResetPasswordCode('hello123'));
+
+        //This function resets the reset code when its called.
+        $this->assertNotSame('hello123', $resetCodeUser->getResetPasswordCode());
+    }
+
+    /**
+     * @test
+     */
+    public function attemptResetPasswordWorks()
+    {
+        //Set up a reset code in the database
+        $user                      = User::where('email', 'test@example.com')->first();
+        $user->reset_password_code = 'hello123';
+        $user->save();
+        $resetCodeUser = $this->sut->findByLogin('test@example.com');
+        $this->assertTrue($resetCodeUser->checkResetPasswordCode('hello123'));
+
+        $this->assertFalse($resetCodeUser->attemptResetPassword('asdfgj', 'newPassword123'));
+        $this->assertTrue($resetCodeUser->checkPassword('secret'));
+
+        $this->assertTrue($resetCodeUser->attemptResetPassword('hello123', 'newSecret'));
+        $this->assertTrue($resetCodeUser->checkPassword('newSecret'));
+    }
+
+    /**
+     * @test
+     */
+    public function getUserReturnsUser()
+    {
+        $this->assertInstanceOf(\Cartalyst\Sentry\Users\UserInterface::class, $this->user->getUser());
+    }
+}

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -2,10 +2,10 @@
 
 namespace OpenCFP\Test;
 
-use Cartalyst\Sentry\Users\UserInterface;
 use Mockery;
 use OpenCFP\Domain\CallForProposal;
 use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Infrastructure\Auth\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class WebTestCase extends BaseTestCase


### PR DESCRIPTION
This PR moves the UserInterface up to our own namespace, which allows us to make use of it when moving from sentry to sentinel

Follows #501 .
Related to #498.
