### PR TITLE
Fix: Reduce visibility

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -18,7 +18,7 @@ class BaseTestCase extends \PHPUnit\Framework\TestCase
         self::runBeforeClassTraits();
     }
 
-    public function setUp()
+    protected function setUp()
     {
         if (!$this->app) {
             $this->refreshApplication();
@@ -26,7 +26,7 @@ class BaseTestCase extends \PHPUnit\Framework\TestCase
         $this->runBeforeTestTraits();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if ($this->app) {
             $this->app->flush();

--- a/tests/Console/AdminPromoteCommandTest.php
+++ b/tests/Console/AdminPromoteCommandTest.php
@@ -15,7 +15,7 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
  */
 class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console;
  */
 class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/Domain/Model/AirportTest.php
+++ b/tests/Domain/Model/AirportTest.php
@@ -15,7 +15,7 @@ class AirportTest extends BaseTestCase
 
     private $airports;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->airports = $this->getAirport();

--- a/tests/Domain/Services/PaginationTest.php
+++ b/tests/Domain/Services/PaginationTest.php
@@ -16,7 +16,7 @@ class PaginationTest extends BaseTestCase
      */
     private $pagination;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->pagination = new Pagination([1,2,3,4,5,6,7,8,9,10], 2);

--- a/tests/Domain/Talk/TalkFilterTest.php
+++ b/tests/Domain/Talk/TalkFilterTest.php
@@ -14,7 +14,7 @@ class TalkFilterTest extends BaseTestCase
 
     protected $formatter;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->talk      = Mockery::mock(Talk::class);

--- a/tests/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Domain/Talk/TalkHandlerTest.php
@@ -28,7 +28,7 @@ class TalkHandlerTest extends BaseTestCase
         self::$talk = factory(Talk::class, 1)->create(['selected' => 0])->first();
     }
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $auth     = Mockery::mock(Authentication::class);

--- a/tests/Http/Controller/ForgotControllerTest.php
+++ b/tests/Http/Controller/ForgotControllerTest.php
@@ -18,7 +18,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
 {
     protected $app;
 
-    public function setup()
+    protected function setUp()
     {
         $this->app                 = new Application(BASE_PATH, Environment::testing());
         $this->app['session.test'] = true;

--- a/tests/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -22,7 +22,7 @@ class SentryAccountManagementTest extends BaseTestCase
      */
     private $sut;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->sut = new SentryAccountManagement($this->getSentry());

--- a/tests/Infrastructure/Auth/SentryAuthenticationTest.php
+++ b/tests/Infrastructure/Auth/SentryAuthenticationTest.php
@@ -23,7 +23,7 @@ class SentryAuthenticationTest extends BaseTestCase
      */
     private $sut;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Infrastructure/Auth/SentryUserTest.php
+++ b/tests/Infrastructure/Auth/SentryUserTest.php
@@ -27,7 +27,7 @@ class SentryUserTest extends BaseTestCase
      */
     private $user;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->sut = new SentryAccountManagement($this->getSentry());


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` and `tearDown()` to `protected`

💁‍♂️ This is the visibility as declared on the parent test cases, and there's no need to increase it.