### PR TITLE
Fix: Move test into appropriate namespace

### DIFF
--- a/tests/Unit/Console/Command/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/AdminPromoteCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenCFP\Test\Unit\Console;
+namespace OpenCFP\Test\Unit\Console\Command;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;


### PR DESCRIPTION
This PR

* [x] moves a test into the appropriate namespace