### PR TITLE
Enhancement: Enable phpdoc_types_order fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -38,6 +38,7 @@ $config = PhpCsFixer\Config::create()
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
         'phpdoc_trim' => true,
+        'phpdoc_types_order' => true,
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,
         'php_unit_test_class_requires_covers' => true,

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -170,7 +170,7 @@ class Application extends SilexApplication
      *
      * @param string $path the configuration key in dot-notation
      *
-     * @return string|null the configuration value
+     * @return null|string the configuration value
      */
     public function config($path)
     {

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -49,7 +49,7 @@ class User extends Eloquent
      * Will preform a like search with given search string or first or last name.
      *
      * @param Builder     $builder
-     * @param string|null $search           Name to search for
+     * @param null|string $search           Name to search for
      * @param string      $orderByColumn
      * @param string      $orderByDirection
      *

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -95,7 +95,7 @@ abstract class Form
      * @param string $name    The tainted value name
      * @param mixed  $default The default value to return if not set
      *
-     * @return mixed|null
+     * @return null|mixed
      */
     public function getTaintedField($name, $default = null)
     {
@@ -116,7 +116,7 @@ abstract class Form
      * Returns the value of a form's option if set.
      *
      * @param string     $name    The option name
-     * @param mixed|null $default The default value
+     * @param null|mixed $default The default value
      *
      * @return mixed The option value
      */

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -141,7 +141,7 @@ class SignupForm extends Form
     /**
      * Method that applies validation rules to user-submitted passwords
      *
-     * @return true|string
+     * @return string|true
      */
     public function validatePasswords(): bool
     {

--- a/tests/Unit/ContainerAwareTest.php
+++ b/tests/Unit/ContainerAwareTest.php
@@ -35,7 +35,7 @@ class ContainerAwareTest extends \PHPUnit\Framework\TestCase
     //
 
     /**
-     * @return m\MockInterface|Application
+     * @return Application|m\MockInterface
      */
     private function getApplicationMock()
     {

--- a/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -119,7 +119,7 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return m\MockInterface|Entity\User
+     * @return Entity\User|m\MockInterface
      */
     private function getUserMock()
     {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_types_order` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**phpdoc_types_order**
>
>Sorts PHPDoc types.
>
>Configuration options:
>
>* `null_adjustment` (`'always_first'`, `'always_last'`, `'none'`): forces the position of null (overrides `sort_algorithm`); defaults to `'always_first'`
>* `sort_algorithm` (`'alpha'`, `'none'`): the sorting algorithm to apply; defaults to `'alpha'`