### PR TITLE
Enhancement: Allow to pass in $_SERVER

### DIFF
--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -39,9 +39,26 @@ class Environment
         return new self(self::TYPE_TESTING);
     }
 
+    /**
+     * @deprecated
+     *
+     * @return self
+     */
     public static function fromEnvironmentVariable(): self
     {
-        $type = $_SERVER['CFP_ENV'] ?? self::TYPE_DEVELOPMENT;
+        return self::fromServer($_SERVER);
+    }
+
+    /**
+     * @param array $server
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return self
+     */
+    public static function fromServer(array $server): self
+    {
+        $type = $server['CFP_ENV'] ?? self::TYPE_DEVELOPMENT;
 
         return new self($type);
     }

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -43,6 +43,21 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @dataProvider providerEnvironment
+     *
+     * @param string $type
+     */
+    public function testFromServerReturnsEnvironment(string $type)
+    {
+        $environment = Environment::fromServer([
+            'CFP_ENV' => $type,
+        ]);
+
+        $this->assertInstanceOf(Environment::class, $environment);
+        $this->assertEquals($type, $environment);
+    }
+
+    /**
      * @test
      * @dataProvider providerEnvironment
      *

--- a/web/index.php
+++ b/web/index.php
@@ -6,7 +6,7 @@ use OpenCFP\Application;
 use OpenCFP\Environment;
 
 $basePath    = realpath(dirname(__DIR__));
-$environment = Environment::fromEnvironmentVariable();
+$environment = Environment::fromServer($_SERVER);
 
 $app = new Application($basePath, $environment);
 


### PR DESCRIPTION
This PR

* [x] allows to pass in `$_SERVER` to create an instance of `Environment` instead of accessing the superglobal from within

Follows https://github.com/opencfp/opencfp/pull/671#discussion_r152666225.