### PR TITLE
Enhancement: Update phpunit settings to ignore the API

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         defaultTestSuite="all"
          processIsolation="false"
          stopOnFailure="false">
     <php>
@@ -20,6 +21,8 @@
             <directory>classes</directory>
             <exclude>
                 <directory>classes/Provider</directory>
+                <directory>classes/Http/API</directory>
+                <directory>classes/Infrastructure/Oauth</directory>
             </exclude>
         </whitelist>
     </filter>
@@ -27,6 +30,7 @@
     <testsuites>
         <testsuite name="all">
             <directory>tests</directory>
+            <exclude>tests/Http/API</exclude>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
This PR will ignore the API classes for code coverage, and exclude the remaining API tests from the standard testsuite.

This should give a better idea of the code coverage, and speed up the tests just a little bit.

Since phpunit will use ```phpunit.xml``` over ```phpunit.xml.dist``` 
```bash
$ cp phpunit.xml.dist phpunit.xml
```
Should be ran locally to update the file.