### PR TITLE
Fix: Cover named constructor

### DIFF
--- a/tests/Unit/Domain/ValidationExceptionTest.php
+++ b/tests/Unit/Domain/ValidationExceptionTest.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Test\Unit\Domain;
 
 use OpenCFP\Domain\ValidationException;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 use PHPUnit\Framework;
 
 /**
@@ -10,10 +11,24 @@ use PHPUnit\Framework;
  */
 final class ValidationExceptionTest extends Framework\TestCase
 {
+    use GeneratorTrait;
+
     public function testIsException()
     {
         $exception = new ValidationException();
 
         $this->assertInstanceOf(\Exception::class, $exception);
+    }
+
+    public function testWithErrorsReturnsException()
+    {
+        $errors = $this->getFaker()->sentences;
+
+        $exception = ValidationException::withErrors($errors);
+
+        $this->assertInstanceOf(ValidationException::class, $exception);
+        $this->assertSame('There was an error.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($errors, $exception->errors());
     }
 }


### PR DESCRIPTION
This PR

* [x] covers a named constructor

Follows #656.