### PR TITLE
Enhancement: Enable function_typehint_space fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -22,6 +22,7 @@ $config = PhpCsFixer\Config::create()
             'spacing' => 'one',
         ],
         'function_to_constant' => true,
+        'function_typehint_space' => true,
         'increment_style' => true,
         'is_null' => [
             'use_yoda_style' => false,

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -102,7 +102,7 @@ class TestResponse
         return $this;
     }
 
-    public function assertTargetURLContains(string$targetUrl): self
+    public function assertTargetURLContains(string $targetUrl): self
     {
         Assert::assertInstanceOf(RedirectResponse::class, $this->baseResponse);
         Assert::assertContains($targetUrl, $this->baseResponse->getTargetUrl());


### PR DESCRIPTION
This PR

* [x] enables the `function_typehint_space` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**function_typehint_space** [`@Symfony`]
>
>Add missing space between function's argument and its typehint.