### PR TITLE
Enhancement: Enable phpdoc_trim fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -31,6 +31,7 @@ $config = PhpCsFixer\Config::create()
         'phpdoc_no_package' => true,
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
+        'phpdoc_trim' => true,
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,
         'psr0' => false,

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
- *
  * @method Builder recent(int $limit=10)
  * @method Builder selected()
  * @method Builder notViewedBy(int $userId)

--- a/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
@@ -11,7 +11,6 @@ interface TalkRatingStrategy
      * @param $rating
      *
      * @throws TalkRatingException
-     *
      */
     public function rate(int $talkId, $rating);
 }

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -165,7 +165,6 @@ abstract class Form
 
     /**
      * Method that sanitizes all data
-     *
      */
     public function sanitize()
     {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_trim` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**phpdoc_trim** [`@Symfony`]
>
>Phpdocs should start and end with content, excluding the very first and last line of the docblocks.

