### PR TITLE
Enhancement: Decouple ReviewerPromoteCommand from application container

### DIFF
--- a/bin/opencfp
+++ b/bin/opencfp
@@ -17,10 +17,14 @@ $input = new ArgvInput();
 $environment = $input->getParameterOption(array('--env'), getenv('CFP_ENV') ?: 'development');
 
 $container = new ApplicationContainer($basePath, Environment::fromString($environment));
+
+$accountManagement = $container[Services\AccountManagement::class];
+
 $app = new Application($container);
 
 $app->addCommands([
-    new Command\UserCreateCommand($container[Services\AccountManagement::class]),
+    new Command\ReviewerPromoteCommand($accountManagement),
+    new Command\UserCreateCommand($accountManagement),
 ]);
 $status = $app->run($input);
 

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -16,7 +16,6 @@ use OpenCFP\Console\Command\AdminDemoteCommand;
 use OpenCFP\Console\Command\AdminPromoteCommand;
 use OpenCFP\Console\Command\ClearCacheCommand;
 use OpenCFP\Console\Command\ReviewerDemoteCommand;
-use OpenCFP\Console\Command\ReviewerPromoteCommand;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
@@ -51,7 +50,6 @@ class Application extends ConsoleApplication
             new ListCommand(),
             new AdminPromoteCommand(),
             new AdminDemoteCommand(),
-            new ReviewerPromoteCommand(),
             new ReviewerDemoteCommand(),
             new ClearCacheCommand(),
         ];

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -76,7 +76,6 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
             Console\Command\ListCommand::class,
             Command\AdminDemoteCommand::class,
             Command\AdminPromoteCommand::class,
-            Command\ReviewerPromoteCommand::class,
             Command\ReviewerDemoteCommand::class,
             Command\ClearCacheCommand::class,
         ];

--- a/tests/Unit/Console/Command/ReviewerPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/ReviewerPromoteCommandTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Unit\Console\Command;
+
+use Cartalyst\Sentry;
+use OpenCFP\Console\Command\ReviewerPromoteCommand;
+use OpenCFP\Domain\Services;
+use OpenCFP\Infrastructure\Auth;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+
+/**
+ * @covers \OpenCFP\Console\Command\ReviewerPromoteCommand
+ */
+final class ReviewerPromoteCommandTest extends Framework\TestCase
+{
+    use GeneratorTrait;
+
+    public function testIsFinal()
+    {
+        $reflection = new \ReflectionClass(ReviewerPromoteCommand::class);
+
+        $this->assertTrue($reflection->isFinal());
+    }
+
+    public function testExtendsCommand()
+    {
+        $command = new ReviewerPromoteCommand($this->createAccountManagementMock());
+
+        $this->assertInstanceOf(Console\Command\Command::class, $command);
+    }
+
+    public function testHasNameAndDescription()
+    {
+        $command = new ReviewerPromoteCommand($this->createAccountManagementMock());
+
+        $this->assertSame('reviewer:promote', $command->getName());
+        $this->assertSame('Promote an existing user to be a reviewer', $command->getDescription());
+    }
+
+    public function testHasEmailArgument()
+    {
+        $command = new ReviewerPromoteCommand($this->createAccountManagementMock());
+
+        $inputDefinition = $command->getDefinition();
+
+        $this->assertTrue($inputDefinition->hasArgument('email'));
+
+        $argument = $inputDefinition->getArgument('email');
+
+        $this->assertSame('Email address of user to promote to reviewer', $argument->getDescription());
+        $this->assertTrue($argument->isRequired());
+        $this->assertNull($argument->getDefault());
+        $this->assertFalse($argument->isArray());
+    }
+
+    public function testExecuteFailsIfUserDoesNotExist()
+    {
+        $email= $this->getFaker()->email;
+
+        $accountManagement = $this->createAccountManagementMock();
+
+        $accountManagement
+            ->expects($this->once())
+            ->method('findByLogin')
+            ->with($this->identicalTo($email))
+            ->willThrowException(new Sentry\Users\UserNotFoundException());
+
+        $command = new ReviewerPromoteCommand($accountManagement);
+
+        $commandTester = new Console\Tester\CommandTester($command);
+
+        $commandTester->execute([
+            'email' => $email,
+        ]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+
+        $sectionMessage = \sprintf(
+            'Promoting account with email "%s" to "Reviewer"',
+            $email
+        );
+
+        $this->assertContains($sectionMessage, $commandTester->getDisplay());
+
+        $failureMessage = \sprintf(
+            'Could not find account with email "%s".',
+            $email
+        );
+
+        $this->assertContains($failureMessage, $commandTester->getDisplay());
+    }
+
+    public function testExecuteSucceedsIfUserExists()
+    {
+        $email = $this->getFaker()->email;
+
+        $user = $this->createSentryUserMock();
+
+        $accountManagement = $this->createAccountManagementMock();
+
+        $accountManagement
+            ->expects($this->at(0))
+            ->method('findByLogin')
+            ->with($this->identicalTo($email))
+            ->willReturn($user);
+
+        $accountManagement
+            ->expects($this->at(1))
+            ->method('promoteTo')
+            ->with(
+                $this->identicalTo($email),
+                $this->identicalTo('Reviewer')
+            );
+
+        $command = new ReviewerPromoteCommand($accountManagement);
+
+        $commandTester = new Console\Tester\CommandTester($command);
+
+        $commandTester->execute([
+            'email' => $email,
+        ]);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+
+        $sectionMessage = \sprintf(
+            'Promoting account with email "%s" to "Reviewer"',
+            $email
+        );
+
+        $this->assertContains($sectionMessage, $commandTester->getDisplay());
+
+        $successMessage = \sprintf(
+            'Added account with email "%s" to the "Reviewer" group',
+            $email
+        );
+
+        $this->assertContains($successMessage, $commandTester->getDisplay());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Services\AccountManagement
+     */
+    private function createAccountManagementMock(): Services\AccountManagement
+    {
+        return $this->createMock(Services\AccountManagement::class);
+    }
+
+    /**
+     * @return Auth\SentryUser|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createSentryUserMock(): Auth\SentryUser
+    {
+        return $this->createMock(Auth\SentryUser::class);
+    }
+}

--- a/tests/Unit/phpunit.xml.dist
+++ b/tests/Unit/phpunit.xml.dist
@@ -13,6 +13,10 @@
     processIsolation="false"
     stopOnFailure="false"
 >
+    <php>
+        <!-- https://github.com/symfony/console/blob/v3.3.12/Terminal.php#L24-L36 -->
+        <env name="COLUMNS" value="120"/>
+    </php>
     <filter>
         <whitelist>
             <directory>../../classes</directory>


### PR DESCRIPTION
This PR

* [x] decouples the `ReviewerPromoteCommand` from the application container
* [x] sets console columns to `120`

Follows #717.
Related to #618.
Related to #714.

💁‍♂️ For reference, see:

* http://symfony.com/blog/new-in-symfony-3-2-console-improvements-part-2
* https://github.com/symfony/console/blob/a5a80c40bb9d67f9a992fac8ba3a542fa09e47c8/Tests/TerminalTest.php#L19-L32