### PR TITLE
Fix: Use return type declarations

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -38,7 +38,7 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function createApplication()
+    public function createApplication(): Application
     {
         $app                 = new Application(BASE_PATH, Environment::testing());
         $app['session.test'] = true;

--- a/tests/Helper/DataBaseInteraction.php
+++ b/tests/Helper/DataBaseInteraction.php
@@ -2,7 +2,7 @@
 
 namespace OpenCFP\Test\Helper;
 
-use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Capsule\Manager;
 
 trait DataBaseInteraction
 {
@@ -11,8 +11,8 @@ trait DataBaseInteraction
         $this->getCapsule()->getConnection()->unprepared(file_get_contents(__DIR__ . '/../dump.sql'));
     }
 
-    protected function getCapsule()
+    protected function getCapsule(): Manager
     {
-        return $this->app[Capsule::class];
+        return $this->app[Manager::class];
     }
 }

--- a/tests/Integration/Http/Controller/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/DashboardControllerTest.php
@@ -117,7 +117,7 @@ class DashboardControllerTest extends WebTestCase
             ->assertNotSee('Need Hotel');
     }
 
-    private function stubProfileWith($stubMethods = [])
+    private function stubProfileWith($stubMethods = []): SpeakerProfile
     {
         $speakerProfileDouble = m::mock(SpeakerProfile::class);
         $speakerProfileDouble->shouldReceive($stubMethods);

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -158,7 +158,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    private function createUser()
+    private function createUser(): UserInterface
     {
         $user = m::mock(UserInterface::class);
         $user->shouldReceive('getResetPasswordCode');
@@ -167,7 +167,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         return $user;
     }
 
-    private function createForm($valid_status)
+    private function createForm($valid_status): \OpenCFP\Http\Form\ForgotForm
     {
         $is_valid = ($valid_status == 'valid');
         $form     = m::mock(\OpenCFP\Http\Form\ForgotForm::class);

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -34,7 +34,7 @@ class TestResponse
         $this->app          = $app;
     }
 
-    public function assertSuccessful()
+    public function assertSuccessful(): self
     {
         Assert::assertTrue(
             $this->isSuccessful(),
@@ -44,7 +44,7 @@ class TestResponse
         return $this;
     }
 
-    public function assertStatus($status)
+    public function assertStatus($status): self
     {
         $actual = $this->getStatusCode();
 
@@ -57,7 +57,7 @@ class TestResponse
         return $this;
     }
 
-    public function assertRedirect($route = null, $parameters = [])
+    public function assertRedirect($route = null, $parameters = []): self
     {
         Assert::assertTrue(
             $this->isRedirect(),
@@ -72,21 +72,21 @@ class TestResponse
         return $this;
     }
 
-    public function assertSee($content)
+    public function assertSee($content): self
     {
         Assert::assertContains($content, $this->getContent());
 
         return $this;
     }
 
-    public function assertNotSee($content)
+    public function assertNotSee($content): self
     {
         Assert::assertNotContains($content, $this->getContent());
 
         return $this;
     }
 
-    public function assertFlashContains($flash)
+    public function assertFlashContains($flash): self
     {
         $fullFlash = $this->app['session']->get('flash');
         $fullFlash = is_array($fullFlash) ? $fullFlash : [];
@@ -95,14 +95,14 @@ class TestResponse
         return $this;
     }
 
-    public function assertNoFlashSet()
+    public function assertNoFlashSet(): self
     {
         Assert::assertNull($this->app['session']->get('flash'));
 
         return $this;
     }
 
-    public function assertTargetURLContains(string$targetUrl)
+    public function assertTargetURLContains(string$targetUrl): self
     {
         Assert::assertInstanceOf(RedirectResponse::class, $this->baseResponse);
         Assert::assertContains($targetUrl, $this->baseResponse->getTargetUrl());

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -213,7 +213,7 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
             ->andThrow(\OpenCFP\Domain\EntityNotFoundException::class);
     }
 
-    private function getSpeaker()
+    private function getSpeaker(): User
     {
         return new User([
             'id'         => self::SPEAKER_ID,
@@ -223,7 +223,7 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    private function getSpeakerWithNoTalks()
+    private function getSpeakerWithNoTalks(): \stdClass
     {
         // Set up stub speaker.
         $stub = m::mock(\stdClass::class);
@@ -233,7 +233,7 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
         return $stub;
     }
 
-    private function getSpeakerFromMisbehavingRelation()
+    private function getSpeakerFromMisbehavingRelation(): \stdClass
     {
         // Set up stub speaker.
         $stub     = m::mock(\stdClass::class);
@@ -253,7 +253,7 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
         return $stub;
     }
 
-    private function getSpeakerWithOneTalk()
+    private function getSpeakerWithOneTalk(): \stdClass
     {
         // Set up stub speaker.
         $stub     = m::mock(\stdClass::class);
@@ -273,7 +273,7 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
         return $stub;
     }
 
-    private function getSpeakerWithManyTalks()
+    private function getSpeakerWithManyTalks(): \stdClass
     {
         // Set up stub speaker.
         $stub     = m::mock(\stdClass::class);

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -159,7 +159,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($response, 0);
     }
 
-    protected function createInputInterfaceWithEmail($email)
+    protected function createInputInterfaceWithEmail($email): \Symfony\Component\Console\Input\InputInterface
     {
         $input = Mockery::mock(\Symfony\Component\Console\Input\InputInterface::class);
         $input->shouldReceive('getArgument')->with('email')->andReturn($email);
@@ -167,7 +167,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         return $input;
     }
 
-    protected function createOutputInterface()
+    protected function createOutputInterface(): \Symfony\Component\Console\Output\OutputInterface
     {
         /**
          * Create a partial mock that stubs out method calls where we don't

--- a/tests/Unit/Console/Command/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/AdminPromoteCommandTest.php
@@ -80,7 +80,7 @@ class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($response, 0);
     }
 
-    protected function createInputInterfaceWithEmail($email)
+    protected function createInputInterfaceWithEmail($email): \Symfony\Component\Console\Input\InputInterface
     {
         $input = Mockery::mock(\Symfony\Component\Console\Input\InputInterface::class);
         $input->shouldReceive('getArgument')->with('email')->andReturn($email);
@@ -88,7 +88,7 @@ class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
         return $input;
     }
 
-    protected function createOutputInterface()
+    protected function createOutputInterface(): \Symfony\Component\Console\Output\OutputInterface
     {
         /**
          * Create a partial mock that stubs out method calls where we don't

--- a/tests/Unit/ContainerAwareTest.php
+++ b/tests/Unit/ContainerAwareTest.php
@@ -37,7 +37,7 @@ class ContainerAwareTest extends \PHPUnit\Framework\TestCase
     /**
      * @return Application|m\MockInterface
      */
-    private function getApplicationMock()
+    private function getApplicationMock(): Application
     {
         return m::mock(Application::class);
     }

--- a/tests/Unit/Domain/CallForProposalTest.php
+++ b/tests/Unit/Domain/CallForProposalTest.php
@@ -19,7 +19,7 @@ class CallForProposalTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($cfp->isOpen());
     }
 
-    public function stillOpenCfPsProvider()
+    public function stillOpenCfPsProvider(): array
     {
         return [
             ['+1 day'],

--- a/tests/Unit/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/Unit/Domain/Talk/TalkSubmissionTest.php
@@ -48,7 +48,7 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
         TalkSubmission::fromNative(['title' => $title]);
     }
 
-    public function invalidTalkTitles()
+    public function invalidTalkTitles(): array
     {
         return [
             [''],

--- a/tests/Unit/Http/API/ApiControllerTest.php
+++ b/tests/Unit/Http/API/ApiControllerTest.php
@@ -74,7 +74,7 @@ class ApiControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertContains($expectedDefaultMessage, $response->getContent());
     }
 
-    public function specializedResponseExamples()
+    public function specializedResponseExamples(): array
     {
         return [
             ['BadRequest', HttpFoundation\Response::HTTP_BAD_REQUEST, 'Bad request'],

--- a/tests/Unit/Http/API/ProfileApiControllerTest.php
+++ b/tests/Unit/Http/API/ProfileApiControllerTest.php
@@ -71,7 +71,7 @@ class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
     // Factory Methods
     //
 
-    private function getRequest(array $data = [])
+    private function getRequest(array $data = []): Request
     {
         $request = Request::create('');
         $request->request->replace($data);
@@ -79,7 +79,7 @@ class ProfileApiControllerTest extends \PHPUnit\Framework\TestCase
         return $request;
     }
 
-    private function someSpeakerProfile()
+    private function someSpeakerProfile(): SpeakerProfile
     {
         return new SpeakerProfile(new User(['first_name' => 'Hamburglar']));
     }

--- a/tests/Unit/Http/API/TalkApiControllerTest.php
+++ b/tests/Unit/Http/API/TalkApiControllerTest.php
@@ -133,7 +133,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
     // Factory Methods
     //
 
-    private function getRequest(array $data = [])
+    private function getRequest(array $data = []): Request
     {
         $request = Request::create('');
         $request->request->replace($data);
@@ -141,7 +141,7 @@ class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
         return $request;
     }
 
-    private function getValidRequest()
+    private function getValidRequest(): Request
     {
         return $this->getRequest([
             'title'       => 'Happy Path Submission',

--- a/tests/Unit/Http/Controller/FlashableTraitTest.php
+++ b/tests/Unit/Http/Controller/FlashableTraitTest.php
@@ -69,7 +69,7 @@ class FlashableTraitTest extends \PHPUnit\Framework\TestCase
      *
      * @return Application|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getApplicationMock(array $items = [])
+    private function getApplicationMock(array $items = []): Application
     {
         $application = $this->getMockBuilder(\OpenCFP\Application::class)
             ->disableOriginalConstructor()
@@ -90,7 +90,7 @@ class FlashableTraitTest extends \PHPUnit\Framework\TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|SessionInterface
      */
-    private function getSessionMock()
+    private function getSessionMock(): SessionInterface
     {
         return $this->getMockBuilder(\Symfony\Component\HttpFoundation\Session\SessionInterface::class)->getMock();
     }

--- a/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -97,7 +97,7 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * @return m\MockInterface|Sentry
      */
-    private function getSentryMock()
+    private function getSentryMock(): Sentry
     {
         return m::mock(Sentry::class);
     }
@@ -105,7 +105,7 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * @return m\MockInterface|Users\UserInterface
      */
-    private function getSentryUserMock()
+    private function getSentryUserMock(): Users\UserInterface
     {
         return m::mock(Users\UserInterface::class);
     }
@@ -113,7 +113,7 @@ class SentryIdentityProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * @return m\MockInterface|SpeakerRepository
      */
-    private function getSpeakerRepositoryMock()
+    private function getSpeakerRepositoryMock(): SpeakerRepository
     {
         return m::mock(SpeakerRepository::class);
     }

--- a/tests/Unit/Provider/SymfonySentrySessionTest.php
+++ b/tests/Unit/Provider/SymfonySentrySessionTest.php
@@ -99,7 +99,7 @@ class SymfonySentrySessionTest extends \PHPUnit\Framework\TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|SessionInterface
      */
-    private function getSessionMock()
+    private function getSessionMock(): SessionInterface
     {
         return $this->getMockBuilder(\Symfony\Component\HttpFoundation\Session\SessionInterface::class)->getMock();
     }


### PR DESCRIPTION
This PR

* [x] uses return type declarations in test code where appropriate

Follows #675.