### PR TITLE
Enhancement: Enable phpdoc_order fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -29,6 +29,7 @@ $config = PhpCsFixer\Config::create()
         'phpdoc_indent' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
+        'phpdoc_order' => true,
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
         'php_unit_expectation' => true,

--- a/classes/Application/Speakers.php
+++ b/classes/Application/Speakers.php
@@ -60,9 +60,10 @@ class Speakers
      *
      * @param int $talkId
      *
+     * @throws NotAuthorizedException
+     *
      * @return Talk
      *
-     * @throws NotAuthorizedException
      */
     public function getTalk(int $talkId)
     {
@@ -94,9 +95,10 @@ class Speakers
      *
      * @param TalkSubmission $submission
      *
+     * @throws \Exception
+     *
      * @return Talk
      *
-     * @throws \Exception
      */
     public function submitTalk(TalkSubmission $submission)
     {

--- a/classes/Domain/Model/Airport.php
+++ b/classes/Domain/Model/Airport.php
@@ -12,9 +12,10 @@ class Airport extends Eloquent implements AirportInformationDatabase
     /**
      * @param string $code the IATA Airport Code to get information for
      *
+     * @throws \Exception
+     *
      * @return self
      *
-     * @throws \Exception
      */
     public function withCode($code): self
     {

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -74,9 +74,10 @@ class User extends Eloquent
     /**
      * Deletes user, all of their talks, and meta/favorites/comments
      *
+     * @throws \Exception
+     *
      * @return bool
      *
-     * @throws \Exception
      */
     public function delete(): bool
     {

--- a/classes/Domain/Services/Authentication.php
+++ b/classes/Domain/Services/Authentication.php
@@ -19,18 +19,20 @@ interface Authentication
     /**
      * Returns current authenticated User account.
      *
+     * @throws NotAuthenticatedException
+     *
      * @return UserInterface
      *
-     * @throws NotAuthenticatedException
      */
     public function user(): UserInterface;
 
     /**
      * Returns current authenticated User Id.
      *
+     * @throws NotAuthenticatedException
+     *
      * @return int
      *
-     * @throws NotAuthenticatedException
      */
     public function userId(): int;
 

--- a/classes/Domain/Services/IdentityProvider.php
+++ b/classes/Domain/Services/IdentityProvider.php
@@ -9,9 +9,10 @@ interface IdentityProvider
     /**
      * Retrieves the currently authenticate user's username.
      *
+     * @throws NotAuthenticatedException
+     *
      * @return User
      *
-     * @throws NotAuthenticatedException
      */
     public function getCurrentUser();
 }

--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -45,9 +45,10 @@ class ProfileImageProcessor
      * @param UploadedFile $file
      * @param string       $publishFilename
      *
+     * @throws \Exception
+     *
      * @return string
      *
-     * @throws \Exception
      */
     public function process(UploadedFile $file, $publishFilename = null): string
     {

--- a/classes/Http/API/TalkController.php
+++ b/classes/Http/API/TalkController.php
@@ -25,9 +25,10 @@ class TalkController extends ApiController
     /**
      * @param Request $request
      *
+     * @throws \Exception
+     *
      * @return JsonResponse
      *
-     * @throws \Exception
      */
     public function handleSubmitTalk(Request $request)
     {

--- a/classes/Infrastructure/Auth/OAuthIdentityProvider.php
+++ b/classes/Infrastructure/Auth/OAuthIdentityProvider.php
@@ -30,10 +30,11 @@ class OAuthIdentityProvider implements IdentityProvider
     /**
      * Retrieves the currently authenticate user's username.
      *
-     * @return User
-     *
      * @throws InvalidRequestException
      * @throws AccessDeniedException
+     *
+     * @return User
+     *
      */
     public function getCurrentUser()
     {

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -40,9 +40,10 @@ class SentryAuthentication implements Authentication
     /**
      * Returns current authenticated User account.
      *
+     * @throws NotAuthenticatedException
+     *
      * @return UserInterface
      *
-     * @throws NotAuthenticatedException
      */
     public function user(): UserInterface
     {

--- a/classes/Infrastructure/Auth/SentryIdentityProvider.php
+++ b/classes/Infrastructure/Auth/SentryIdentityProvider.php
@@ -22,9 +22,10 @@ class SentryIdentityProvider implements IdentityProvider
     /**
      * Retrieves the currently authenticate user's username.
      *
+     * @throws NotAuthenticatedException
+     *
      * @return User
      *
-     * @throws NotAuthenticatedException
      */
     public function getCurrentUser()
     {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_order` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**phpdoc_order**
>
>Annotations in phpdocs should be ordered so that param annotations come first, then throws annotations, then return annotations.
