### PR TITLE
Add excludes to code coverage

### DIFF
--- a/tests/Unit/phpunit.xml.dist
+++ b/tests/Unit/phpunit.xml.dist
@@ -19,6 +19,11 @@
     <filter>
         <whitelist>
             <directory>../../classes</directory>
+            <exclude>
+                <directory>../../classes/Provider</directory>
+                <directory>../../classes/Http/API</directory>
+                <directory>../../classes/Infrastructure/Oauth</directory>
+            </exclude>
         </whitelist>
     </filter>
     <testsuites>


### PR DESCRIPTION
This PR

* [x] (Re-) adds excludes to the code coverage

This is how the set-up was before the split of Unit and Integration tests, and i see no reason not to exclude these from the total coverage.

I'm partial to adding Models to the excludes for coverage as well, since they would be impossible to test without using the database.