### PR TITLE
Enhancement: except Environment from the static access rule

### DIFF
--- a/PHPMDRuleSet.xml
+++ b/PHPMDRuleSet.xml
@@ -11,7 +11,7 @@
 
     <rule ref="rulesets/cleancode.xml/StaticAccess">
         <properties>
-            <property name="exceptions" value="\OpenCFP\Domain\Model\Airport,\OpenCFP\Domain\Model\Favorite,\OpenCFP\Domain\Model\Group,\OpenCFP\Domain\Model\Talk,\OpenCFP\Domain\Model\TalkComment,\OpenCFP\Domain\Model\TalkMeta,\OpenCFP\Domain\Model\User" />
+            <property name="exceptions" value="\OpenCFP\Domain\Model\Airport,\OpenCFP\Domain\Model\Favorite,\OpenCFP\Domain\Model\Group,\OpenCFP\Domain\Model\Talk,\OpenCFP\Domain\Model\TalkComment,\OpenCFP\Domain\Model\TalkMeta,\OpenCFP\Domain\Model\User,\OpenCfp\Environment" />
         </properties>
     </rule>
 </ruleset>


### PR DESCRIPTION
This PR adds the Environment class to the list of exceptions for the PHPMD static access rule

Somewhat related to #631 

