### PR TITLE
Enhancement: Decouple UserCreateCommand from application container

### DIFF
--- a/bin/opencfp
+++ b/bin/opencfp
@@ -9,6 +9,8 @@ use OpenCFP\Environment;
 use OpenCFP\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use OpenCFP\Application as ApplicationContainer;
+use OpenCFP\Console\Command;
+use OpenCFP\Domain\Services;
 
 $basePath = realpath(dirname(__DIR__));
 $input = new ArgvInput();
@@ -16,6 +18,10 @@ $environment = $input->getParameterOption(array('--env'), getenv('CFP_ENV') ?: '
 
 $container = new ApplicationContainer($basePath, Environment::fromString($environment));
 $app = new Application($container);
+
+$app->addCommands([
+    new Command\UserCreateCommand($container[Services\AccountManagement::class]),
+]);
 $status = $app->run($input);
 
 exit($status);

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -8,7 +8,6 @@ use OpenCFP\Console\Command\AdminPromoteCommand;
 use OpenCFP\Console\Command\ClearCacheCommand;
 use OpenCFP\Console\Command\ReviewerDemoteCommand;
 use OpenCFP\Console\Command\ReviewerPromoteCommand;
-use OpenCFP\Console\Command\UserCreateCommand;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
@@ -45,7 +44,6 @@ class Application extends ConsoleApplication
             new AdminDemoteCommand(),
             new ReviewerPromoteCommand(),
             new ReviewerDemoteCommand(),
-            new UserCreateCommand(),
             new ClearCacheCommand(),
         ];
     }

--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -2,20 +2,32 @@
 
 namespace OpenCFP\Console\Command;
 
-use Cartalyst\Sentry\Users\UserExistsException;
-use OpenCFP\Console\BaseCommand;
-use OpenCFP\Domain\Services\AccountManagement;
+use Cartalyst\Sentry;
+use OpenCFP\Domain\Services;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class UserCreateCommand extends BaseCommand
+final class UserCreateCommand extends Command
 {
+    /**
+     * @var Services\AccountManagement
+     */
+    private $accountManagement;
+
+    public function __construct(Services\AccountManagement $accountManagement)
+    {
+        parent::__construct('user:create');
+
+        $this->accountManagement = $accountManagement;
+    }
+
     protected function configure()
     {
         $this
-            ->setName('user:create')
+            ->setDescription('Creates a new user')
             ->setDefinition([
                 new InputOption('first_name', 'f', InputOption::VALUE_REQUIRED, 'First Name of the user to create', null),
                 new InputOption('last_name', 'l', InputOption::VALUE_REQUIRED, 'Last Name of the user to create', null),
@@ -23,8 +35,7 @@ class UserCreateCommand extends BaseCommand
                 new InputOption('password', 'p', InputOption::VALUE_REQUIRED, 'Password of the user to create', null),
                 new InputOption('admin', 'a', InputOption::VALUE_NONE, 'Promote to administrator', null),
                 new InputOption('reviewer', 'r', InputOption::VALUE_NONE, 'Promote to reviewer', null),
-            ])
-            ->setDescription('Creates a new user');
+            ]);
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -38,70 +49,63 @@ class UserCreateCommand extends BaseCommand
 
         $io->section('Creating User');
 
-        $user = $this->createUser([
+        $data = [
             'first_name' => $input->getOption('first_name'),
             'last_name'  => $input->getOption('last_name'),
-            'password'   => $input->getOption('password'),
             'email'      => $input->getOption('email'),
-        ]);
+            'password'   => $input->getOption('password'),
+        ];
 
-        if ($user == false) {
-            $io->error('User Already Exists!');
+        try {
+            $user = $this->accountManagement->create(
+                $data['email'],
+                $data['password'],
+                $data
+            );
+        } catch (Sentry\Users\UserExistsException $exception) {
+            $io->error(sprintf(
+                'A user with the login "%s" already exists.',
+                $data['email']
+            ));
 
             return 1;
         }
 
-        $io->block('Account was created');
+        $io->writeln(sprintf(
+            ' * created user with login <info>%s</info>',
+            $data['email']
+        ));
+
+        $this->accountManagement->activate($data['email']);
+
+        $roles = [];
 
         if ($input->getOption('admin')) {
-            $io->block('Promoting to admin.');
-            $this->promoteTo($user);
+            $roles[] = 'admin';
         }
+
         if ($input->getOption('reviewer')) {
-            $io->block('Promoting to reviewer.');
-            $this->promoteTo($user, 'Reviewer');
+            $roles[] = 'reviewer';
         }
 
-        $io->success('User Created!');
-    }
+        if (count($roles)) {
+            foreach ($roles as $role) {
+                if ($user->hasAccess($role)) {
+                    continue;
+                }
 
-    private function createUser($data)
-    {
-        try {
-            $user_data = [
-                'first_name' => $data['first_name'],
-                'last_name'  => $data['last_name'],
-                'email'      => $data['email'],
-                'password'   => $data['password'],
-            ];
+                $this->accountManagement->promoteTo(
+                    $user->getLogin(),
+                    $role
+                );
 
-            /** @var AccountManagement $accounts */
-            $accounts = $this->app[AccountManagement::class];
-
-            $user = $accounts->create($data['email'], $data['password'], $user_data);
-            $accounts->activate($user->getLogin());
-
-            return $user;
-        } catch (UserExistsException $e) {
-            return false;
-        }
-    }
-
-    private function promoteTo($user, $role = 'Admin')
-    {
-        if ($user->hasAccess(\strtolower($role))) {
-            $io->error(sprintf(
-                'Account with email %s already is in the Admin group.',
-                $email
-            ));
-
-            return false;
+                $io->writeln(sprintf(
+                    ' * promoted user to <info>%s</info>',
+                    $role
+                ));
+            }
         }
 
-        /** @var AccountManagement $accounts */
-        $accounts = $this->app[AccountManagement::class];
-        $accounts->promoteTo($user->getLogin(), $role);
-
-        return true;
+        $io->success('User Created');
     }
 }

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -68,7 +68,6 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
             Command\AdminPromoteCommand::class,
             Command\ReviewerPromoteCommand::class,
             Command\ReviewerDemoteCommand::class,
-            Command\UserCreateCommand::class,
             Command\ClearCacheCommand::class,
         ];
 

--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -1,0 +1,372 @@
+<?php
+
+namespace OpenCFP\Test\Unit\Console\Command;
+
+use Cartalyst\Sentry;
+use OpenCFP\Console\Command\UserCreateCommand;
+use OpenCFP\Domain\Services;
+use OpenCFP\Infrastructure\Auth;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+
+/**
+ * @covers \OpenCFP\Console\Command\UserCreateCommand
+ */
+final class UserCreateCommandTest extends Framework\TestCase
+{
+    use GeneratorTrait;
+
+    public function testIsFinal()
+    {
+        $reflection = new \ReflectionClass(UserCreateCommand::class);
+
+        $this->assertTrue($reflection->isFinal());
+    }
+
+    public function testExtendsCommand()
+    {
+        $command = new UserCreateCommand($this->createAccountManagementMock());
+
+        $this->assertInstanceOf(Console\Command\Command::class, $command);
+    }
+
+    public function testHasNameAndDescription()
+    {
+        $command = new UserCreateCommand($this->createAccountManagementMock());
+
+        $this->assertSame('user:create', $command->getName());
+        $this->assertSame('Creates a new user', $command->getDescription());
+    }
+
+    public function testHasFirstNameOption()
+    {
+        $command = new UserCreateCommand($this->createAccountManagementMock());
+
+        $inputDefinition = $command->getDefinition();
+
+        $this->assertTrue($inputDefinition->hasOption('first_name'));
+
+        $option = $inputDefinition->getOption('first_name');
+
+        $this->assertSame('f', $option->getShortcut());
+        $this->assertSame('First Name of the user to create', $option->getDescription());
+        $this->assertTrue($option->isValueRequired());
+        $this->assertNull($option->getDefault());
+        $this->assertFalse($option->isArray());
+    }
+
+    public function testHasLastNameOption()
+    {
+        $command = new UserCreateCommand($this->createAccountManagementMock());
+
+        $inputDefinition = $command->getDefinition();
+
+        $this->assertTrue($inputDefinition->hasOption('last_name'));
+
+        $option = $inputDefinition->getOption('last_name');
+
+        $this->assertSame('l', $option->getShortcut());
+        $this->assertSame('Last Name of the user to create', $option->getDescription());
+        $this->assertTrue($option->isValueRequired());
+        $this->assertNull($option->getDefault());
+        $this->assertFalse($option->isArray());
+    }
+
+    public function testHasEmailOption()
+    {
+        $command = new UserCreateCommand($this->createAccountManagementMock());
+
+        $inputDefinition = $command->getDefinition();
+
+        $this->assertTrue($inputDefinition->hasOption('email'));
+
+        $option = $inputDefinition->getOption('email');
+
+        $this->assertSame('e', $option->getShortcut());
+        $this->assertSame('Email of the user to create', $option->getDescription());
+        $this->assertTrue($option->isValueRequired());
+        $this->assertNull($option->getDefault());
+        $this->assertFalse($option->isArray());
+    }
+
+    public function testHasPasswordOption()
+    {
+        $command = new UserCreateCommand($this->createAccountManagementMock());
+
+        $inputDefinition = $command->getDefinition();
+
+        $this->assertTrue($inputDefinition->hasOption('password'));
+
+        $option = $inputDefinition->getOption('password');
+
+        $this->assertSame('p', $option->getShortcut());
+        $this->assertSame('Password of the user to create', $option->getDescription());
+        $this->assertTrue($option->isValueRequired());
+        $this->assertNull($option->getDefault());
+        $this->assertFalse($option->isArray());
+    }
+
+    public function testHasAdminOption()
+    {
+        $command = new UserCreateCommand($this->createAccountManagementMock());
+
+        $inputDefinition = $command->getDefinition();
+
+        $this->assertTrue($inputDefinition->hasOption('admin'));
+
+        $option = $inputDefinition->getOption('admin');
+
+        $this->assertSame('a', $option->getShortcut());
+        $this->assertSame('Promote to administrator', $option->getDescription());
+        $this->assertFalse($option->isValueRequired());
+        $this->assertFalse($option->getDefault());
+        $this->assertFalse($option->isArray());
+    }
+
+    public function testHasReviewerOption()
+    {
+        $command = new UserCreateCommand($this->createAccountManagementMock());
+
+        $inputDefinition = $command->getDefinition();
+
+        $this->assertTrue($inputDefinition->hasOption('reviewer'));
+
+        $option = $inputDefinition->getOption('reviewer');
+
+        $this->assertSame('r', $option->getShortcut());
+        $this->assertSame('Promote to reviewer', $option->getDescription());
+        $this->assertFalse($option->isValueRequired());
+        $this->assertFalse($option->getDefault());
+        $this->assertFalse($option->isArray());
+    }
+
+    public function testExecuteFailsIfUserExists()
+    {
+        $faker = $this->getFaker();
+
+        $firstName = $faker->firstName;
+        $lastName  = $faker->lastName;
+        $email     = $faker->email;
+        $password  = $faker->password;
+
+        $accountManagement = $this->createAccountManagementMock();
+
+        $accountManagement
+            ->expects($this->once())
+            ->method('create')
+            ->with(
+                $this->identicalTo($email),
+                $this->identicalTo($password),
+                $this->identicalTo([
+                    'first_name' => $firstName,
+                    'last_name'  => $lastName,
+                    'email'      => $email,
+                    'password'   => $password,
+                ])
+            )
+            ->willThrowException(new Sentry\Users\UserExistsException());
+
+        $command = new UserCreateCommand($accountManagement);
+
+        $commandTester = new Console\Tester\CommandTester($command);
+
+        $commandTester->execute([
+            '--first_name' => $firstName,
+            '--last_name'  => $lastName,
+            '--email'      => $email,
+            '--password'   => $password,
+        ]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+
+        $message = sprintf(
+            'A user with the login "%s" already exists.',
+            $email
+        );
+
+        $this->assertContains($message, $commandTester->getDisplay());
+    }
+
+    public function testExecuteSucceedsIfUserDoesNotExist()
+    {
+        $faker = $this->getFaker();
+
+        $firstName = $faker->firstName;
+        $lastName  = $faker->lastName;
+        $email     = $faker->email;
+        $password  = $faker->password;
+
+        $user = $this->createSentryUserMock();
+
+        $accountManagement = $this->createAccountManagementMock();
+
+        $accountManagement
+            ->expects($this->at(0))
+            ->method('create')
+            ->with(
+                $this->identicalTo($email),
+                $this->identicalTo($password),
+                $this->identicalTo([
+                    'first_name' => $firstName,
+                    'last_name'  => $lastName,
+                    'email'      => $email,
+                    'password'   => $password,
+                ])
+            )
+            ->willReturn($user);
+
+        $accountManagement
+            ->expects($this->at(1))
+            ->method('activate')
+            ->with($this->identicalTo($email));
+
+        $command = new UserCreateCommand($accountManagement);
+
+        $commandTester = new Console\Tester\CommandTester($command);
+
+        $commandTester->execute([
+            '--first_name' => $firstName,
+            '--last_name'  => $lastName,
+            '--email'      => $email,
+            '--password'   => $password,
+        ]);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertContains('Creating User', $commandTester->getDisplay());
+
+        $creationMessage = sprintf(
+            ' * created user with login %s',
+            $email
+        );
+
+        $this->assertContains($creationMessage, $commandTester->getDisplay());
+        $this->assertContains('User Created', $commandTester->getDisplay());
+    }
+
+    /**
+     * @dataProvider providerOptionsAndRoles
+     *
+     * @param string[] $options
+     * @param string[] $roles
+     */
+    public function testExecuteSucceedsIfUserDoesNotExistAndPromotesUser(array $options, array $roles)
+    {
+        $faker = $this->getFaker();
+
+        $firstName = $faker->firstName;
+        $lastName  = $faker->lastName;
+        $email     = $faker->email;
+        $password  = $faker->password;
+
+        $accountManagement = $this->createAccountManagementMock();
+
+        $accountManagement
+            ->expects($this->at(0))
+            ->method('create')
+            ->with(
+                $this->identicalTo($email),
+                $this->identicalTo($password),
+                $this->identicalTo([
+                    'first_name' => $firstName,
+                    'last_name'  => $lastName,
+                    'email'      => $email,
+                    'password'   => $password,
+                ])
+            )
+            ->willReturn($this->createSentryUserMock());
+
+        $accountManagement
+            ->expects($this->at(1))
+            ->method('activate')
+            ->with($this->identicalTo($email));
+
+        $command = new UserCreateCommand($accountManagement);
+
+        $commandTester = new Console\Tester\CommandTester($command);
+
+        $options = array_merge([
+            '--first_name' => $firstName,
+            '--last_name'  => $lastName,
+            '--email'      => $email,
+            '--password'   => $password,
+        ], $options);
+
+        $commandTester->execute($options);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertContains('Creating User', $commandTester->getDisplay());
+
+        $creationMessage = sprintf(
+            ' * created user with login %s',
+            $email
+        );
+
+        $this->assertContains($creationMessage, $commandTester->getDisplay());
+
+        $promotionMessage = implode(PHP_EOL, array_map(function (string $role) {
+            return sprintf(
+                ' * promoted user to %s',
+                $role
+            );
+        }, $roles));
+
+        $this->assertContains($promotionMessage, $commandTester->getDisplay());
+        $this->assertContains('User Created', $commandTester->getDisplay());
+    }
+
+    public function providerOptionsAndRoles(): \Generator
+    {
+        $values = [
+            'admin-only' => [
+                [
+                    '--admin' => null,
+                ],
+                [
+                    'admin',
+                ],
+            ],
+            'reviewer-only' => [
+                [
+                    '--reviewer' => null,
+                ],
+                [
+                    'reviewer',
+                ],
+            ],
+            'admin-and-reviewer-only' => [
+                [
+                    '--admin'    => null,
+                    '--reviewer' => null,
+                ],
+                [
+                    'admin',
+                    'reviewer',
+                ],
+            ],
+        ];
+
+        foreach ($values as $key => list($options, $roles)) {
+            yield $key => [
+                $options,
+                $roles,
+            ];
+        }
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Services\AccountManagement
+     */
+    private function createAccountManagementMock(): Services\AccountManagement
+    {
+        return $this->createMock(Services\AccountManagement::class);
+    }
+
+    /**
+     * @return Auth\SentryUser|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createSentryUserMock(): Auth\SentryUser
+    {
+        return $this->createMock(Auth\SentryUser::class);
+    }
+}


### PR DESCRIPTION
This PR

* [x] decouples the `UserCreateCommand` from the application container

Somewhat related to #714.
Somewhat related to #618.