### PR TITLE
Enhancement: Enable whitespace_after_comma_in_array fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -62,6 +62,7 @@ return PhpCsFixer\Config::create()
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
+        'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
             'equal' => false,
             'identical' => false,

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -103,7 +103,7 @@ class ExportsController extends BaseController
         $output = $keys . "\n";
 
         foreach ($contents as $content) {
-            $content = array_map([$this,'csvFormat'], $content);
+            $content = array_map([$this, 'csvFormat'], $content);
             $output  = $output . implode(',', $content) . "\n";
         }
 

--- a/tests/Integration/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Integration/Domain/Speaker/SpeakerProfileTest.php
@@ -110,7 +110,7 @@ class SpeakerProfileTest extends BaseTestCase
 
     public function testIsAllowedtoSeeReturnsFalseIfEntryIsAHiddenProperty()
     {
-        $profile = new SpeakerProfile(self::$user, ['email','twitter']);
+        $profile = new SpeakerProfile(self::$user, ['email', 'twitter']);
 
         $this->assertFalse($profile->isAllowedToSee('email'));
         $this->assertFalse($profile->isAllowedToSee('twitter'));
@@ -119,7 +119,7 @@ class SpeakerProfileTest extends BaseTestCase
 
     public function testErrorGetsThrownWhenGettingAFieldThatIsNotAllowed()
     {
-        $profile = new SpeakerProfile(self::$user, ['email','twitter']);
+        $profile = new SpeakerProfile(self::$user, ['email', 'twitter']);
         //Check we are still allowed to see other items
         $photoPath = self::$user->photo_path;
 

--- a/tests/Unit/Domain/Services/PaginationTest.php
+++ b/tests/Unit/Domain/Services/PaginationTest.php
@@ -18,7 +18,7 @@ class PaginationTest extends Framework\TestCase
 
     protected function setUp()
     {
-        $this->pagination = new Pagination([1,2,3,4,5,6,7,8,9,10], 2);
+        $this->pagination = new Pagination([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2);
     }
 
     /**

--- a/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -39,7 +39,7 @@ class YesNoRatingTest extends \PHPUnit\Framework\TestCase
             [PHP_INT_MAX, false],
             ['3', false],
             ['-1', true],
-            ['0',true],
+            ['0', true],
             ['1', true],
             [-0, true],
             ['-0', true],


### PR DESCRIPTION
This PR

* [x] enables the `whitespace_after_comma_in_array` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**whitespace_after_comma_in_array** [`@Symfony`]
>
>In array declaration, there MUST be a whitespace after each comma.
