### PR TITLE
Fix: Move test helper traits into OpenCFP\Test\Helper namespace

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -5,6 +5,8 @@ namespace OpenCFP\Test;
 use Mockery;
 use OpenCFP\Application;
 use OpenCFP\Environment;
+use OpenCFP\Test\Helper\DataBaseInteraction;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 class BaseTestCase extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Domain/Model/AirportTest.php
+++ b/tests/Domain/Model/AirportTest.php
@@ -4,7 +4,7 @@ namespace OpenCFP\Test\Domain\Model;
 
 use OpenCFP\Domain\Model\Airport;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 /**
  * @group db

--- a/tests/Domain/Model/Interaction/TalkTest.php
+++ b/tests/Domain/Model/Interaction/TalkTest.php
@@ -7,7 +7,7 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkComment;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\DataBaseInteraction;
+use OpenCFP\Test\Helper\DataBaseInteraction;
 
 class TalkTest extends BaseTestCase
 {

--- a/tests/Domain/Model/Interaction/UserTest.php
+++ b/tests/Domain/Model/Interaction/UserTest.php
@@ -5,7 +5,7 @@ namespace OpenCFP\Test\Domain\Model\Interaction;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\DataBaseInteraction;
+use OpenCFP\Test\Helper\DataBaseInteraction;
 
 class UserTest extends BaseTestCase
 {

--- a/tests/Domain/Model/TalkMetaTest.php
+++ b/tests/Domain/Model/TalkMetaTest.php
@@ -7,7 +7,7 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 class TalkMetaTest extends BaseTestCase
 {

--- a/tests/Domain/Model/TalkTest.php
+++ b/tests/Domain/Model/TalkTest.php
@@ -6,7 +6,7 @@ use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 /**
  * @group db

--- a/tests/Domain/Model/UserTest.php
+++ b/tests/Domain/Model/UserTest.php
@@ -8,7 +8,7 @@ use OpenCFP\Domain\Model\TalkComment;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 /**
  * @group db

--- a/tests/Domain/Services/TalkFormatterTest.php
+++ b/tests/Domain/Services/TalkFormatterTest.php
@@ -7,7 +7,7 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 /**
  * @group db

--- a/tests/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Domain/Speaker/SpeakerProfileTest.php
@@ -6,7 +6,7 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Speaker\NotAllowedException;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 class SpeakerProfileTest extends BaseTestCase
 {

--- a/tests/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Domain/Talk/TalkHandlerTest.php
@@ -11,7 +11,7 @@ use OpenCFP\Domain\Services\TalkRating\TalkRatingStrategy;
 use OpenCFP\Domain\Talk\TalkHandler;
 use OpenCFP\Domain\Talk\TalkProfile;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 class TalkHandlerTest extends BaseTestCase
 {

--- a/tests/Domain/Talk/TalkProfileTest.php
+++ b/tests/Domain/Talk/TalkProfileTest.php
@@ -7,7 +7,7 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Domain\Talk\TalkProfile;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 class TalkProfileTest extends BaseTestCase
 {

--- a/tests/Helper/DataBaseInteraction.php
+++ b/tests/Helper/DataBaseInteraction.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Test;
+namespace OpenCFP\Test\Helper;
 
 use Illuminate\Database\Capsule\Manager as Capsule;
 
@@ -8,7 +8,7 @@ trait DataBaseInteraction
 {
     protected function resetDatabase()
     {
-        $this->getCapsule()->getConnection()->unprepared(file_get_contents(__DIR__. '/dump.sql'));
+        $this->getCapsule()->getConnection()->unprepared(file_get_contents(__DIR__. '/../dump.sql'));
     }
 
     protected function getCapsule()

--- a/tests/Helper/Faker/GeneratorTrait.php
+++ b/tests/Helper/Faker/GeneratorTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Test\Util\Faker;
+namespace OpenCFP\Test\Helper\Faker;
 
 use Faker\Factory;
 use Faker\Generator;

--- a/tests/Helper/RefreshDatabase.php
+++ b/tests/Helper/RefreshDatabase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Test;
+namespace OpenCFP\Test\Helper;
 
 use Illuminate\Database\Capsule\Manager as Capsule;
 
@@ -8,7 +8,7 @@ trait RefreshDatabase
 {
     protected static function setUpDatabase()
     {
-        self::createCapsule()->getConnection()->unprepared(file_get_contents(__DIR__. '/dump.sql'));
+        self::createCapsule()->getConnection()->unprepared(file_get_contents(__DIR__. '/../dump.sql'));
     }
 
     protected static function createCapsule()

--- a/tests/Helper/SentryTestHelpers.php
+++ b/tests/Helper/SentryTestHelpers.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Test\Infrastructure\Auth;
+namespace OpenCFP\Test\Helper;
 
 use OpenCFP\Provider\SymfonySentrySession;
 use Symfony\Component\HttpFoundation\Session\Session;

--- a/tests/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Http/Controller/Admin/DashboardControllerTest.php
@@ -3,7 +3,7 @@
 namespace OpenCFP\Test\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 class DashboardControllerTest extends WebTestCase

--- a/tests/Http/Controller/Admin/ExportsControllerTest.php
+++ b/tests/Http/Controller/Admin/ExportsControllerTest.php
@@ -3,7 +3,7 @@
 namespace OpenCFP\Test\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 /**

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -6,7 +6,7 @@ use Mockery;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Infrastructure\Auth\UserInterface;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 /**

--- a/tests/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Http/Controller/Admin/TalksControllerTest.php
@@ -4,7 +4,7 @@ namespace OpenCFP\Test\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkMeta;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 class TalksControllerTest extends WebTestCase

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -6,7 +6,7 @@ use Mockery as m;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Infrastructure\Auth\UserInterface;
-use OpenCFP\Test\Util\Faker\GeneratorTrait;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 use OpenCFP\Test\WebTestCase;
 
 /**

--- a/tests/Http/Controller/ProfileControllerTest.php
+++ b/tests/Http/Controller/ProfileControllerTest.php
@@ -3,7 +3,7 @@
 namespace OpenCFP\Test\Http\Controller;
 
 use OpenCFP\Domain\Model\User;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 /**

--- a/tests/Http/Controller/Reviewer/DashboardControllerTest.php
+++ b/tests/Http/Controller/Reviewer/DashboardControllerTest.php
@@ -3,7 +3,7 @@
 namespace OpenCFP\Test\Http\Controller\Reviewer;
 
 use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 class DashboardControllerTest extends WebTestCase

--- a/tests/Http/Controller/Reviewer/SpeakerControllerTest.php
+++ b/tests/Http/Controller/Reviewer/SpeakerControllerTest.php
@@ -3,7 +3,7 @@
 namespace OpenCFP\Test\Http\Controller\Reviewer;
 
 use OpenCFP\Domain\Model\User;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 class SpeakerControllerTest extends WebTestCase

--- a/tests/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Http/Controller/Reviewer/TalksControllerTest.php
@@ -3,7 +3,7 @@
 namespace OpenCFP\Test\Http\Controller\Reviewer;
 
 use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 class TalksControllerTest extends WebTestCase

--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Test\Http\Controller;
 
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 /**

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -7,7 +7,7 @@ use OpenCFP\Application\Speakers;
 use OpenCFP\Domain\CallForProposal;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
 /**

--- a/tests/Http/Form/TalkFormTest.php
+++ b/tests/Http/Form/TalkFormTest.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Test\Http\Form;
 
-use OpenCFP\Test\Util\Faker\GeneratorTrait;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
 class TalkFormTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -4,7 +4,8 @@ namespace OpenCFP\Test\Infrastructure\Auth;
 
 use OpenCFP\Infrastructure\Auth\SentryAccountManagement;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\DataBaseInteraction;
+use OpenCFP\Test\Helper\DataBaseInteraction;
+use OpenCFP\Test\Helper\SentryTestHelpers;
 
 /**
  * Class SentryAccountManagementTest

--- a/tests/Infrastructure/Auth/SentryAuthenticationTest.php
+++ b/tests/Infrastructure/Auth/SentryAuthenticationTest.php
@@ -5,7 +5,8 @@ namespace OpenCFP\Test\Infrastructure\Auth;
 use OpenCFP\Infrastructure\Auth\SentryAccountManagement;
 use OpenCFP\Infrastructure\Auth\SentryAuthentication;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\DataBaseInteraction;
+use OpenCFP\Test\Helper\DataBaseInteraction;
+use OpenCFP\Test\Helper\SentryTestHelpers;
 
 /**
  * Class SentryAuthenticationTest

--- a/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -9,7 +9,7 @@ use OpenCFP\Domain\Entity;
 use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Domain\Speaker\SpeakerRepository;
 use OpenCFP\Infrastructure\Auth\SentryIdentityProvider;
-use OpenCFP\Test\Util\Faker\GeneratorTrait;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
 class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Infrastructure/Auth/SentryUserTest.php
+++ b/tests/Infrastructure/Auth/SentryUserTest.php
@@ -7,7 +7,8 @@ use OpenCFP\Infrastructure\Auth\SentryAccountManagement;
 use OpenCFP\Infrastructure\Auth\SentryUser;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\DataBaseInteraction;
+use OpenCFP\Test\Helper\DataBaseInteraction;
+use OpenCFP\Test\Helper\SentryTestHelpers;
 
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentryUser

--- a/tests/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
@@ -8,8 +8,8 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Speaker\SpeakerRepository;
 use OpenCFP\Infrastructure\Persistence\IlluminateSpeakerRepository;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
-use OpenCFP\Test\Util\Faker\GeneratorTrait;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 class IlluminateSpeakerRepositoryTest extends BaseTestCase
 {

--- a/tests/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
@@ -6,7 +6,7 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Talk\TalkRepository;
 use OpenCFP\Infrastructure\Persistence\IlluminateTalkRepository;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\RefreshDatabase;
+use OpenCFP\Test\Helper\RefreshDatabase;
 
 class IlluminateTalkRepositoryTest extends BaseTestCase
 {

--- a/tests/Util/Faker/GeneratorTest.php
+++ b/tests/Util/Faker/GeneratorTest.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Test\Util\Faker;
 
 use Faker\Generator;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
 class GeneratorTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] moves test helper traits into `OpenCFP\Test\Helper` namespace

Somewhat related to #629.

💁‍♂️ Now they can all hang out in the same namespace!