### PR TITLE
Enhancement: Enable php_unit_test_class_requires_covers fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -33,6 +33,7 @@ $config = PhpCsFixer\Config::create()
         'phpdoc_separation' => true,
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,
+        'php_unit_test_class_requires_covers' => true,
         'psr0' => false,
         'return_type_declaration' => true,
         'single_blank_line_before_namespace' => true,

--- a/tests/Integration/Domain/Model/AirportTest.php
+++ b/tests/Integration/Domain/Model/AirportTest.php
@@ -8,6 +8,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
 
 /**
  * @group db
+ * @coversNothing
  */
 class AirportTest extends BaseTestCase
 {

--- a/tests/Integration/Domain/Model/Interaction/TalkTest.php
+++ b/tests/Integration/Domain/Model/Interaction/TalkTest.php
@@ -9,6 +9,9 @@ use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\DataBaseInteraction;
 
+/**
+ * @coversNothing
+ */
 class TalkTest extends BaseTestCase
 {
     use DataBaseInteraction;

--- a/tests/Integration/Domain/Model/Interaction/UserTest.php
+++ b/tests/Integration/Domain/Model/Interaction/UserTest.php
@@ -7,6 +7,9 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\DataBaseInteraction;
 
+/**
+ * @coversNothing
+ */
 class UserTest extends BaseTestCase
 {
     use DataBaseInteraction;

--- a/tests/Integration/Domain/Model/TalkMetaTest.php
+++ b/tests/Integration/Domain/Model/TalkMetaTest.php
@@ -9,6 +9,9 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\RefreshDatabase;
 
+/**
+ * @coversNothing
+ */
 class TalkMetaTest extends BaseTestCase
 {
     use RefreshDatabase;

--- a/tests/Integration/Domain/Model/TalkTest.php
+++ b/tests/Integration/Domain/Model/TalkTest.php
@@ -10,6 +10,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
 
 /**
  * @group db
+ * @coversNothing
  */
 class TalkTest extends BaseTestCase
 {

--- a/tests/Integration/Domain/Model/UserTest.php
+++ b/tests/Integration/Domain/Model/UserTest.php
@@ -12,6 +12,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
 
 /**
  * @group db
+ * @coversNothing
  */
 class UserTest extends BaseTestCase
 {

--- a/tests/Integration/Domain/Services/TalkFormatterTest.php
+++ b/tests/Integration/Domain/Services/TalkFormatterTest.php
@@ -11,6 +11,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
 
 /**
  * @group db
+ * @coversNothing
  */
 class TalkFormatterTest extends BaseTestCase
 {

--- a/tests/Integration/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Integration/Domain/Speaker/SpeakerProfileTest.php
@@ -8,6 +8,9 @@ use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\RefreshDatabase;
 
+/**
+ * @coversNothing
+ */
 class SpeakerProfileTest extends BaseTestCase
 {
     use RefreshDatabase;

--- a/tests/Integration/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Integration/Domain/Talk/TalkHandlerTest.php
@@ -13,6 +13,9 @@ use OpenCFP\Domain\Talk\TalkProfile;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\RefreshDatabase;
 
+/**
+ * @coversNothing
+ */
 class TalkHandlerTest extends BaseTestCase
 {
     use RefreshDatabase;

--- a/tests/Integration/Domain/Talk/TalkProfileTest.php
+++ b/tests/Integration/Domain/Talk/TalkProfileTest.php
@@ -9,6 +9,9 @@ use OpenCFP\Domain\Talk\TalkProfile;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\RefreshDatabase;
 
+/**
+ * @coversNothing
+ */
 class TalkProfileTest extends BaseTestCase
 {
     use RefreshDatabase;

--- a/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
@@ -6,6 +6,9 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
+/**
+ * @coversNothing
+ */
 class DashboardControllerTest extends WebTestCase
 {
     use RefreshDatabase;

--- a/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
@@ -11,6 +11,7 @@ use OpenCFP\Test\WebTestCase;
 
 /**
  * @group db
+ * @coversNothing
  */
 class SpeakersControllerTest extends WebTestCase
 {

--- a/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
@@ -7,6 +7,9 @@ use OpenCFP\Domain\Model\TalkMeta;
 use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
+/**
+ * @coversNothing
+ */
 class TalksControllerTest extends WebTestCase
 {
     use RefreshDatabase;

--- a/tests/Integration/Http/Controller/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/DashboardControllerTest.php
@@ -11,6 +11,7 @@ use OpenCFP\Test\WebTestCase;
 
 /**
  * @group db
+ * @coversNothing
  */
 class DashboardControllerTest extends WebTestCase
 {

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -10,6 +10,7 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
 
 /**
  * @group db
+ * @coversNothing
  */
 class ForgotControllerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Integration/Http/Controller/ProfileControllerTest.php
+++ b/tests/Integration/Http/Controller/ProfileControllerTest.php
@@ -8,6 +8,7 @@ use OpenCFP\Test\WebTestCase;
 
 /**
  * @group db
+ * @coversNothing
  */
 class ProfileControllerTest extends WebTestCase
 {

--- a/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
@@ -6,6 +6,9 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
+/**
+ * @coversNothing
+ */
 class DashboardControllerTest extends WebTestCase
 {
     use RefreshDatabase;

--- a/tests/Integration/Http/Controller/Reviewer/SpeakerControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/SpeakerControllerTest.php
@@ -6,6 +6,9 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
+/**
+ * @coversNothing
+ */
 class SpeakerControllerTest extends WebTestCase
 {
     use RefreshDatabase;

--- a/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
@@ -6,6 +6,9 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\WebTestCase;
 
+/**
+ * @coversNothing
+ */
 class TalksControllerTest extends WebTestCase
 {
     use RefreshDatabase;

--- a/tests/Integration/Http/Controller/SignupControllerTest.php
+++ b/tests/Integration/Http/Controller/SignupControllerTest.php
@@ -7,6 +7,7 @@ use OpenCFP\Test\WebTestCase;
 
 /**
  * @group db
+ * @coversNothing
  */
 class SignupControllerTest extends WebTestCase
 {

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -12,6 +12,7 @@ use OpenCFP\Test\WebTestCase;
 
 /**
  * @group db
+ * @coversNothing
  */
 class TalkControllerTest extends WebTestCase
 {

--- a/tests/Integration/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -9,6 +9,7 @@ use OpenCFP\Test\Helper\SentryTestHelpers;
 
 /**
  * @group db
+ * @coversNothing
  */
 class SentryAccountManagementTest extends BaseTestCase
 {

--- a/tests/Integration/Infrastructure/Auth/SentryAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentryAuthenticationTest.php
@@ -10,6 +10,7 @@ use OpenCFP\Test\Helper\SentryTestHelpers;
 
 /**
  * @group db
+ * @coversNothing
  */
 class SentryAuthenticationTest extends BaseTestCase
 {

--- a/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
@@ -11,6 +11,9 @@ use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 use OpenCFP\Test\Helper\RefreshDatabase;
 
+/**
+ * @coversNothing
+ */
 class IlluminateSpeakerRepositoryTest extends BaseTestCase
 {
     use GeneratorTrait;

--- a/tests/Integration/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
@@ -8,6 +8,9 @@ use OpenCFP\Infrastructure\Persistence\IlluminateTalkRepository;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\RefreshDatabase;
 
+/**
+ * @coversNothing
+ */
 class IlluminateTalkRepositoryTest extends BaseTestCase
 {
     use RefreshDatabase;

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -14,6 +14,9 @@ use OpenCFP\Domain\Speaker\SpeakerRepository;
 use OpenCFP\Domain\Talk\TalkRepository;
 use OpenCFP\Domain\Talk\TalkSubmission;
 
+/**
+ * @coversNothing
+ */
 class SpeakersTest extends \PHPUnit\Framework\TestCase
 {
     const SPEAKER_ID = '1';

--- a/tests/Unit/Console/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/AdminPromoteCommandTest.php
@@ -9,6 +9,7 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
 
 /**
  * @group db
+ * @coversNothing
  */
 class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console;
 
 /**
  * @group db
+ * @coversNothing
  */
 class ApplicationTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/ContainerAwareTest.php
+++ b/tests/Unit/ContainerAwareTest.php
@@ -5,6 +5,9 @@ namespace OpenCFP\Test\Unit;
 use Mockery as m;
 use OpenCFP\Application;
 
+/**
+ * @coversNothing
+ */
 class ContainerAwareTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllowsToRetrieveService()

--- a/tests/Unit/Domain/CallForProposalTest.php
+++ b/tests/Unit/Domain/CallForProposalTest.php
@@ -4,6 +4,9 @@ namespace OpenCFP\Test\Unit\Domain;
 
 use OpenCFP\Domain\CallForProposal;
 
+/**
+ * @coversNothing
+ */
 class CallForProposalTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Unit/Domain/Services/ResetEmailerTest.php
+++ b/tests/Unit/Domain/Services/ResetEmailerTest.php
@@ -8,6 +8,9 @@ use Swift_Mailer;
 use Swift_Message;
 use Twig_Template;
 
+/**
+ * @coversNothing
+ */
 class ResetEmailerTest extends \PHPUnit\Framework\TestCase
 {
     protected function tearDown()

--- a/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -9,6 +9,9 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
 use OpenCFP\Domain\Services\TalkRating\YesNoRating;
 
+/**
+ * @coversNothing
+ */
 class YesNoRatingTest extends MockeryTestCase
 {
     public function testRateThrowsExceptionOnInvalidRating()

--- a/tests/Unit/Domain/Talk/TalkFilterTest.php
+++ b/tests/Unit/Domain/Talk/TalkFilterTest.php
@@ -8,6 +8,9 @@ use OpenCFP\Domain\Talk\TalkFilter;
 use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Test\BaseTestCase;
 
+/**
+ * @coversNothing
+ */
 class TalkFilterTest extends BaseTestCase
 {
     protected $talk;

--- a/tests/Unit/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/Unit/Domain/Talk/TalkSubmissionTest.php
@@ -4,6 +4,9 @@ namespace OpenCFP\Test\Unit\Domain\Talk;
 
 use OpenCFP\Domain\Talk\TalkSubmission;
 
+/**
+ * @coversNothing
+ */
 class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */

--- a/tests/Unit/Faker/GeneratorTest.php
+++ b/tests/Unit/Faker/GeneratorTest.php
@@ -5,6 +5,9 @@ namespace OpenCFP\Test\Unit\Faker;
 use Faker\Generator;
 use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
+/**
+ * @coversNothing
+ */
 class GeneratorTest extends \PHPUnit\Framework\TestCase
 {
     use GeneratorTrait;

--- a/tests/Unit/Http/API/ApiControllerTest.php
+++ b/tests/Unit/Http/API/ApiControllerTest.php
@@ -4,6 +4,9 @@ namespace OpenCFP\Test\Unit\Http\API;
 
 use Symfony\Component\HttpFoundation;
 
+/**
+ * @coversNothing
+ */
 class ApiControllerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Unit/Http/API/ProfileApiControllerTest.php
+++ b/tests/Unit/Http/API/ProfileApiControllerTest.php
@@ -11,6 +11,9 @@ use OpenCFP\Http\API\ProfileController;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @coversNothing
+ */
 class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Unit/Http/API/TalkApiControllerTest.php
+++ b/tests/Unit/Http/API/TalkApiControllerTest.php
@@ -11,6 +11,9 @@ use OpenCFP\Http\API\TalkController;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @coversNothing
+ */
 class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Unit/Http/Controller/FlashableTraitTest.php
+++ b/tests/Unit/Http/Controller/FlashableTraitTest.php
@@ -5,6 +5,9 @@ namespace OpenCFP\Test\Unit\Http\Controller;
 use OpenCFP\Application;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
+/**
+ * @coversNothing
+ */
 class FlashableTraitTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetFlashReturnsFlashAndClearsIt()

--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -5,6 +5,9 @@ namespace OpenCFP\Test\Unit\Http\Form;
 use Mockery as m;
 use OpenCFP\Http\Form\SignupForm;
 
+/**
+ * @coversNothing
+ */
 class SignupFormTest extends \PHPUnit\Framework\TestCase
 {
     private $purifier;

--- a/tests/Unit/Http/Form/TalkFormTest.php
+++ b/tests/Unit/Http/Form/TalkFormTest.php
@@ -4,6 +4,9 @@ namespace OpenCFP\Test\Unit\Http\Form;
 
 use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
+/**
+ * @coversNothing
+ */
 class TalkFormTest extends \PHPUnit\Framework\TestCase
 {
     use GeneratorTrait;

--- a/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
@@ -9,6 +9,9 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
+/**
+ * @coversNothing
+ */
 class RoleAccessTest extends WebTestCase
 {
     public function testReturnsRedirectIfCheckFailed()

--- a/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -11,6 +11,9 @@ use OpenCFP\Domain\Speaker\SpeakerRepository;
 use OpenCFP\Infrastructure\Auth\SentryIdentityProvider;
 use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
+/**
+ * @coversNothing
+ */
 class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
 {
     use GeneratorTrait;

--- a/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
@@ -8,6 +8,9 @@ use OpenCFP\Infrastructure\Auth\SpeakerAccess;
 use OpenCFP\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
+/**
+ * @coversNothing
+ */
 class SpeakerAccessTest extends WebTestCase
 {
     public function testReturnsRedirectIfCheckFailed()

--- a/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -4,6 +4,9 @@ namespace OpenCFP\Test\Unit\Infrastructure\Crypto;
 
 use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
 
+/**
+ * @coversNothing
+ */
 class PseudoRandomStringGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Unit/Provider/SymfonySentrySessionTest.php
+++ b/tests/Unit/Provider/SymfonySentrySessionTest.php
@@ -5,6 +5,9 @@ namespace OpenCFP\Test\Unit\Provider;
 use OpenCFP\Provider\SymfonySentrySession;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
+/**
+ * @coversNothing
+ */
 class SymfonySentrySessionTest extends \PHPUnit\Framework\TestCase
 {
     public function testDefaults()


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_test_class_requires_covers` fixer
* [x] runs `make cs`

Somewhat related to #620.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**php_unit_test_class_requires_covers**
>
>Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation.

❗️ Merging this probably only makes sense after #620 and #629.