### PR TITLE
Enhancement: Enable no_blank_lines_after_phpdoc fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -24,6 +24,7 @@ $config = PhpCsFixer\Config::create()
         'increment_style' => true,
         'method_separation' => true,
         'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
         'no_empty_phpdoc' => true,
         'no_extra_consecutive_blank_lines' => true,
         'no_multiline_whitespace_before_semicolons' => true,

--- a/factories/Common.php
+++ b/factories/Common.php
@@ -1,7 +1,6 @@
 <?php
 
 /** @var $factory \Illuminate\Database\Eloquent\Factory */
-
 $factory->define(\OpenCFP\Domain\Model\User::class, function (\Faker\Generator $faker) {
     return [
         'email'          => $faker->unique()->safeEmail,


### PR DESCRIPTION
This PR

* [x] enables the `no_blank_lines_after_phpdoc` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**no_blank_lines_after_phpdoc** [`@Symfony`]
>
>There should not be blank lines between docblock and the documented element.