### PR TITLE
Enhancement: Enable no_unneeded_control_parentheses fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -38,6 +38,7 @@ return PhpCsFixer\Config::create()
         'no_singleline_whitespace_before_semicolons' => true,
         'no_superfluous_elseif' => true,
         'no_trailing_comma_in_singleline_array' => true,
+        'no_unneeded_control_parentheses' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,

--- a/classes/Domain/Services/TalkRating/YesNoRating.php
+++ b/classes/Domain/Services/TalkRating/YesNoRating.php
@@ -6,6 +6,6 @@ class YesNoRating extends TalkRating
 {
     public function isValidRating(int $rating): bool
     {
-        return ($rating >= -1 && $rating <= 1);
+        return $rating >= -1 && $rating <= 1;
     }
 }

--- a/classes/Domain/Talk/TalkHandler.php
+++ b/classes/Domain/Talk/TalkHandler.php
@@ -64,7 +64,7 @@ class TalkHandler
 
     public function hasTalk(): bool
     {
-        return ($this->talk instanceof Talk);
+        return $this->talk instanceof Talk;
     }
 
     public function commentOn(string $message): bool

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -84,7 +84,7 @@ class ExportsController extends BaseController
     {
         $length = strlen($needle);
 
-        return (substr($haystack, 0, $length) === $needle);
+        return substr($haystack, 0, $length) === $needle;
     }
 
     private function csvReturn(array $contents, string $filename = 'data')

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -61,7 +61,7 @@ abstract class Form
         $dataKeys    = array_keys($this->_taintedData);
         $foundFields = array_intersect($this->_fieldList, $dataKeys);
 
-        return ($foundFields == $this->_fieldList);
+        return $foundFields == $this->_fieldList;
     }
 
     /**

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -60,19 +60,18 @@ class SignupForm extends Form
             $valid_speaker_bio = $this->validateSpeakerBio();
         }
 
-        return (
-            $valid_email &&
-            $valid_passwords &&
-            $valid_first_name &&
-            $valid_last_name &&
-            $valid_company &&
-            $valid_twitter &&
-            $valid_url &&
-            $valid_speaker_info &&
-            $valid_speaker_bio &&
+        return
+            $valid_email         &&
+            $valid_passwords     &&
+            $valid_first_name    &&
+            $valid_last_name     &&
+            $valid_company       &&
+            $valid_twitter       &&
+            $valid_url           &&
+            $valid_speaker_info  &&
+            $valid_speaker_bio   &&
             $valid_speaker_photo &&
-            $agree_coc
-        );
+            $agree_coc;
     }
 
     public function validateSpeakerPhoto(): bool

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -55,16 +55,15 @@ class TalkForm extends Form
      */
     public function validateAll($action = 'create')
     {
-        return (
-            $this->validateTitle() &&
+        return
+            $this->validateTitle()       &&
             $this->validateDescription() &&
-            $this->validateLevel() &&
-            $this->validateCategory() &&
-            $this->validateDesired() &&
-            $this->validateSlides() &&
-            $this->validateOther() &&
-            $this->validateSponsor()
-        );
+            $this->validateLevel()       &&
+            $this->validateCategory()    &&
+            $this->validateDesired()     &&
+            $this->validateSlides()      &&
+            $this->validateOther()       &&
+            $this->validateSponsor();
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] enables the `no_unneeded_control_parentheses` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**no_unneeded_control_parentheses** [`@Symfony`]
>
>Removes unneeded parentheses around control statements.
>
>Configuration options:
>
>* `statements` (`array`): list of control statements to fix; defaults to `['break', 'clone', 'continue', 'echo_print', 'return', 'switch_case', 'yield']`