### PR TITLE
CSRF additions

### DIFF
--- a/resources/views/admin/speaker/index.twig
+++ b/resources/views/admin/speaker/index.twig
@@ -37,16 +37,16 @@
             </div>
             <div>
                 {% if speaker.is_admin == false %}
-                    <a class="text-sm text-brand underline mr-3" href="{{ url('admin_speaker_promote', { id: speaker.id ,role: 'Admin'}) }}" onClick="return confirm('Are you sure you want promote this user as an admin?');">Promote To Admin</a>
+                    <a class="text-sm text-brand underline mr-3" href="{{ url('admin_speaker_promote', { id: speaker.id ,role: 'Admin', token: csrf_token('admin_speaker_promote')}) }}" onClick="return confirm('Are you sure you want promote this user as an admin?');">Promote To Admin</a>
                 {% else %}
-                    <a class="text-sm text-brand underline mr-3" href="{{ url('admin_speaker_demote', { id: speaker.id ,role: 'Admin' }) }}" onClick="return confirm('Are you sure you want demote this admin?');">Demote Admin</a>
+                    <a class="text-sm text-brand underline mr-3" href="{{ url('admin_speaker_demote', { id: speaker.id ,role: 'Admin', token: csrf_token('admin_speaker_demote') }) }}" onClick="return confirm('Are you sure you want demote this admin?');">Demote Admin</a>
                 {% endif %}
                 {% if speaker.is_reviewer == false %}
-                    <a class="text-sm text-brand underline mr-3" href="{{ url('admin_speaker_promote', { id: speaker.id ,role: 'Reviewer'}) }}" onClick="return confirm('Are you sure you want promote this user as a reviewer?');">Promote To Reviewer</a>
+                    <a class="text-sm text-brand underline mr-3" href="{{ url('admin_speaker_promote', { id: speaker.id ,role: 'Reviewer', token: csrf_token('admin_speaker_promote')}) }}" onClick="return confirm('Are you sure you want promote this user as a reviewer?');">Promote To Reviewer</a>
                 {% else %}
-                    <a class="text-sm text-brand underline mr-3" href="{{ url('admin_speaker_demote', { id: speaker.id ,role: 'Reviewer' }) }}" onClick="return confirm('Are you sure you want demote this reviewer?');">Demote Reviewer</a>
+                    <a class="text-sm text-brand underline mr-3" href="{{ url('admin_speaker_demote', { id: speaker.id ,role: 'Reviewer', token: csrf_token('admin_speaker_demote') }) }}" onClick="return confirm('Are you sure you want demote this reviewer?');">Demote Reviewer</a>
                 {% endif %}
-                <a class="text-sm text-brand underline" href="{{ url('admin_speaker_delete', { id: speaker.id }) }}" onClick="return confirm('Are you sure you want to delete this user');">Delete</a>
+                <a class="text-sm text-brand underline" href="{{ url('admin_speaker_delete', { id: speaker.id, token: csrf_token('admin_speaker_delete') }) }}" onClick="return confirm('Are you sure you want to delete this user');">Delete</a>
             </div>
         </div>
     {% endfor %}

--- a/resources/views/dashboard.twig
+++ b/resources/views/dashboard.twig
@@ -6,7 +6,7 @@ function deleteTalk(tid) {
     $.ajax({
         type: "POST",
         url: "/talk/delete",
-        data: "tid=" + tid + "&user_id=" + {{ user.id }},
+        data: "tid=" + tid + "&user_id=" + {{ user.id }} + "&token={{ csrf_token('delete_talk') }}",
         success: function(data, textStatus, jqXHR) {
             if (data.delete == 'ok') {
                 $("#talk-"+tid).remove();
@@ -73,11 +73,11 @@ function deleteTalk(tid) {
                     </div>
                     <div>
                         {% if cfp_open %}
-                            <a href="{{ url('talk_edit', { id: talk.id }) }}" class="underline text-sm text-brand">Edit</a>
+                            <a href="{{ url('talk_edit', { id: talk.id, token: csrf_token('edit_talk') }) }}" class="underline text-sm text-brand">Edit</a>
                         {% else %}
                             <a href="{{ url('talk_view', { id: talk.id }) }}" class="underline text-sm text-brand">View</a>
                         {% endif %}
-                        <a href="#" onClick="deleteTalk('{{ talk.id }}');return false;" class="ml-2 underline text-sm text-brand">Delete</a>
+                        <a href="#" onClick="deleteTalk('{{ talk.id }}', '{{ csrf_token('delete_talk') }}');return false;" class="ml-2 underline text-sm text-brand">Delete</a>
                     </div>
                 </div>
             {% endfor %}

--- a/resources/views/forms/_talk.twig
+++ b/resources/views/forms/_talk.twig
@@ -1,5 +1,6 @@
 {% include "_flash.twig" %}
 <form action="{{ formAction }}" method="POST" class="form-horizontal">
+    <input type="hidden" name="_token" value="{{ csrf_token("speaker_talk") }}">
     {% if id is defined %}
         <input name="id" type="hidden" value="{{ id }}">
     {% endif %}

--- a/resources/views/layouts/default.twig
+++ b/resources/views/layouts/default.twig
@@ -4,6 +4,8 @@
         <title>{% block title %}{{ site.title }}{% endblock %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="/assets/css/app.css" rel="stylesheet" media="screen">
+        <script src="https://use.fontawesome.com/82adfc9f97.js"></script>
+
     </head>
     <body class="border-t-4 border-brand">
         <nav class="{% if not active('homepage') %}border-b border-white{% endif %}">

--- a/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
@@ -188,4 +188,15 @@ class SpeakersControllerTest extends WebTestCase
             ->assertRedirect()
             ->assertTargetURLContains('/admin/speakers');
     }
+
+    /**
+     * @test
+     */
+    public function deleteActionFailsWithBadToken()
+    {
+        $this->asAdmin(self::$users->first()->id)
+            ->get('/admin/speakers/delete/' . self::$users->last()->id . '?token=' . uniqid())
+            ->assertRedirect()
+            ->assertTargetURLContains('/admin/speakers');
+    }
 }

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -156,6 +156,17 @@ class TalkControllerTest extends WebTestCase
     /**
      * @test
      */
+    public function cannotEditTalkWithBadToken()
+    {
+        $this->asLoggedInSpeaker(self::$user->id)
+            ->get('/talk/edit/' . self::$talk->id . '?token=' . uniqid())
+            ->assertRedirect()
+            ->assertTargetURLContains('/dashboard');
+    }
+
+    /**
+     * @test
+     */
     public function notAllowedToDeleteAfterCFPIsOver()
     {
         $this->asLoggedInSpeaker(self::$user->id)


### PR DESCRIPTION
This PR

* [x] fixes some CSRF vulnerabilities

A helpful security audit from @enygma revealed a few spots where our forms and some GET actions with side effects were not protected using CSRF tokens. This PR fixes those spots and also adds CSRF protection to talk creation.