### PR TITLE
Fix faulty coversNothing

### DIFF
--- a/tests/Unit/Http/API/TalkApiControllerTest.php
+++ b/tests/Unit/Http/API/TalkApiControllerTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @coversNothing \OpenCFP\Http\API\TalkController
+ * @covers \OpenCFP\Http\API\TalkController
  */
 class TalkApiControllerTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] Changes an ```@coversNothing``` to ```@covers``` 