### PR TITLE
Fix: Add infection as phony target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: composer coverage cs database it test
+.PHONY: composer coverage cs database infection it test
 
 it: cs test
 


### PR DESCRIPTION
This PR

* [x] adds `infection` as a phony target to `Makefile`

Follows #606.