### PR TITLE
Enhancement: Enable no_blank_lines_after_class_opening fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -29,6 +29,7 @@ return PhpCsFixer\Config::create()
         ],
         'method_separation' => true,
         'no_alias_functions' => true,
+        'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_empty_phpdoc' => true,
         'no_extra_consecutive_blank_lines' => true,

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -9,7 +9,6 @@ use OpenCFP\Domain\Services\NotAuthenticatedException;
 
 class SentryAuthentication implements Authentication
 {
-
     /**
      * @var Sentry
      */


### PR DESCRIPTION
This PR

* [x] enables the `no_blank_lines_after_class_opening` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**no_blank_lines_after_class_opening** [`@Symfony`]
>
>There should be no empty lines after class opening brace.