### PR TITLE
Enhancement: Enable phpdoc_no_package fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -28,6 +28,7 @@ $config = PhpCsFixer\Config::create()
         'phpdoc_align' => true,
         'phpdoc_indent' => true,
         'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
         'php_unit_expectation' => true,

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 /**
  * Class Talk
  *
- * @package OpenCFP\Domain\Model
  *
  * @method Builder recent(int $limit=10)
  * @method Builder selected()

--- a/classes/Http/View/TalkHelper.php
+++ b/classes/Http/View/TalkHelper.php
@@ -5,7 +5,6 @@ namespace OpenCFP\Http\View;
 /**
  * Class TalkHelper
  *
- * @package OpenCFP\Http\View
  */
 class TalkHelper
 {

--- a/tests/Console/AdminPromoteCommandTest.php
+++ b/tests/Console/AdminPromoteCommandTest.php
@@ -10,7 +10,6 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
 /**
  * Class AdminPromoteTest
  *
- * @package OpenCFP\Test\Console
  * @group db
  */
 class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console;
 /**
  * Class ApplicationTest
  *
- * @package OpenCFP\Test\Console
  * @group db
  */
 class ApplicationTest extends \PHPUnit\Framework\TestCase

--- a/tests/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Http/Controller/Admin/SpeakersControllerTest.php
@@ -12,7 +12,6 @@ use OpenCFP\Test\WebTestCase;
 /**
  * Class SpeakersControllerTest
  *
- * @package OpenCFP\Test\Http\Controller\Admin
  * @group db
  */
 class SpeakersControllerTest extends WebTestCase

--- a/tests/Http/Controller/DashboardControllerTest.php
+++ b/tests/Http/Controller/DashboardControllerTest.php
@@ -12,7 +12,6 @@ use OpenCFP\Test\WebTestCase;
 /**
  * Class DashboardControllerTest
  *
- * @package OpenCFP\Test\Http\Controller
  * @group db
  */
 class DashboardControllerTest extends WebTestCase

--- a/tests/Http/Controller/ForgotControllerTest.php
+++ b/tests/Http/Controller/ForgotControllerTest.php
@@ -11,7 +11,6 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
 /**
  * Class ForgotControllerTest
  *
- * @package OpenCFP\Test\Http\Controller
  * @group db
  */
 class ForgotControllerTest extends \PHPUnit\Framework\TestCase

--- a/tests/Http/Controller/ProfileControllerTest.php
+++ b/tests/Http/Controller/ProfileControllerTest.php
@@ -9,7 +9,6 @@ use OpenCFP\Test\WebTestCase;
 /**
  * Class ProfileControllerTest
  *
- * @package OpenCFP\Test\Http\Controller
  * @group db
  */
 class ProfileControllerTest extends WebTestCase

--- a/tests/Http/Controller/SignupControllerTest.php
+++ b/tests/Http/Controller/SignupControllerTest.php
@@ -8,7 +8,6 @@ use OpenCFP\Test\WebTestCase;
 /**
  * Class SignupControllerTest
  *
- * @package OpenCFP\Test\Http\Controller
  * @group db
  */
 class SignupControllerTest extends WebTestCase

--- a/tests/Http/Controller/TalkControllerTest.php
+++ b/tests/Http/Controller/TalkControllerTest.php
@@ -13,7 +13,6 @@ use OpenCFP\Test\WebTestCase;
 /**
  * Class TalkControllerTest
  *
- * @package OpenCFP\Test\Http\Controller
  * @group db
  */
 class TalkControllerTest extends WebTestCase

--- a/tests/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -9,7 +9,6 @@ use OpenCFP\Test\DataBaseInteraction;
 /**
  * Class SentryAccountManagementTest
  *
- * @package OpenCFP\Test\Infrastructure\Auth
  * @group db
  */
 class SentryAccountManagementTest extends BaseTestCase

--- a/tests/Infrastructure/Auth/SentryAuthenticationTest.php
+++ b/tests/Infrastructure/Auth/SentryAuthenticationTest.php
@@ -10,7 +10,6 @@ use OpenCFP\Test\DataBaseInteraction;
 /**
  * Class SentryAuthenticationTest
  *
- * @package OpenCFP\Test\Infrastructure\Auth
  * @group db
  */
 class SentryAuthenticationTest extends BaseTestCase


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_no_package` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**phpdoc_no_package** [`@Symfony`]
>
>`@package` and `@subpackage` annotations should be omitted from phpdocs.