### PR TITLE
Enhancement: Enable no_useless_return fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -35,6 +35,7 @@ $config = PhpCsFixer\Config::create()
         'no_trailing_comma_in_singleline_array' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
+        'no_useless_return' => true,
         'ordered_imports' => true,
         'phpdoc_align' => true,
         'phpdoc_indent' => true,

--- a/classes/Infrastructure/OAuth/AccessTokenStorage.php
+++ b/classes/Infrastructure/OAuth/AccessTokenStorage.php
@@ -26,8 +26,6 @@ class AccessTokenStorage extends AbstractStorage implements AccessTokenInterface
 
             return $token;
         }
-
-        return;
     }
 
     /**

--- a/classes/Infrastructure/OAuth/AuthCodeStorage.php
+++ b/classes/Infrastructure/OAuth/AuthCodeStorage.php
@@ -28,8 +28,6 @@ class AuthCodeStorage extends AbstractStorage implements AuthCodeInterface
 
             return $token;
         }
-
-        return;
     }
 
     public function create($token, $expireTime, $sessionId, $redirectUri)

--- a/classes/Infrastructure/OAuth/ClientStorage.php
+++ b/classes/Infrastructure/OAuth/ClientStorage.php
@@ -47,8 +47,6 @@ class ClientStorage extends AbstractStorage implements ClientInterface
 
             return $client;
         }
-
-        return;
     }
 
     /**
@@ -71,7 +69,5 @@ class ClientStorage extends AbstractStorage implements ClientInterface
 
             return $client;
         }
-
-        return;
     }
 }

--- a/classes/Infrastructure/OAuth/RefreshTokenStorage.php
+++ b/classes/Infrastructure/OAuth/RefreshTokenStorage.php
@@ -26,8 +26,6 @@ class RefreshTokenStorage extends AbstractStorage implements RefreshTokenInterfa
 
             return $token;
         }
-
-        return;
     }
 
     /**

--- a/classes/Infrastructure/OAuth/SessionStorage.php
+++ b/classes/Infrastructure/OAuth/SessionStorage.php
@@ -30,8 +30,6 @@ class SessionStorage extends AbstractStorage implements SessionInterface
 
             return $session;
         }
-
-        return;
     }
 
     /**
@@ -52,8 +50,6 @@ class SessionStorage extends AbstractStorage implements SessionInterface
 
             return $session;
         }
-
-        return;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] enables the `no_useless_return` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**no_useless_return**
>
>There should not be an empty return statement at the end of a function.