### PR TITLE
Enhancement: Link to speaker page from talks

### DIFF
--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -49,6 +49,11 @@ class SpeakerProfile
         return $this->speaker->has_made_profile == 0;
     }
 
+    public function getId()
+    {
+        return $this->speaker->id;
+    }
+
     /**
      * Retrieves all of the speakers talks
      *

--- a/resources/views/admin/index.twig
+++ b/resources/views/admin/index.twig
@@ -54,7 +54,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a> <a class="text-sm text-grey-dark" href="{{ url("admin_speaker_view", {id:talk.speaker.id}) }}"><span> &mdash; {{ talk.speaker.name }}</span></a></h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>

--- a/resources/views/admin/talks/index.twig
+++ b/resources/views/admin/talks/index.twig
@@ -43,7 +43,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><a class="text-sm text-grey-dark" href="{{ url("admin_speaker_view", {id:talk.speaker.id}) }}"><span> &mdash;  {{ talk.speaker.name }}</span></a></h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>

--- a/resources/views/admin/talks/view.twig
+++ b/resources/views/admin/talks/view.twig
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between">
         <div>
             <h2 class="mb-2">
-                {{ talk.title|raw }} <span class="text-grey-dark">&mdash; {{ talk.speaker.name }}</span>
+                {{ talk.title|raw }} <a class="text-sm text-grey-dark" href="{{ url("admin_speaker_view", {id:talk.speaker.id}) }}"><span>&mdash; {{ talk.speaker.name }}</span></a>
             </h2>
             {% if talk.slides is defined and talk.slides is not empty %}
                 <div><i class="fa fa-television mr-1"></i> <a class="hover:text-brand" href="{{ talk.slides }}">{{ talk.slides }}</a></div>

--- a/resources/views/reviewer/index.twig
+++ b/resources/views/reviewer/index.twig
@@ -54,7 +54,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><a class="text-sm text-grey-dark" href="{{ url("reviewer_speaker_view", {id:talk.speaker.id}) }}"><span> &mdash; {{ talk.speaker.name }}</span></a></h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>

--- a/resources/views/reviewer/talks/index.twig
+++ b/resources/views/reviewer/talks/index.twig
@@ -43,7 +43,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><a class="text-sm text-grey-dark" href="{{ url("reviewer_speaker_view", {id:talk.speaker.id}) }}"><span> &mdash; {{ talk.speaker.name }}</span></a></h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>

--- a/resources/views/reviewer/talks/view.twig
+++ b/resources/views/reviewer/talks/view.twig
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between">
         <div>
             <h2 class="mb-2">
-                {{ talk.title|raw }} {% if talk.speaker.isAllowedToSee('name') %}<span class="text-grey-dark">&mdash; {{ talk.speaker.name }}</span> {% endif %}
+                {{ talk.title|raw }} {% if talk.speaker.isAllowedToSee('name') %}<a class="text-sm text-grey-dark" href="{{ url("reviewer_speaker_view", {id:talk.speaker.id}) }}"><span> &mdash; {{ talk.speaker.name }}</span></a> {% endif %}
             </h2>
             {% if talk.slides is defined and talk.slides is not empty %}
                 <div><i class="fa fa-television mr-1"></i> <a class="hover:text-brand" href="{{ talk.slides }}">{{ talk.slides }}</a></div>

--- a/tests/Integration/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Integration/Domain/Speaker/SpeakerProfileTest.php
@@ -27,6 +27,12 @@ class SpeakerProfileTest extends BaseTestCase
         self::$profile = new SpeakerProfile(self::$user);
     }
 
+    public function testGetIdReturnsId()
+    {
+        $id = self::$user->id;
+        $this->assertSame($id, self::$profile->getId());
+    }
+
     public function testNeedsProfileReturnsCorrectly()
     {
         //if the user needs a profile they haven't made one, hence the !


### PR DESCRIPTION
This PR

* [x] Adds a link to a speaker page when looking at their talks
* [x] Adds links to the talk overviews
* [x] Updates the SpeakerProfile class and its tests to make this possible.

I think this used to be a feature but it probably got lost during #518 