### PR TITLE
Enhancement: Enable unary_operator_spaces fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -55,6 +55,7 @@ $config = PhpCsFixer\Config::create()
         'ternary_operator_spaces' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,
+        'unary_operator_spaces' => true,
         'yoda_style' => [
             'equal' => false,
             'identical' => false,

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -160,7 +160,7 @@ class Application extends SilexApplication
             $this['config'] = $driver->load($config);
         }
 
-        if (! $this['env']->isProduction()) {
+        if (!$this['env']->isProduction()) {
             $this['debug'] = true;
         }
     }
@@ -177,7 +177,7 @@ class Application extends SilexApplication
         $cursor = $this['config'];
 
         foreach (explode('.', $path) as $part) {
-            if (! isset($cursor[$part])) {
+            if (!isset($cursor[$part])) {
                 return null;
             }
 

--- a/classes/Console/BaseCommand.php
+++ b/classes/Console/BaseCommand.php
@@ -65,7 +65,7 @@ abstract class BaseCommand extends Command
             return 1;
         }
 
-        if (! $user->hasAccess(\strtolower($role))) {
+        if (!$user->hasAccess(\strtolower($role))) {
             $io->error(sprintf(
                 'Account with email %s is not in the Reviewer group.',
                 $email

--- a/classes/Domain/CallForProposal.php
+++ b/classes/Domain/CallForProposal.php
@@ -30,7 +30,7 @@ class CallForProposal
      */
     public function isOpen(\DateTimeInterface $currentTime = null): bool
     {
-        if (! $currentTime) {
+        if (!$currentTime) {
             $currentTime = new \DateTimeImmutable('now');
         }
 

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -83,11 +83,11 @@ class User extends Eloquent
         $this->talks()
             ->get()
             ->each(function ($talk) {
-                if (! $talk->delete()) {
+                if (!$talk->delete()) {
                     throw new \Exception('Unable to delete talks of user');
                 }
             });
-        if (! parent::delete()) {
+        if (!parent::delete()) {
             throw new \Exception('Unable to delete User');
         }
 

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -39,7 +39,7 @@ class SpeakerProfile
 
     private function assertAllowedToSee(string $property)
     {
-        if (! $this->isAllowedToSee($property)) {
+        if (!$this->isAllowedToSee($property)) {
             throw NotAllowedException::notAllowedToView($property);
         }
     }

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -28,7 +28,7 @@ class Environment
             self::TYPE_TESTING,
         ];
 
-        if (! in_array($type, $types)) {
+        if (!in_array($type, $types)) {
             throw new \InvalidArgumentException(sprintf(
                 'Environment needs to be one of "%s"; got "%s" instead.',
                 implode('", "', $types),

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -127,7 +127,7 @@ class ForgotController extends BaseController
         $form = $this->service('form.factory')->createBuilder(ResetForm::class)->getForm();
         $form->handleRequest($req);
         
-        if (! $form->isValid()) {
+        if (!$form->isValid()) {
             $form->get('user_id')->setData($user_id);
             $form->get('reset_code')->setData($reset_code);
 
@@ -146,7 +146,7 @@ class ForgotController extends BaseController
             ++$error;
         }
 
-        if (! $user->checkResetPasswordCode($req->get('reset_code'))) {
+        if (!$user->checkResetPasswordCode($req->get('reset_code'))) {
             ++$error;
         }
 
@@ -166,7 +166,7 @@ class ForgotController extends BaseController
         $form = $this->service('form.factory')->createBuilder(ResetForm::class)->getForm();
         $form->handleRequest($req);
         
-        if (! $form->isValid()) {
+        if (!$form->isValid()) {
             return $this->render('user/reset_password.twig', ['form' => $form->createView()]);
         }
 

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -132,7 +132,7 @@ class ProfileController extends BaseController
         $sanitized_data = $form->getCleanData();
         $reset_code     = $user->getResetPasswordCode();
 
-        if (! $user->attemptResetPassword($reset_code, $sanitized_data['password'])) {
+        if (!$user->attemptResetPassword($reset_code, $sanitized_data['password'])) {
             $this->service('session')->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -23,7 +23,7 @@ class SignupController extends BaseController
 
         $cfp = $this->service('callforproposal');
 
-        if (! $cfp->isOpen()) {
+        if (!$cfp->isOpen()) {
             $this->service('session')->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -58,7 +58,7 @@ class TalkController extends BaseController
         $talkId      = (int) $req->get('id');
         // You can only edit talks while the CfP is open
         // This will redirect to "view" the talk in a read-only template
-        if (! $this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforproposal')->isOpen()) {
             $this->service('session')->set(
                 'flash',
                 [
@@ -106,7 +106,7 @@ class TalkController extends BaseController
     public function createAction(Request $req)
     {
         // You can only create talks while the CfP is open
-        if (! $this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforproposal')->isOpen()) {
             $this->service('session')->set(
                 'flash',
                 [
@@ -143,7 +143,7 @@ class TalkController extends BaseController
     public function processCreateAction(Request $req)
     {
         // You can only create talks while the CfP is open
-        if (! $this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforproposal')->isOpen()) {
             $this->service('session')->set(
                 'flash',
                 [
@@ -220,7 +220,7 @@ class TalkController extends BaseController
 
     public function updateAction(Request $req)
     {
-        if (! $this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforproposal')->isOpen()) {
             $this->service('session')->set(
                 'flash',
                 [
@@ -303,7 +303,7 @@ class TalkController extends BaseController
     public function deleteAction(Request $req)
     {
         // You can only delete talks while the CfP is open
-        if (! $this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforproposal')->isOpen()) {
             return $this->app->json(['delete' => 'no']);
         }
 

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -78,7 +78,7 @@ class SentryAuthentication implements Authentication
      */
     public function guest(): bool
     {
-        return ! $this->check();
+        return !$this->check();
     }
 
     /**

--- a/tests/Integration/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Integration/Domain/Speaker/SpeakerProfileTest.php
@@ -33,7 +33,7 @@ class SpeakerProfileTest extends BaseTestCase
     public function testNeedsProfileReturnsCorrectly()
     {
         //if the user needs a profile they haven't made one, hence the !
-        $this->assertSame(! self::$user->has_made_profile, self::$profile->needsProfile());
+        $this->assertSame(!self::$user->has_made_profile, self::$profile->needsProfile());
     }
 
     public function testGetNameReturnsFirstAndLastNameCombined()

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Eloquent\Factory;
 
-if (! function_exists('factory')) {
+if (!function_exists('factory')) {
     /**
      * Create a model factory builder for a given class, name, and amount.
      *


### PR DESCRIPTION
This PR

* [x] enables the `unary_operator_spaces` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**unary_operator_spaces** [`@Symfony`]
>
>Unary operators should be placed adjacent to their operands.