### PR TITLE
Fix: Remove duplicates from the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,3 @@ test: integration unit
 
 unit: composer
 	vendor/bin/phpunit --configuration tests/Unit/phpunit.xml.dist
-
-test: composer database
-	vendor/bin/phpunit


### PR DESCRIPTION
This PR

* [x] Removes a duplicate entry of test from the makefile

