### PR TITLE
Enhancement: Enable and configure concat_space fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -18,6 +18,9 @@ $config = PhpCsFixer\Config::create()
         'blank_line_after_opening_tag' => true,
         'blank_line_before_statement' => true,
         'cast_spaces' => true,
+        'concat_space' => [
+            'spacing' => 'one',
+        ],
         'method_separation' => true,
         'no_alias_functions' => true,
         'no_empty_phpdoc' => true,

--- a/classes/Console/BaseCommand.php
+++ b/classes/Console/BaseCommand.php
@@ -108,7 +108,7 @@ abstract class BaseCommand extends Command
         $io->title('OpenCFP');
 
         $io->section(sprintf(
-            'Promoting account with email %s to '. $role,
+            'Promoting account with email %s to ' . $role,
             $email
         ));
 
@@ -126,7 +126,7 @@ abstract class BaseCommand extends Command
         $accounts->promoteTo($user->getLogin(), $role);
 
         $io->success(sprintf(
-            'Added account with email %s to the '. $role .' group',
+            'Added account with email %s to the ' . $role . ' group',
             $email
         ));
 

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -66,8 +66,8 @@ class User extends Eloquent
         }
 
         return $builder
-            ->where('first_name', 'like', '%' . $search. '%')
-            ->orWhere('last_name', 'like', '%' . $search. '%')
+            ->where('first_name', 'like', '%' . $search . '%')
+            ->orWhere('last_name', 'like', '%' . $search . '%')
             ->orderBy($orderByColumn, $orderByDirection);
     }
 

--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -56,7 +56,7 @@ class ProfileImageProcessor
     public function process(UploadedFile $file, $publishFilename = null): string
     {
         if ($publishFilename === null) {
-            $publishFilename = $this->generator->generate(50). '.'. $file->guessExtension();
+            $publishFilename = $this->generator->generate(50) . '.' . $file->guessExtension();
         }
         // Temporary filename to work with.
         $tempFilename = $this->generator->generate(40);

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -74,7 +74,7 @@ class ExportsController extends BaseController
                 || $this->startsWith($info, '-')
                 || $this->startsWith($info, '@')
             ) {
-            $info = "'". $info;
+            $info = "'" . $info;
         }
 
         return $info;
@@ -107,6 +107,6 @@ class ExportsController extends BaseController
             $output  = $output . implode(',', $content) . "\n";
         }
 
-        return $this->export($output, $filename. '.csv');
+        return $this->export($output, $filename . '.csv');
     }
 }

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -161,7 +161,7 @@ class SpeakersController extends BaseController
             $this->service('session')->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
-                'ext'   => 'Sorry, you cannot remove yourself as '. $role .'.',
+                'ext'   => 'Sorry, you cannot remove yourself as ' . $role . '.',
             ]);
 
             return $this->redirectTo('admin_speakers');
@@ -180,7 +180,7 @@ class SpeakersController extends BaseController
             $this->service('session')->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
-                'ext'   => 'We were unable to remove the '. $role.'. Please try again.',
+                'ext'   => 'We were unable to remove the ' . $role . '. Please try again.',
             ]);
         }
 
@@ -199,7 +199,7 @@ class SpeakersController extends BaseController
                 $this->service('session')->set('flash', [
                     'type'  => 'error',
                     'short' => 'Error',
-                    'ext'   => 'User already is in the '. $role .' group.',
+                    'ext'   => 'User already is in the ' . $role . ' group.',
                 ]);
 
                 return $this->redirectTo('admin_speakers');

--- a/tests/Helper/DataBaseInteraction.php
+++ b/tests/Helper/DataBaseInteraction.php
@@ -8,7 +8,7 @@ trait DataBaseInteraction
 {
     protected function resetDatabase()
     {
-        $this->getCapsule()->getConnection()->unprepared(file_get_contents(__DIR__. '/../dump.sql'));
+        $this->getCapsule()->getConnection()->unprepared(file_get_contents(__DIR__ . '/../dump.sql'));
     }
 
     protected function getCapsule()

--- a/tests/Helper/RefreshDatabase.php
+++ b/tests/Helper/RefreshDatabase.php
@@ -8,7 +8,7 @@ trait RefreshDatabase
 {
     protected static function setUpDatabase()
     {
-        self::createCapsule()->getConnection()->unprepared(file_get_contents(__DIR__. '/../dump.sql'));
+        self::createCapsule()->getConnection()->unprepared(file_get_contents(__DIR__ . '/../dump.sql'));
     }
 
     protected static function createCapsule()

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -128,7 +128,7 @@ class SpeakersControllerTest extends WebTestCase
         $user = self::$users->last();
 
         $this->asAdmin($user->id)
-            ->get('/admin/speakers/'. $user->id . '/demote', ['role' => 'Admin'])
+            ->get('/admin/speakers/' . $user->id . '/demote', ['role' => 'Admin'])
             ->assertFlashContains('Sorry, you cannot remove yourself as Admin.')
             ->assertRedirect()
             ->assertTargetURLContains('/admin/speakers');
@@ -150,7 +150,7 @@ class SpeakersControllerTest extends WebTestCase
         $this->swap(AccountManagement::class, $accounts);
 
         $this->asAdmin(self::$users->first()->id)
-            ->get('/admin/speakers/'. self::$users->last()->id . '/demote', ['role' => 'Admin'])
+            ->get('/admin/speakers/' . self::$users->last()->id . '/demote', ['role' => 'Admin'])
             ->assertFlashContains('success')
             ->assertRedirect()
             ->assertTargetURLContains('/admin/speakers');

--- a/tests/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Http/Controller/Admin/TalksControllerTest.php
@@ -52,7 +52,7 @@ class TalksControllerTest extends WebTestCase
 
         $this->asAdmin()
             ->post(
-                '/admin/talks/'. $talk->id.'/comment',
+                '/admin/talks/' . $talk->id . '/comment',
                 ['comment' => 'Great Talk i rate 10/10']
             )
             ->assertNotSee('Server Error')
@@ -79,7 +79,7 @@ class TalksControllerTest extends WebTestCase
         $talk = self::$talks->first();
 
         $this->asAdmin()
-            ->get('/admin/talks/'. $talk->id)
+            ->get('/admin/talks/' . $talk->id)
             ->assertSuccessful();
     }
 
@@ -91,7 +91,7 @@ class TalksControllerTest extends WebTestCase
         $meta = factory(TalkMeta::class, 1)->create();
         $this->asAdmin($meta->first()->admin_user_id);
 
-        $this->get('/admin/talks/'. $meta->first()->talk_id)
+        $this->get('/admin/talks/' . $meta->first()->talk_id)
             ->assertSuccessful();
     }
 
@@ -103,7 +103,7 @@ class TalksControllerTest extends WebTestCase
         $talk = self::$talks->first();
 
         $this->asAdmin()
-            ->post('/admin/talks/'. $talk->id. '/select')
+            ->post('/admin/talks/' . $talk->id . '/select')
             ->assertSee('1')
             ->assertSuccessful();
     }
@@ -116,7 +116,7 @@ class TalksControllerTest extends WebTestCase
         $talk = self::$talks->first();
 
         $this->asAdmin()
-            ->post('/admin/talks/'. $talk->id. '/select', ['delete' => 1])
+            ->post('/admin/talks/' . $talk->id . '/select', ['delete' => 1])
             ->assertSee('1')
             ->assertSuccessful();
     }
@@ -140,7 +140,7 @@ class TalksControllerTest extends WebTestCase
         $talk = self::$talks->first();
 
         $this->asAdmin()
-            ->post('/admin/talks/'. $talk->id . '/favorite')
+            ->post('/admin/talks/' . $talk->id . '/favorite')
             ->assertSee('1')
             ->assertSuccessful();
     }
@@ -153,7 +153,7 @@ class TalksControllerTest extends WebTestCase
         $talk = self::$talks->first();
 
         $this->asAdmin()
-            ->post('/admin/talks/'. $talk->id . '/favorite', ['delete' =>1])
+            ->post('/admin/talks/' . $talk->id . '/favorite', ['delete' =>1])
             ->assertSee('1')
             ->assertSuccessful();
     }
@@ -177,7 +177,7 @@ class TalksControllerTest extends WebTestCase
         $talk = self::$talks->first();
 
         $this->asAdmin()
-            ->post('/admin/talks/'.$talk->id. '/rate', ['rating' => 1])
+            ->post('/admin/talks/' . $talk->id . '/rate', ['rating' => 1])
             ->assertSee('1')
             ->assertSuccessful();
     }
@@ -190,7 +190,7 @@ class TalksControllerTest extends WebTestCase
         $talk = self::$talks->first();
 
         $this->asAdmin()
-            ->post('/admin/talks/'.$talk->id. '/rate', ['rating' => 12])
+            ->post('/admin/talks/' . $talk->id . '/rate', ['rating' => 12])
             ->assertNotSee('1')
             ->assertSuccessful();
     }

--- a/tests/Http/Controller/ProfileControllerTest.php
+++ b/tests/Http/Controller/ProfileControllerTest.php
@@ -42,7 +42,7 @@ class ProfileControllerTest extends WebTestCase
         $id = self::$user->id;
 
         $this->asLoggedInSpeaker($id)
-            ->get('/profile/edit/'. $id)
+            ->get('/profile/edit/' . $id)
             ->assertSuccessful();
     }
 

--- a/tests/Http/Controller/Reviewer/SpeakerControllerTest.php
+++ b/tests/Http/Controller/Reviewer/SpeakerControllerTest.php
@@ -59,7 +59,7 @@ class SpeakerControllerTest extends WebTestCase
         $speaker = self::$users->first();
 
         $this->asReviewer()
-            ->get('/reviewer/speakers/'.$speaker->id)
+            ->get('/reviewer/speakers/' . $speaker->id)
             ->assertSee($speaker->first_name)
             ->assertSee($speaker->bio)
             ->assertSuccessful();

--- a/tests/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Http/Controller/Reviewer/TalksControllerTest.php
@@ -49,7 +49,7 @@ class TalksControllerTest extends WebTestCase
     {
         $talk = self::$talks->first();
         $this->asReviewer()
-            ->get('/reviewer/talks/'.$talk->id)
+            ->get('/reviewer/talks/' . $talk->id)
             ->assertSee($talk->title)
             ->assertSee($talk->description)
             ->assertSuccessful();

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -110,7 +110,7 @@ class TalkControllerTest extends WebTestCase
     {
         $this->asLoggedInSpeaker(self::$user->id)
             ->callForPapersIsClosed()
-            ->get('/talk/edit/'. self::$talk->id)
+            ->get('/talk/edit/' . self::$talk->id)
             ->assertFlashContains('error')
             ->assertFlashContains('You cannot edit talks once the call for papers has ended')
             ->assertNotSee('Edit Your Talk')

--- a/web/index.php
+++ b/web/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 use OpenCFP\Application;
 use OpenCFP\Environment;

--- a/web/index_dev.php
+++ b/web/index_dev.php
@@ -1,8 +1,8 @@
 <?php
 
-$filename = __DIR__.preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
+$filename = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
 if (php_sapi_name() === 'cli-server' && is_file($filename)) {
     return false;
 }
 
-require_once __DIR__.'/index.php';
+require_once __DIR__ . '/index.php';


### PR DESCRIPTION
This PR

* [x] enables and configures the `concat_space` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**concat_space** [`@Symfony`]
>
>Concatenation should be spaced according configuration.
>
>Configuration options:
>
>* `spacing` (`'none'`, `'one'`): spacing to apply around concatenation operator; defaults to `'none'`