### PR TITLE
Enhancement: Add asset target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-.PHONY: composer coverage cs database infection integration it test unit
+.PHONY: asset composer coverage cs database infection integration it test unit
 
 it: cs test
+
+asset:
+	yarn install
+	yarn run production
 
 composer:
 	composer install


### PR DESCRIPTION
This PR

* [x] adds an `asset` target to `Makefile`

Somewhat related to https://github.com/opencfp/opencfp/pull/705#discussion_r153040895.