### PR TITLE
Feature: different production path for uploaded files.

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -45,7 +45,7 @@ class Application extends SilexApplication
     {
         parent::__construct();
 
-        $this['path']  = $basePath;
+        $this['path']  = new Path($basePath, $environment);
         $this['env']   = $environment;
         $this['debug'] = true;
 
@@ -112,7 +112,7 @@ class Application extends SilexApplication
     protected function bindPathsInApplicationContainer()
     {
         foreach ($this->getConfigSlugs() as $slug) {
-            $this["paths.{$slug}"] = $this->{$this->camelCaseFrom($slug) . 'Path'}();
+            $this["paths.{$slug}"] = $this['path']->{$this->camelCaseFrom($slug). 'Path'}();
         }
     }
 
@@ -147,19 +147,20 @@ class Application extends SilexApplication
      */
     protected function bindConfiguration()
     {
+        $config = $this['path']->configPath();
         $driver = new YamlConfigDriver();
 
-        if (!file_exists($this->configPath())) {
+        if (!file_exists($config)) {
             throw new \InvalidArgumentException(
-                sprintf("The config file '%s' does not exist.", $this->configPath())
+                sprintf("The config file '%s' does not exist.", $config)
             );
         }
 
-        if ($driver->supports($this->configPath())) {
-            $this['config'] = $driver->load($this->configPath());
+        if ($driver->supports($config)) {
+            $this['config'] = $driver->load($config);
         }
 
-        if (! $this->isProduction()) {
+        if (! $this['env']->isProduction()) {
             $this['debug'] = true;
         }
     }
@@ -184,116 +185,6 @@ class Application extends SilexApplication
         }
 
         return $cursor;
-    }
-
-    /**
-     * Get the base path for the application.
-     *
-     * @return string
-     */
-    public function basePath()
-    {
-        return $this['path'];
-    }
-
-    /**
-     * Get the configuration path.
-     *
-     * @return string
-     */
-    public function configPath()
-    {
-        return $this->basePath() . "/config/{$this['env']}.yml";
-    }
-
-    /**
-     * Get the uploads path.
-     *
-     * @return string
-     */
-    public function uploadPath()
-    {
-        return $this->basePath() . '/web/uploads';
-    }
-
-    /**
-     * Get the templates path.
-     *
-     * @return string
-     */
-    public function templatesPath()
-    {
-        return $this->basePath() . '/resources/views';
-    }
-
-    /**
-     * Get the public path.
-     *
-     * @return string
-     */
-    public function publicPath()
-    {
-        return $this->basePath() . '/web';
-    }
-
-    /**
-     * Get the assets path.
-     *
-     * @return string
-     */
-    public function assetsPath()
-    {
-        return $this->basePath() . '/web/assets';
-    }
-
-    /**
-     * Get the Twig cache path.
-     *
-     * @return string
-     */
-    public function cacheTwigPath()
-    {
-        return $this->basePath() . '/cache/twig';
-    }
-
-    /**
-     * Get the HTML Purifier cache path.
-     *
-     * @return string
-     */
-    public function cachePurifierPath()
-    {
-        return $this->basePath() . '/cache/htmlpurifier';
-    }
-
-    /**
-     * Tells if application is in production environment.
-     *
-     * @return bool
-     */
-    public function isProduction()
-    {
-        return $this['env']->equals(Environment::production());
-    }
-
-    /**
-     * Tells if application is in development environment.
-     *
-     * @return bool
-     */
-    public function isDevelopment()
-    {
-        return $this['env']->equals(Environment::development());
-    }
-
-    /**
-     * Tells if application is in testing environment.
-     *
-     * @return bool
-     */
-    public function isTesting()
-    {
-        return $this['env']->equals(Environment::testing());
     }
 
     private function setUpDataBaseConnection()

--- a/classes/Console/Command/ClearCacheCommand.php
+++ b/classes/Console/Command/ClearCacheCommand.php
@@ -28,8 +28,8 @@ class ClearCacheCommand extends BaseCommand
         $io->section('Clearing caches');
 
         $paths = [
-            $this->app->cachePurifierPath(),
-            $this->app->cacheTwigPath(),
+            $this->app['path']->cachePurifierPath(),
+            $this->app['path']->cacheTwigPath(),
         ];
 
         array_walk($paths, function ($path) use ($io) {

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -74,6 +74,36 @@ class Environment
         return $this->slug === (string) $environment;
     }
 
+    /**
+     * Tells if application is in production environment.
+     *
+     * @return bool
+     */
+    public function isProduction(): bool
+    {
+        return $this->equals(Environment::production());
+    }
+
+    /**
+     * Tells if application is in development environment.
+     *
+     * @return bool
+     */
+    public function isDevelopment(): bool
+    {
+        return $this->equals(Environment::development());
+    }
+
+    /**
+     * Tells if application is in testing environment.
+     *
+     * @return bool
+     */
+    public function isTesting(): bool
+    {
+        return $this->equals(Environment::testing());
+    }
+
     public function __toString()
     {
         return $this->slug;

--- a/classes/Path.php
+++ b/classes/Path.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace OpenCFP;
+
+class Path
+{
+    private $path;
+    private $env;
+
+    public function __construct($path, $env)
+    {
+        $this->path = $path;
+        $this->env  = $env;
+    }
+
+    public function basePath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get the configuration path.
+     *
+     * @return string
+     */
+    public function configPath(): string
+    {
+        return $this->basePath() . "/config/{$this->env}.yml";
+    }
+
+    /**
+     * Get the uploads path.
+     *
+     * @return string
+     */
+    public function uploadPath(): string
+    {
+        return $this->basePath() . '/web/uploads';
+    }
+
+    /**
+     * Get the templates path.
+     *
+     * @return string
+     */
+    public function templatesPath(): string
+    {
+        return $this->basePath() . '/resources/views';
+    }
+
+    /**
+     * Get the public path.
+     *
+     * @return string
+     */
+    public function publicPath(): string
+    {
+        return $this->basePath() . '/web';
+    }
+
+    /**
+     * Get the assets path.
+     *
+     * @return string
+     */
+    public function assetsPath(): string
+    {
+        return $this->basePath() . '/web/assets';
+    }
+
+    /**
+     * Get the Twig cache path.
+     *
+     * @return string
+     */
+    public function cacheTwigPath(): string
+    {
+        return $this->basePath() . '/cache/twig';
+    }
+
+    /**
+     * Get the HTML Purifier cache path.
+     *
+     * @return string
+     */
+    public function cachePurifierPath(): string
+    {
+        return $this->basePath() . '/cache/htmlpurifier';
+    }
+}

--- a/classes/Path.php
+++ b/classes/Path.php
@@ -5,9 +5,12 @@ namespace OpenCFP;
 class Path
 {
     private $path;
+    /**
+     * @var Environment
+     */
     private $env;
 
-    public function __construct($path, $env)
+    public function __construct($path, Environment $env)
     {
         $this->path = $path;
         $this->env  = $env;
@@ -31,10 +34,17 @@ class Path
     /**
      * Get the uploads path.
      *
+     * The production path is separated to make it easier for prod environments where it is
+     * not possible to store files on the disk.
+     *
      * @return string
      */
     public function uploadPath(): string
     {
+        if ($this->env->isProduction()) {
+            return $this->basePath() . '/web/uploads';
+        }
+
         return $this->basePath() . '/web/uploads';
     }
 

--- a/classes/Provider/HtmlPurifierServiceProvider.php
+++ b/classes/Provider/HtmlPurifierServiceProvider.php
@@ -20,7 +20,7 @@ class HtmlPurifierServiceProvider implements ServiceProviderInterface
             if ($app->config('cache.enabled')) {
                 $cachePermissions = 0755;
                 $config->set('Cache.SerializerPermissions', $cachePermissions);
-                $cacheDirectory = $app->cachePurifierPath();
+                $cacheDirectory = $app['path']->cachePurifierPath();
 
                 if (!is_dir($cacheDirectory)) {
                     mkdir($cacheDirectory, $cachePermissions, true);

--- a/classes/Provider/ImageProcessorProvider.php
+++ b/classes/Provider/ImageProcessorProvider.php
@@ -14,7 +14,7 @@ class ImageProcessorProvider implements ServiceProviderInterface
     public function register(Container $app)
     {
         $app['profile_image_processor'] = function ($app) {
-            return new ProfileImageProcessor($app->uploadPath(), $app['security.random']);
+            return new ProfileImageProcessor($app['path']->uploadPath(), $app['security.random']);
         };
     }
 }

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -28,15 +28,15 @@ class TwigServiceProvider implements ServiceProviderInterface
     public function register(Container $c)
     {
         $c->register(new SilexTwigServiceProvider, [
-            'twig.path'    => $this->app->templatesPath(),
+            'twig.path'    => $this->app['path']->templatesPath(),
             'twig.options' => [
-                'debug' => !$this->app->isProduction(),
-                'cache' => $this->app->config('cache.enabled') ? $this->app->cacheTwigPath() : false,
+                'debug' => !$this->app['env']->isProduction(),
+                'cache' => $this->app->config('cache.enabled') ? $this->app['path']->cacheTwigPath() : false,
             ],
         ]);
 
         $c->extend('twig', function (Twig_Environment $twig, Application $app) {
-            if (!$app->isProduction()) {
+            if (!$app['env']->isProduction()) {
                 $twig->addExtension(new Twig_Extension_Debug);
             }
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -36,8 +36,8 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     {
         $this->sut = new Application(BASE_PATH, Environment::testing());
 
-        $this->assertTrue($this->sut->isTesting());
-        $this->assertContains('testing.yml', $this->sut->configPath());
+        $this->assertTrue($this->sut['env']->isTesting());
+        $this->assertContains('testing.yml', $this->sut['path']->configPath());
     }
 
     /**
@@ -47,8 +47,8 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     {
         $app = new Application(BASE_PATH, Environment::testing());
 
-        $this->assertTrue($app->isTesting());
-        $this->assertFalse($app->isDevelopment());
-        $this->assertFalse($app->isProduction());
+        $this->assertTrue($app['env']->isTesting());
+        $this->assertFalse($app['env']->isDevelopment());
+        $this->assertFalse($app['env']->isProduction());
     }
 }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -41,4 +41,43 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
 
         Environment::fromString('foo');
     }
+
+    /**
+     * @test
+     */
+    public function isProductionReturnsCorrectBool()
+    {
+        $prod = Environment::production();
+        $this->assertTrue($prod->isProduction());
+        $dev = Environment::development();
+        $this->assertFalse($dev->isProduction());
+        $test = Environment::testing();
+        $this->assertFalse($test->isProduction());
+    }
+
+    /**
+     * @test
+     */
+    public function isDevelopmentReturnsCorrectBool()
+    {
+        $prod = Environment::production();
+        $this->assertFalse($prod->isDevelopment());
+        $dev = Environment::development();
+        $this->assertTrue($dev->isDevelopment());
+        $test = Environment::testing();
+        $this->assertFalse($test->isDevelopment());
+    }
+
+    /**
+     * @test
+     */
+    public function isTestingReturnsCorrectBool()
+    {
+        $prod = Environment::production();
+        $this->assertFalse($prod->isTesting());
+        $dev = Environment::development();
+        $this->assertFalse($dev->isTesting());
+        $test = Environment::testing();
+        $this->assertTrue($test->isTesting());
+    }
 }

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace OpenCFP\Test;
+
+use OpenCFP\Environment;
+use OpenCFP\Path;
+
+/**
+ * @covers \OpenCFP\Path
+ */
+class PathTest extends BaseTestCase
+{
+    /**
+     * @var Path
+     */
+    private $path;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->path = new Path('/home/folder/base', Environment::testing());
+    }
+
+    /**
+     * @test
+     */
+    public function basePathReturnsBasePath()
+    {
+        $this->assertSame('/home/folder/base', $this->path->basePath());
+    }
+
+    /**
+     * @test
+     */
+    public function configPathReturnsConfgiPath()
+    {
+        $this->assertSame(
+            '/home/folder/base/config/testing.yml',
+            $this->path->configPath()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function uploadPathReturnsUploadPath()
+    {
+        $this->assertSame(
+            '/home/folder/base/web/uploads',
+            $this->path->uploadPath()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function templatesPathReturnsTemplatesPath()
+    {
+        $this->assertSame(
+            '/home/folder/base/resources/views',
+            $this->path->templatesPath()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function publicPathReturnsPublicPath()
+    {
+        $this->assertSame(
+            '/home/folder/base/web',
+            $this->path->publicPath()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function assetsPathReturnsAssetsPath()
+    {
+        $this->assertSame(
+            '/home/folder/base/web/assets',
+            $this->path->assetsPath()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function cacheTwigPathReturnsCacheTwigPath()
+    {
+        $this->assertSame(
+            '/home/folder/base/cache/twig',
+            $this->path->cacheTwigPath()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function cachePurifierPathReturnsPurifierPath()
+    {
+        $this->assertSame(
+            '/home/folder/base/cache/htmlpurifier',
+            $this->path->cachePurifierPath()
+        );
+    }
+}

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -32,11 +32,28 @@ class PathTest extends BaseTestCase
     /**
      * @test
      */
-    public function configPathReturnsConfgiPath()
+    public function configPathReturnsConfigPath()
     {
         $this->assertSame(
             '/home/folder/base/config/testing.yml',
             $this->path->configPath()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function configPathWorksForProdAndDev()
+    {
+        $prod = new Path('/home/folder/base', Environment::production());
+        $dev  = new Path('/home/folder/base', Environment::development());
+        $this->assertSame(
+            '/home/folder/base/config/production.yml',
+            $prod->configPath()
+        );
+        $this->assertSame(
+            '/home/folder/base/config/development.yml',
+            $dev->configPath()
         );
     }
 
@@ -48,6 +65,18 @@ class PathTest extends BaseTestCase
         $this->assertSame(
             '/home/folder/base/web/uploads',
             $this->path->uploadPath()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function uploadPathReturnsUploadPathWhenProduction()
+    {
+        $path = new Path('/home/folder/base', Environment::production());
+        $this->assertSame(
+            '/home/folder/base/web/uploads',
+            $path->uploadPath()
         );
     }
 


### PR DESCRIPTION
This PR is an extension of #631, as it splits up the uploads path getter for production.

On some production environments its not possible to have files persist on the disk.

By separating the production version of the uploads path this allows developers to still use the dev version locally, but not have to edit things every time a deployment happens.

Another possibility would be to move the uploads location to the config file. This would make it impossible to grab files from remote locations if the basePath function is used.
