### PR TITLE
Fix: Use return type declarations

### DIFF
--- a/classes/Domain/Services/TalkRating/TalkRatingException.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingException.php
@@ -4,7 +4,7 @@ namespace OpenCFP\Domain\Services\TalkRating;
 
 class TalkRatingException extends \RuntimeException
 {
-    public static function invalidRating($rating)
+    public static function invalidRating($rating): self
     {
         return new self(sprintf('Invalid talk rating: %s', $rating));
     }

--- a/classes/Domain/Speaker/NotAllowedException.php
+++ b/classes/Domain/Speaker/NotAllowedException.php
@@ -4,7 +4,7 @@ namespace OpenCFP\Domain\Speaker;
 
 class NotAllowedException extends \Exception
 {
-    public static function notAllowedToView(string $property)
+    public static function notAllowedToView(string $property): self
     {
         return new self(sprintf('Not allowed to view %s. Hidden property', $property));
     }

--- a/classes/Domain/ValidationException.php
+++ b/classes/Domain/ValidationException.php
@@ -6,7 +6,7 @@ class ValidationException extends \Exception
 {
     private $errors;
 
-    public static function withErrors(array $errors = [])
+    public static function withErrors(array $errors = []): self
     {
         $instance         = new static('There was an error.');
         $instance->errors = $errors;
@@ -14,7 +14,7 @@ class ValidationException extends \Exception
         return $instance;
     }
 
-    public function errors()
+    public function errors(): array
     {
         return $this->errors;
     }


### PR DESCRIPTION
This PR

* [x] uses return type declarations

Follows #656.
Related to #684.