### PR TITLE
Fix: True is not a type

### DIFF
--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -141,7 +141,7 @@ class SignupForm extends Form
     /**
      * Method that applies validation rules to user-submitted passwords
      *
-     * @return string|true
+     * @return bool|string
      */
     public function validatePasswords(): bool
     {


### PR DESCRIPTION
This PR

* [x] adjusts a docblock that uses `true` as a type

Spotted in #673.
