### PR TITLE
Enhancement: Enable new_with_braces fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -28,6 +28,7 @@ return PhpCsFixer\Config::create()
             'use_yoda_style' => false,
         ],
         'method_separation' => true,
+        'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_empty_phpdoc' => true,

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -57,26 +57,26 @@ class Application extends SilexApplication
         }
 
         // Register Gateways...
-        $this->register(new WebGatewayProvider);
-        $this->register(new ApiGatewayProvider);
-        $this->register(new OAuthGatewayProvider);
+        $this->register(new WebGatewayProvider());
+        $this->register(new ApiGatewayProvider());
+        $this->register(new OAuthGatewayProvider());
 
         // Services...
-        $this->register(new SessionServiceProvider);
-        $this->register(new FormServiceProvider);
-        $this->register(new CsrfServiceProvider);
-        $this->register(new ControllerResolverServiceProvider);
-        $this->register(new ValidatorServiceProvider);
-        $this->register(new LocaleServiceProvider);
-        $this->register(new TranslationServiceProvider);
-        $this->register(new MonologServiceProvider, [
+        $this->register(new SessionServiceProvider());
+        $this->register(new FormServiceProvider());
+        $this->register(new CsrfServiceProvider());
+        $this->register(new ControllerResolverServiceProvider());
+        $this->register(new ValidatorServiceProvider());
+        $this->register(new LocaleServiceProvider());
+        $this->register(new TranslationServiceProvider());
+        $this->register(new MonologServiceProvider(), [
             'monolog.logfile' => $this->config('log.path') ?: "{$basePath}/log/app.log",
             'monolog.name'    => 'opencfp',
             'monlog.level'    => strtoupper(
                 $this->config('log.level') ?: 'debug'
             ),
         ]);
-        $this->register(new SwiftmailerServiceProvider, [
+        $this->register(new SwiftmailerServiceProvider(), [
             'swiftmailer.options' => [
                 'host'       => $this->config('mail.host'),
                 'port'       => $this->config('mail.port'),
@@ -88,11 +88,11 @@ class Application extends SilexApplication
         ]);
 
         $this->register(new CallForProposalProvider());
-        $this->register(new SentryServiceProvider);
+        $this->register(new SentryServiceProvider());
         $app = $this;
         $this->register(new TwigServiceProvider($app));
-        $this->register(new HtmlPurifierServiceProvider);
-        $this->register(new ImageProcessorProvider);
+        $this->register(new HtmlPurifierServiceProvider());
+        $this->register(new ImageProcessorProvider());
         $this->register(new ResetEmailerServiceProvider());
         $this->register(new TalkHandlerProvider());
         $this->register(new TalkHelperProvider());
@@ -100,7 +100,7 @@ class Application extends SilexApplication
         $this->register(new TalkFilterProvider());
 
         // Application Services...
-        $this->register(new ApplicationServiceProvider);
+        $this->register(new ApplicationServiceProvider());
 
         $this->setUpDataBaseConnection();
         $this->registerGlobalErrorHandler();

--- a/classes/Application/Speakers.php
+++ b/classes/Application/Speakers.php
@@ -71,12 +71,12 @@ class Speakers
 
         // If it can't grab by relation, it's likely not their talk.
         if (!$talk instanceof Talk) {
-            throw new NotAuthorizedException;
+            throw new NotAuthorizedException();
         }
 
         // Do an explicit check of ownership because why not.
         if ((int) $talk->user_id !== (int) $speaker->id) {
-            throw new NotAuthorizedException;
+            throw new NotAuthorizedException();
         }
 
         return $talk;

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -39,14 +39,14 @@ class Application extends ConsoleApplication
     public function getDefaultCommands()
     {
         return [
-            new HelpCommand,
-            new ListCommand,
-            new AdminPromoteCommand,
-            new AdminDemoteCommand,
-            new ReviewerPromoteCommand,
-            new ReviewerDemoteCommand,
-            new UserCreateCommand,
-            new ClearCacheCommand,
+            new HelpCommand(),
+            new ListCommand(),
+            new AdminPromoteCommand(),
+            new AdminDemoteCommand(),
+            new ReviewerPromoteCommand(),
+            new ReviewerDemoteCommand(),
+            new UserCreateCommand(),
+            new ClearCacheCommand(),
         ];
     }
 

--- a/classes/Domain/Services/TalkRating/TalkRatingContext.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingContext.php
@@ -12,9 +12,9 @@ class TalkRatingContext
         $strategy = strtolower($strategy);
         switch ($strategy) {
             case 'yesno':
-                return new YesNoRating(new TalkMeta, $auth);
+                return new YesNoRating(new TalkMeta(), $auth);
             default:
-                return new YesNoRating(new TalkMeta, $auth);
+                return new YesNoRating(new TalkMeta(), $auth);
         }
     }
 }

--- a/classes/Http/OAuth/AuthorizationController.php
+++ b/classes/Http/OAuth/AuthorizationController.php
@@ -88,7 +88,7 @@ class AuthorizationController extends ApiController
             return $this->setStatusCode(Response::HTTP_FOUND)->respond('', ['Location' => $redirectUri]);
         }
 
-        $error = new AccessDeniedException;
+        $error = new AccessDeniedException();
 
         $redirectUri = RedirectUri::make($authParams['redirect_uri'], [
             'error'   => $error->errorType,

--- a/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
@@ -33,7 +33,7 @@ class IlluminateSpeakerRepository implements SpeakerRepository
         try {
             $speaker = $this->userModel->findOrFail($speakerId);
         } catch (ModelNotFoundException $e) {
-            throw new EntityNotFoundException;
+            throw new EntityNotFoundException();
         }
 
         return $speaker;

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -48,7 +48,7 @@ class ApplicationServiceProvider implements ServiceProviderInterface
         };
 
         $app[Capsule::class] = function ($app) {
-            $capsule = new Capsule;
+            $capsule = new Capsule();
 
             $capsule->addConnection([
                 'driver'    => 'mysql',
@@ -80,7 +80,7 @@ class ApplicationServiceProvider implements ServiceProviderInterface
         };
 
         $app[AirportInformationDatabase::class] = function ($app) {
-            return new Airport;
+            return new Airport();
         };
 
         $app['security.random'] = function () {

--- a/classes/Provider/Gateways/OAuthGatewayProvider.php
+++ b/classes/Provider/Gateways/OAuthGatewayProvider.php
@@ -25,8 +25,8 @@ class OAuthGatewayProvider implements ServiceProviderInterface, BootableProvider
             $server->setScopeStorage(new ScopeStorage());
             $server->setAuthCodeStorage(new AuthCodeStorage());
 
-            $server->addGrantType(new AuthCodeGrant);
-            $server->addGrantType(new RefreshTokenGrant);
+            $server->addGrantType(new AuthCodeGrant());
+            $server->addGrantType(new RefreshTokenGrant());
 
             /* @var Locator $spot */
             $spot = $app['spot'];

--- a/classes/Provider/SentryServiceProvider.php
+++ b/classes/Provider/SentryServiceProvider.php
@@ -14,9 +14,9 @@ class SentryServiceProvider implements ServiceProviderInterface
     public function register(Container $app)
     {
         $app['sentry'] = function ($app) {
-            $hasher           = new \Cartalyst\Sentry\Hashing\NativeHasher;
+            $hasher           = new \Cartalyst\Sentry\Hashing\NativeHasher();
             $userProvider     = new \Cartalyst\Sentry\Users\Eloquent\Provider($hasher);
-            $groupProvider    = new \Cartalyst\Sentry\Groups\Eloquent\Provider;
+            $groupProvider    = new \Cartalyst\Sentry\Groups\Eloquent\Provider();
             $throttleProvider = new \Cartalyst\Sentry\Throttling\Eloquent\Provider($userProvider);
             $session          = new SymfonySentrySession($app['session']);
             $cookie           = new \Cartalyst\Sentry\Cookies\NativeCookie([]);

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -27,7 +27,7 @@ class TwigServiceProvider implements ServiceProviderInterface
      */
     public function register(Container $c)
     {
-        $c->register(new SilexTwigServiceProvider, [
+        $c->register(new SilexTwigServiceProvider(), [
             'twig.path'    => $this->app['path']->templatesPath(),
             'twig.options' => [
                 'debug' => !$this->app['env']->isProduction(),
@@ -37,7 +37,7 @@ class TwigServiceProvider implements ServiceProviderInterface
 
         $c->extend('twig', function (Twig_Environment $twig, Application $app) {
             if (!$app['env']->isProduction()) {
-                $twig->addExtension(new Twig_Extension_Debug);
+                $twig->addExtension(new Twig_Extension_Debug());
             }
 
             $twig->addFunction(new Twig_SimpleFunction('uploads', function ($path) {

--- a/tests/Helper/SentryTestHelpers.php
+++ b/tests/Helper/SentryTestHelpers.php
@@ -10,9 +10,9 @@ trait SentryTestHelpers
 {
     public function getSentry(): \Cartalyst\Sentry\Sentry
     {
-        $hasher           = new \Cartalyst\Sentry\Hashing\NativeHasher;
+        $hasher           = new \Cartalyst\Sentry\Hashing\NativeHasher();
         $userProvider     = new \Cartalyst\Sentry\Users\Eloquent\Provider($hasher);
-        $groupProvider    = new \Cartalyst\Sentry\Groups\Eloquent\Provider;
+        $groupProvider    = new \Cartalyst\Sentry\Groups\Eloquent\Provider();
         $throttleProvider = new \Cartalyst\Sentry\Throttling\Eloquent\Provider($userProvider);
         $session          = new SymfonySentrySession(new Session(new MockFileSessionStorage()));
         $cookie           = new \Cartalyst\Sentry\Cookies\NativeCookie([]);

--- a/tests/Integration/Domain/Model/AirportTest.php
+++ b/tests/Integration/Domain/Model/AirportTest.php
@@ -45,6 +45,6 @@ class AirportTest extends BaseTestCase
 
     private function getAirport(): Airport
     {
-        return new Airport;
+        return new Airport();
     }
 }

--- a/tests/Integration/Domain/Services/TalkFormatterTest.php
+++ b/tests/Integration/Domain/Services/TalkFormatterTest.php
@@ -28,7 +28,7 @@ class TalkFormatterTest extends BaseTestCase
      */
     public function createFormattedOutputWorksWithNoMeta()
     {
-        $talk      = new Talk;
+        $talk      = new Talk();
         $formatter = new TalkFormatter();
 
         $format =$formatter->createdFormattedOutput($talk->first(), 1);
@@ -45,7 +45,7 @@ class TalkFormatterTest extends BaseTestCase
     public function createFormattedOutputWorksWithMeta()
     {
         $formatter = new TalkFormatter();
-        $talk      = new Talk;
+        $talk      = new Talk();
 
         // Now to see if the meta gets put in correctly
         $secondFormat =$formatter->createdFormattedOutput($talk->first(), 2);

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -93,7 +93,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
          * add it to our Application mock
          */
         $sentry = Mockery::mock(\Cartalyst\Sentry\Sentry::class);
-        $sentry->shouldReceive('getUserProvider->findByLogin')->andThrow(new \Cartalyst\Sentry\Users\UserNotFoundException);
+        $sentry->shouldReceive('getUserProvider->findByLogin')->andThrow(new \Cartalyst\Sentry\Users\UserNotFoundException());
         $app           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
         $app['sentry'] = $sentry;
 

--- a/tests/Unit/Console/Command/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/AdminPromoteCommandTest.php
@@ -26,7 +26,7 @@ class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
         $output = $this->createOutputInterface();
 
         $accounts = Mockery::mock(AccountManagement::class);
-        $accounts->shouldReceive('findByLogin')->andThrow(new \Cartalyst\Sentry\Users\UserNotFoundException);
+        $accounts->shouldReceive('findByLogin')->andThrow(new \Cartalyst\Sentry\Users\UserNotFoundException());
         $app                           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
         $app[AccountManagement::class] = $accounts;
 


### PR DESCRIPTION
This PR

* [x] enables the `new_with_braces` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**new_with_braces** [`@Symfony`]
>
>All instances created with new keyword must be followed by braces.