### PR TITLE
Enhancement: Enable ternary_operator_spaces fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -46,6 +46,7 @@ $config = PhpCsFixer\Config::create()
         'return_type_declaration' => true,
         'single_blank_line_before_namespace' => true,
         'single_quote' => true,
+        'ternary_operator_spaces' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,
         'yoda_style' => [

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -184,7 +184,7 @@ class Talk extends Eloquent
      */
     public function getMetaFor(int $userId, bool $willCreate = false)
     {
-        return $willCreate ? $this->getOrCreateMeta($userId): $this->getOrFailMeta($userId);
+        return $willCreate ? $this->getOrCreateMeta($userId) : $this->getOrFailMeta($userId);
     }
 
     private function getOrCreateMeta(int $userId)

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -45,7 +45,7 @@ class SpeakersController extends BaseController
 
         $talks        = $speakerDetails->talks()->get()->toArray();
         $templateData = [
-            'speaker'    => new SpeakerProfile($speakerDetails, $this->app->config('reviewer.users')?: []),
+            'speaker'    => new SpeakerProfile($speakerDetails, $this->app->config('reviewer.users') ?: []),
             'talks'      => $talks,
             'photo_path' => '/uploads/',
             'page'       => $req->get('page'),


### PR DESCRIPTION
This PR

* [x] enables the `ternary_operator_spaces` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**ternary_operator_spaces** [`@Symfony`]
>
>Standardize spaces around ternary operator.