### PR TITLE
Enhancement: Enable and configure is_null fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -22,6 +22,9 @@ $config = PhpCsFixer\Config::create()
             'spacing' => 'one',
         ],
         'increment_style' => true,
+        'is_null' => [
+            'use_yoda_style' => false,
+        ],
         'method_separation' => true,
         'no_alias_functions' => true,
         'no_empty_phpdoc' => true,

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -64,7 +64,7 @@ class TestResponse
             "Response status code [{$this->getStatusCode()}] is not a redirect status code."
         );
 
-        if (!is_null($route)) {
+        if ($route !== null) {
             $expected = $this->app['url_generator']->generate($route, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
             Assert::assertEquals($expected, $this->headers->get('Location'));
         }


### PR DESCRIPTION
This PR

* [x] enables and configures the `is_null` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**is_null** [`@Symfony:risky`]
>
>Replaces is_null(parameter) expression with `null === parameter`.
>
>Risky rule: risky when the function ``is_null()`` is overridden.
>
>Configuration options:
>
>* `use_yoda_style` (`bool`): whether Yoda style conditions should be used; defaults to `true`