### PR TITLE
Make the path for background configurable

### DIFF
--- a/config/development.dist.yml
+++ b/config/development.dist.yml
@@ -14,6 +14,7 @@ application:
   date_format: d/m/Y
   date_timezone: "UTC"
   coc_link: http://confcodeofconduct.com/
+  venue_image_path: /assets/img/venue.jpg
 
 api:
   enabled: true

--- a/config/production.dist.yml
+++ b/config/production.dist.yml
@@ -14,6 +14,7 @@ application:
   date_format: d/m/Y
   date_timezone: "UTC"
   coc_link: http://confcodeofconduct.com/
+  venue_image_path: /assets/img/venue.jpg
 
 api:
   enabled: true

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -13,6 +13,7 @@ application:
   online_conference: false
   date_format: m-d-Y
   coc_link: http://confcodeofconduct.com
+  venue_image_path: /assets/img/venue.jpg
 
 
 api:

--- a/resources/views/home.twig
+++ b/resources/views/home.twig
@@ -1,7 +1,7 @@
 {% extends "layouts/default.twig" %}
 
 {% block header %}
-    <header id="hero" class="bg-cover p-24" style="background:linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url(/assets/img/venue.jpg) no-repeat center -300px fixed;">
+    <header id="hero" class="bg-cover p-24" style="background:linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url({{ app.config.application.venue_image_path }}) no-repeat center -300px fixed;">
         <div class="container mx-auto flex">
             <div class="p-8 bg-brand text-white">
                 {% if cfp_open %}

--- a/resources/views/layouts/splash.twig
+++ b/resources/views/layouts/splash.twig
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="/assets/css/app.css" rel="stylesheet" media="screen">
     </head>
-    <body class="h-full border-t-4 border-brand bg-cover flex items-center justify-center" style="background:linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(/assets/img/venue.jpg) no-repeat center center fixed;">
+    <body class="h-full border-t-4 border-brand bg-cover flex items-center justify-center" style="background:linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url({{ app.config.application.venue_image_path }}) no-repeat center center fixed;">
 
         {% block content %}
         {% endblock %}


### PR DESCRIPTION
This PR

* [x] Allows a user to change the path used for the homepage hero section as well as the login / signup splash screens.

![cats](https://user-images.githubusercontent.com/2453394/33226933-7fca6d7c-d166-11e7-8439-8ea1ba3b2a6a.PNG)
