### PR TITLE
Enhancement: Enable no_multiline_whitespace_before_semicolon fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -26,6 +26,7 @@ $config = PhpCsFixer\Config::create()
         'no_alias_functions' => true,
         'no_empty_phpdoc' => true,
         'no_extra_consecutive_blank_lines' => true,
+        'no_multiline_whitespace_before_semicolons' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unused_imports' => true,
         'ordered_imports' => true,

--- a/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
@@ -64,8 +64,7 @@ class IlluminateSpeakerRepositoryTest extends BaseTestCase
             ->shouldReceive('findOrFail')
             ->once()
             ->with($id)
-            ->andReturn($speaker)
-        ;
+            ->andReturn($speaker);
 
         $repository = new IlluminateSpeakerRepository($speaker);
 

--- a/tests/Unit/ContainerAwareTest.php
+++ b/tests/Unit/ContainerAwareTest.php
@@ -21,8 +21,7 @@ class ContainerAwareTest extends \PHPUnit\Framework\TestCase
             ->shouldReceive('offsetGet')
             ->once()
             ->with($slug)
-            ->andReturn($service)
-        ;
+            ->andReturn($service);
 
         $containerAware = new ContainerAwareFake();
 

--- a/tests/Unit/Domain/Services/ResetEmailerTest.php
+++ b/tests/Unit/Domain/Services/ResetEmailerTest.php
@@ -30,8 +30,7 @@ class ResetEmailerTest extends \PHPUnit\Framework\TestCase
                     $userEmail => null,
                 ];
             }))
-            ->getMock()
-        ;
+            ->getMock();
 
         /* @var Twig_Template $template */
         $template = Mockery::mock(Twig_Template::class)->shouldIgnoreMissing();

--- a/tests/Unit/Http/Controller/FlashableTraitTest.php
+++ b/tests/Unit/Http/Controller/FlashableTraitTest.php
@@ -20,8 +20,7 @@ class FlashableTraitTest extends \PHPUnit\Framework\TestCase
             ->expects($this->at(0))
             ->method('get')
             ->with($this->identicalTo('flash'))
-            ->willReturn($flash)
-        ;
+            ->willReturn($flash);
 
         $session
             ->expects($this->at(1))
@@ -29,8 +28,7 @@ class FlashableTraitTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->identicalTo('flash'),
                 $this->identicalTo(null)
-            )
-        ;
+            );
 
         $application = $this->getApplicationMock([
             'session' => $session,
@@ -51,8 +49,7 @@ class FlashableTraitTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->identicalTo('flash'),
                 $this->identicalTo(null)
-            )
-        ;
+            );
 
         $application = $this->getApplicationMock([
             'session' => $session,
@@ -76,8 +73,7 @@ class FlashableTraitTest extends \PHPUnit\Framework\TestCase
     {
         $application = $this->getMockBuilder(\OpenCFP\Application::class)
             ->disableOriginalConstructor()
-            ->getMock()
-        ;
+            ->getMock();
 
         $application
             ->expects($this->any())
@@ -86,8 +82,7 @@ class FlashableTraitTest extends \PHPUnit\Framework\TestCase
                 if (array_key_exists($alias, $items)) {
                     return $items[$alias];
                 }
-            })
-        ;
+            });
 
         return $application;
     }

--- a/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -38,8 +38,7 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
         $sentry
             ->shouldReceive('getUser')
             ->once()
-            ->andReturnNull()
-        ;
+            ->andReturnNull();
 
         $speakerRepository = $this->getSpeakerRepositoryMock();
 
@@ -64,16 +63,14 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
         $sentryUser
             ->shouldReceive('getId')
             ->once()
-            ->andReturn($id)
-        ;
+            ->andReturn($id);
 
         $sentry = $this->getSentryMock();
 
         $sentry
             ->shouldReceive('getUser')
             ->once()
-            ->andReturn($sentryUser)
-        ;
+            ->andReturn($sentryUser);
 
         $user = $this->getUserMock();
 
@@ -83,8 +80,7 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
             ->shouldReceive('findById')
             ->once()
             ->with($id)
-            ->andReturn($user)
-        ;
+            ->andReturn($user);
 
         $provider = new SentryIdentityProvider(
             $sentry,

--- a/tests/Unit/Provider/SymfonySentrySessionTest.php
+++ b/tests/Unit/Provider/SymfonySentrySessionTest.php
@@ -42,8 +42,7 @@ class SymfonySentrySessionTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->identicalTo($key),
                 $this->identicalTo($value)
-            )
-        ;
+            );
 
         $sentrySession = new SymfonySentrySession(
             $session,
@@ -64,8 +63,7 @@ class SymfonySentrySessionTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('get')
             ->with($this->identicalTo($key))
-            ->willReturn($value)
-        ;
+            ->willReturn($value);
 
         $sentrySession = new SymfonySentrySession(
             $session,
@@ -84,8 +82,7 @@ class SymfonySentrySessionTest extends \PHPUnit\Framework\TestCase
         $session
             ->expects($this->once())
             ->method('remove')
-            ->with($this->identicalTo($key))
-        ;
+            ->with($this->identicalTo($key));
 
         $sentrySession = new SymfonySentrySession(
             $session,


### PR DESCRIPTION
This PR

* [x] enables the `no_multiline_whitespace_before_semicolon` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**no_multiline_whitespace_before_semicolons**
>
>Multi-line whitespace before closing semicolon are prohibited.