### PR TITLE
Enhancement: Enable function_to_constant fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -21,6 +21,7 @@ $config = PhpCsFixer\Config::create()
         'concat_space' => [
             'spacing' => 'one',
         ],
+        'function_to_constant' => true,
         'increment_style' => true,
         'method_separation' => true,
         'no_alias_functions' => true,

--- a/web/index_dev.php
+++ b/web/index_dev.php
@@ -1,7 +1,7 @@
 <?php
 
 $filename = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
-if (php_sapi_name() === 'cli-server' && is_file($filename)) {
+if (PHP_SAPI === 'cli-server' && is_file($filename)) {
     return false;
 }
 


### PR DESCRIPTION
This PR

* [x] enables the `function_to_constant` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**function_to_constant** [`@Symfony:risky`]
>
>Replace core functions calls returning constants with the constants.
>
>Risky rule: risky when any of the configured functions to replace are overridden.
>
>Configuration options:
>
>* `functions` (`array`): list of function names to fix; defaults to `['get_class', 'php_sapi_name', 'phpversion', 'pi']`