### PR TITLE
Enhancement: Enable no_superfluous_elseif fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -34,6 +34,7 @@ return PhpCsFixer\Config::create()
         'no_extra_consecutive_blank_lines' => true,
         'no_multiline_whitespace_before_semicolons' => true,
         'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -19,7 +19,8 @@ if (!function_exists('factory')) {
         $arguments = func_get_args();
         if (isset($arguments[1]) && is_string($arguments[1])) {
             return $factory->of($arguments[0], $arguments[1])->times($arguments[2] ?? null);
-        } elseif (isset($arguments[1])) {
+        }
+        if (isset($arguments[1])) {
             return $factory->of($arguments[0])->times($arguments[1]);
         }
 


### PR DESCRIPTION
This PR

* [x] enables the `no_superfluous_elseif` fixer
* [ ] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**no_superfluous_elseif**
>
>Replaces superfluous `elseif` with `if`.