### PR TITLE
Fix: Do not extend BaseTestCase if unit test

### DIFF
--- a/tests/Unit/Domain/Services/PaginationTest.php
+++ b/tests/Unit/Domain/Services/PaginationTest.php
@@ -3,13 +3,13 @@
 namespace OpenCFP\Test\Unit\Domain\Services;
 
 use OpenCFP\Domain\Services\Pagination;
-use OpenCFP\Test\BaseTestCase;
 use Pagerfanta\Pagerfanta;
+use PHPUnit\Framework;
 
 /**
  * @covers \OpenCFP\Domain\Services\Pagination
  */
-class PaginationTest extends BaseTestCase
+class PaginationTest extends Framework\TestCase
 {
     /**
      * @var Pagination

--- a/tests/Unit/Domain/Talk/TalkFilterTest.php
+++ b/tests/Unit/Domain/Talk/TalkFilterTest.php
@@ -3,16 +3,19 @@
 namespace OpenCFP\Test\Unit\Domain\Talk;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Talk\TalkFilter;
 use OpenCFP\Domain\Talk\TalkFormatter;
-use OpenCFP\Test\BaseTestCase;
+use PHPUnit\Framework;
 
 /**
  * @covers \OpenCFP\Domain\Talk\TalkFilter
  */
-class TalkFilterTest extends BaseTestCase
+class TalkFilterTest extends Framework\TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     protected $talk;
 
     protected $formatter;


### PR DESCRIPTION
This PR

* [x] has a unit test extend from `PHPUnit\Framework\TestCase` instead of `OpenCFP\Test\BaseTestCase`

Follows https://github.com/opencfp/opencfp/pull/629#issuecomment-346014095.

💁‍♂️ Next up, moving `BaseTestCase` into the `OpenCFP\Test\Integration` namespace.