### PR TITLE
Fix: Replace coversNothing with appropriate covers annotations

### DIFF
--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -15,7 +15,7 @@ use OpenCFP\Domain\Talk\TalkRepository;
 use OpenCFP\Domain\Talk\TalkSubmission;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Application\Speakers
  */
 class SpeakersTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Console/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/AdminPromoteCommandTest.php
@@ -9,7 +9,7 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
 
 /**
  * @group db
- * @coversNothing
+ * @covers \OpenCFP\Console\Command\AdminPromoteCommand
  */
 class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console;
 
 /**
  * @group db
- * @coversNothing
+ * @covers \OpenCFP\Console\Application
  */
 class ApplicationTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/ContainerAwareTest.php
+++ b/tests/Unit/ContainerAwareTest.php
@@ -6,7 +6,7 @@ use Mockery as m;
 use OpenCFP\Application;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\ContainerAware
  */
 class ContainerAwareTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Domain/CallForProposalTest.php
+++ b/tests/Unit/Domain/CallForProposalTest.php
@@ -5,7 +5,7 @@ namespace OpenCFP\Test\Unit\Domain;
 use OpenCFP\Domain\CallForProposal;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Domain\CallForProposal
  */
 class CallForProposalTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Domain/Services/ResetEmailerTest.php
+++ b/tests/Unit/Domain/Services/ResetEmailerTest.php
@@ -9,7 +9,7 @@ use Swift_Message;
 use Twig_Template;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Domain\Services\ResetEmailer
  */
 class ResetEmailerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -10,7 +10,7 @@ use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
 use OpenCFP\Domain\Services\TalkRating\YesNoRating;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Domain\Services\TalkRating\YesNoRating
  */
 class YesNoRatingTest extends MockeryTestCase
 {

--- a/tests/Unit/Domain/Talk/TalkFilterTest.php
+++ b/tests/Unit/Domain/Talk/TalkFilterTest.php
@@ -9,7 +9,7 @@ use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Test\BaseTestCase;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Domain\Talk\TalkFilter
  */
 class TalkFilterTest extends BaseTestCase
 {

--- a/tests/Unit/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/Unit/Domain/Talk/TalkSubmissionTest.php
@@ -5,7 +5,7 @@ namespace OpenCFP\Test\Unit\Domain\Talk;
 use OpenCFP\Domain\Talk\TalkSubmission;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Domain\Talk\TalkSubmission
  */
 class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Faker/GeneratorTest.php
+++ b/tests/Unit/Faker/GeneratorTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Test\Helper\Faker\GeneratorTrait
  */
 class GeneratorTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Http/API/ApiControllerTest.php
+++ b/tests/Unit/Http/API/ApiControllerTest.php
@@ -5,7 +5,7 @@ namespace OpenCFP\Test\Unit\Http\API;
 use Symfony\Component\HttpFoundation;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Http\API\ApiController
  */
 class ApiControllerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Http/API/ProfileApiControllerTest.php
+++ b/tests/Unit/Http/API/ProfileApiControllerTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Http\API\ProfileController
  */
 class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Http/API/TalkApiControllerTest.php
+++ b/tests/Unit/Http/API/TalkApiControllerTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @coversNothing
+ * @coversNothing \OpenCFP\Http\API\TalkController
  */
 class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Http/Controller/FlashableTraitTest.php
+++ b/tests/Unit/Http/Controller/FlashableTraitTest.php
@@ -6,7 +6,7 @@ use OpenCFP\Application;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Http\Controller\FlashableTrait
  */
 class FlashableTraitTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -6,7 +6,7 @@ use Mockery as m;
 use OpenCFP\Http\Form\SignupForm;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Http\Form\SignupForm
  */
 class SignupFormTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Http/Form/TalkFormTest.php
+++ b/tests/Unit/Http/Form/TalkFormTest.php
@@ -5,7 +5,7 @@ namespace OpenCFP\Test\Unit\Http\Form;
 use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Http\Form\TalkForm
  */
 class TalkFormTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
@@ -10,7 +10,7 @@ use OpenCFP\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Infrastructure\Auth\RoleAccess
  */
 class RoleAccessTest extends WebTestCase
 {

--- a/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -12,7 +12,7 @@ use OpenCFP\Infrastructure\Auth\SentryIdentityProvider;
 use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Infrastructure\Auth\SentryIdentityProvider
  */
 class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
@@ -9,7 +9,7 @@ use OpenCFP\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Infrastructure\Auth\SpeakerAccess
  */
 class SpeakerAccessTest extends WebTestCase
 {

--- a/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -5,7 +5,7 @@ namespace OpenCFP\Test\Unit\Infrastructure\Crypto;
 use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator
  */
 class PseudoRandomStringGeneratorTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Provider/SymfonySentrySessionTest.php
+++ b/tests/Unit/Provider/SymfonySentrySessionTest.php
@@ -6,7 +6,7 @@ use OpenCFP\Provider\SymfonySentrySession;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Provider\SymfonySentrySession
  */
 class SymfonySentrySessionTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
❗️ Blocked by #651.

This PR

* [x] replaces `@coversNothing` with appropriate `@covers` annotations

Follows #641.
