### PR TITLE
Fix: Mark ContainerAware trait as deprecated

### DIFF
--- a/classes/ContainerAware.php
+++ b/classes/ContainerAware.php
@@ -2,6 +2,10 @@
 
 namespace OpenCFP;
 
+/**
+ * @deprecated
+ * @link https://qafoo.com/blog/057_containeraware_considered_harmful.html
+ */
 trait ContainerAware
 {
     /**
@@ -9,11 +13,23 @@ trait ContainerAware
      */
     protected $app;
 
+    /**
+     * @deprecated https://qafoo.com/blog/057_containeraware_considered_harmful.html
+     *
+     * @param Application $application
+     */
     public function setApplication(Application $application)
     {
         $this->app = $application;
     }
 
+    /**
+     * @deprecated
+     *
+     * @param string $slug
+     *
+     * @return mixed
+     */
     protected function service($slug)
     {
         return $this->app[$slug];


### PR DESCRIPTION
This PR

* [x] marks the `ContainerAware` trait as deprecated

Somewhat related to #618.

💁‍♂️ In order to be able to properly test components currently using it, they should stop using it and have their dependencies injected. Marking the trait as `@deprecated` is a first step into that direction.

