### PR TITLE
Fix: Explicitly mark abstract test cases as abstract

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -6,7 +6,7 @@ use Mockery;
 use OpenCFP\Application;
 use OpenCFP\Environment;
 
-class BaseTestCase extends \PHPUnit\Framework\TestCase
+abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Application

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -8,7 +8,7 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-class WebTestCase extends BaseTestCase
+abstract class WebTestCase extends BaseTestCase
 {
     /**
      * Additional headers for a request.


### PR DESCRIPTION
This PR

* [x] explicitly marks abstract test cases as `abstract`