### PR TITLE
Fix: Add test for AuthenticationException

### DIFF
--- a/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
+++ b/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenCFP\Test\Unit\Domain\Services;
+
+use OpenCFP\Domain\Services\AuthenticationException;
+use PHPUnit\Framework;
+
+/**
+ * @covers \OpenCFP\Domain\Services\AuthenticationException
+ */
+final class AuthenticationExceptionTest extends Framework\TestCase
+{
+    public function testIsException()
+    {
+        $exception = new AuthenticationException();
+
+        $this->assertInstanceOf(\Exception::class, $exception);
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds a test for `OpenCFP\Domain\Services\AuthenticationException`

Follows #656.