### PR TITLE
Enhancement: Use MockeryPHPUnitIntegration trait

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Test;
 
-use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenCFP\Application;
 use OpenCFP\Environment;
 use OpenCFP\Test\Helper\DataBaseInteraction;
@@ -10,6 +10,8 @@ use OpenCFP\Test\Helper\RefreshDatabase;
 
 abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var Application
      */
@@ -33,10 +35,6 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
         if ($this->app) {
             $this->app->flush();
             $this->app = null;
-        }
-
-        if (class_exists('Mockery')) {
-            Mockery::close();
         }
     }
 

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenCFP\Test\Unit\Application;
 
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use Mockery\MockInterface;
 use OpenCFP\Application\Speakers;
@@ -19,6 +20,8 @@ use OpenCFP\Domain\Talk\TalkSubmission;
  */
 class SpeakersTest extends \PHPUnit\Framework\TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     const SPEAKER_ID = '1';
 
     /** @var Speakers */
@@ -48,11 +51,6 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
         $this->dispatcher        = m::mock(\OpenCFP\Domain\Services\EventDispatcher::class);
 
         $this->sut = new Speakers($this->callForProposal, $this->identityProvider, $this->speakerRepository, $this->talkRepository, $this->dispatcher);
-    }
-
-    protected function tearDown()
-    {
-        m::close();
     }
 
     //

--- a/tests/Unit/Console/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/AdminPromoteCommandTest.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Test\Unit\Console;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Environment;
 use OpenCFP\Infrastructure\Auth\UserInterface;
@@ -13,10 +14,7 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
  */
 class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
 {
-    protected function tearDown()
-    {
-        Mockery::close();
-    }
+    use MockeryPHPUnitIntegration;
 
     /**
      * @test

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Test\Unit\Console;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenCFP\Console\Application;
 use OpenCFP\Console\Command;
 use OpenCFP\Domain\Services\AccountManagement;
@@ -16,10 +17,7 @@ use Symfony\Component\Console;
  */
 class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
-    protected function tearDown()
-    {
-        Mockery::close();
-    }
+    use MockeryPHPUnitIntegration;
 
     public function testIsConsoleApplication()
     {

--- a/tests/Unit/Domain/Services/ResetEmailerTest.php
+++ b/tests/Unit/Domain/Services/ResetEmailerTest.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Test\Unit\Domain\Services;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenCFP\Domain\Services\ResetEmailer;
 use Swift_Mailer;
 use Swift_Message;
@@ -13,10 +14,7 @@ use Twig_Template;
  */
 class ResetEmailerTest extends \PHPUnit\Framework\TestCase
 {
-    protected function tearDown()
-    {
-        Mockery::close();
-    }
+    use MockeryPHPUnitIntegration;
 
     /** @test */
     public function it_sends_the_expected_email()


### PR DESCRIPTION
This PR

* [x] makes use of the `MockeryPHPUnitIntegration` trait instead of closing mockery ourselves