### PR TITLE
Enhancement: Enable no_singleline_whitespace_before_semicolons fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -32,6 +32,7 @@ $config = PhpCsFixer\Config::create()
         'no_empty_phpdoc' => true,
         'no_extra_consecutive_blank_lines' => true,
         'no_multiline_whitespace_before_semicolons' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -44,7 +44,7 @@ class ProfileController extends BaseController
             'buttonInfo'     => 'Update Profile',
         ];
 
-        return $this->render('user/edit.twig', $form_data) ;
+        return $this->render('user/edit.twig', $form_data);
     }
 
     public function processAction(Request $req)


### PR DESCRIPTION
This PR

* [x] enables the `no_singleline_whitespace_before_semicolons` fixer
* [ ] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**no_singleline_whitespace_before_semicolons** [`@Symfony`]
>
>Single-line whitespace before closing semicolon are prohibited.