### PR TITLE
Enhancement: Reduce visibility

### DIFF
--- a/classes/Application/Speakers.php
+++ b/classes/Application/Speakers.php
@@ -15,16 +15,16 @@ use OpenCFP\Domain\Talk\TalkWasSubmitted;
 class Speakers
 {
     /** @var CallForProposal */
-    protected $callForProposal;
+    private $callForProposal;
 
     /** @var IdentityProvider */
-    protected $identityProvider;
+    private $identityProvider;
 
     /** @var SpeakerRepository */
-    protected $speakers;
+    private $speakers;
 
     /** @var TalkRepository */
-    protected $talks;
+    private $talks;
 
     /** @var EventDispatcher */
     private $dispatcher;

--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -17,7 +17,7 @@ class ProfileImageProcessor
     /**
      * @var string
      */
-    protected $publishDir;
+    private $publishDir;
 
     /**
      * @var RandomStringGenerator
@@ -27,7 +27,7 @@ class ProfileImageProcessor
     /**
      * @var int
      */
-    protected $size;
+    private $size;
 
     /**
      * Constructor

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -15,7 +15,7 @@ class SpeakerProfile
     /**
      * @var User
      */
-    protected $speaker;
+    private $speaker;
 
     /**
      * @var array

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -11,7 +11,7 @@ class TalkFilter
      *
      * @var array
      */
-    protected $orderByWhiteList = [
+    private $orderByWhiteList = [
         'created_at',
         'title',
         'type',
@@ -90,7 +90,7 @@ class TalkFilter
      *
      * @return array
      */
-    protected function getSortOptions(array $options, array $defaultOptions)
+    private function getSortOptions(array $options, array $defaultOptions)
     {
         if (!isset($options['order_by']) || !in_array($options['order_by'], $this->orderByWhiteList)) {
             $options['order_by'] = $defaultOptions['order_by'];

--- a/classes/Http/Controller/BaseController.php
+++ b/classes/Http/Controller/BaseController.php
@@ -48,7 +48,7 @@ abstract class BaseController
      *
      * @return string the generated URL
      */
-    public function url($route, $parameters = [])
+    protected function url($route, $parameters = [])
     {
         return $this->service('url_generator')->generate($route, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
     }
@@ -62,7 +62,7 @@ abstract class BaseController
      *
      * @return mixed
      */
-    public function render($name, array $context = [], $status = Response::HTTP_OK)
+    protected function render($name, array $context = [], $status = Response::HTTP_OK)
     {
         /* @var Twig_Environment $twig */
         $twig = $this->service('twig');
@@ -76,7 +76,7 @@ abstract class BaseController
      *
      * @return RedirectResponse
      */
-    public function redirectTo($route, $status = Response::HTTP_FOUND)
+    protected function redirectTo($route, $status = Response::HTTP_FOUND)
     {
         return $this->app->redirect($this->url($route), $status);
     }
@@ -84,7 +84,7 @@ abstract class BaseController
     /**
      * @return RedirectResponse
      */
-    public function redirectBack()
+    protected function redirectBack()
     {
         /** @var Request $request */
         $request = $this->service('request_stack')->getCurrentRequest();
@@ -92,7 +92,7 @@ abstract class BaseController
         return $this->app->redirect($request->headers->get('referer'));
     }
 
-    public function validate($rules = [], $messages = [], $customAttributes = [])
+    protected function validate($rules = [], $messages = [], $customAttributes = [])
     {
         /** @var Request $request */
         $request = $this->service('request_stack')->getCurrentRequest();


### PR DESCRIPTION
This PR changes a lot of protected variables to private

There were a bunch of protected variables that had no reason to be protected. 

The public variables in the ```BaseController``` are now protected, since there is no need for outside classes to call those.