### PR TITLE
Fix: Check ratings a bit more strict

### DIFF
--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -6,6 +6,7 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Talk\TalkFilter;
 use OpenCFP\Domain\Talk\TalkHandler;
+use OpenCFP\Domain\ValidationException;
 use OpenCFP\Http\Controller\BaseController;
 use OpenCFP\Http\Controller\FlashableTrait;
 use Symfony\Component\HttpFoundation\Request;
@@ -74,9 +75,17 @@ class TalksController extends BaseController
 
     public function rateAction(Request $req)
     {
-        return $this->service(TalkHandler::class)
-            ->grabTalk((int) $req->get('id'))
-            ->rate((int) $req->get('rating'));
+        try {
+            $this->validate([
+                'rating' => 'required|integer',
+            ]);
+
+            return $this->service(TalkHandler::class)
+                ->grabTalk((int) $req->get('id'))
+                ->rate((int) $req->get('rating'));
+        } catch (ValidationException $e) {
+            return false;
+        }
     }
 
     /**

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -6,6 +6,7 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Talk\TalkFilter;
 use OpenCFP\Domain\Talk\TalkHandler;
+use OpenCFP\Domain\ValidationException;
 use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -67,8 +68,16 @@ class TalksController extends BaseController
 
     public function rateAction(Request $req)
     {
-        return $this->service(TalkHandler::class)
-            ->grabTalk((int) $req->get('id'))
-            ->rate((int) $req->get('rating'));
+        try {
+            $this->validate([
+                'rating' => 'required|integer',
+            ]);
+
+            return $this->service(TalkHandler::class)
+                ->grabTalk((int) $req->get('id'))
+                ->rate((int) $req->get('rating'));
+        } catch (ValidationException $e) {
+            return false;
+        }
     }
 }

--- a/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
@@ -197,4 +197,28 @@ class TalksControllerTest extends WebTestCase
             ->assertNotSee('1')
             ->assertSuccessful();
     }
+
+    /**
+     * @test
+     */
+    public function rateActionWillReturnTrueOnGoodNumericRate()
+    {
+        $talk = self::$talks->first();
+        $this->asAdmin()
+            ->post('/admin/talks/' . $talk->id . '/rate', ['rating' => '0'])
+            ->assertSee('1')
+            ->assertSuccessful();
+    }
+
+    /**
+     * @test
+     */
+    public function rateActionWillReturnFalseOnNonIntInput()
+    {
+        $talk = self::$talks->first();
+        $this->asAdmin()
+            ->post('/admin/talks/' . $talk->id . '/rate', ['rating' => 'blabla'])
+            ->assertNotSee('1')
+            ->assertSuccessful();
+    }
 }

--- a/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
@@ -77,7 +77,31 @@ class TalksControllerTest extends WebTestCase
     {
         $talk = self::$talks->first();
         $this->asReviewer()
-            ->post('/reviewer/talks/' . $talk->id . '/rate', ['rating' => 8])
+            ->post('/reviewer/talks/' . $talk->id . '/rate', ['rating' => 12])
+            ->assertNotSee('1')
+            ->assertSuccessful();
+    }
+
+    /**
+     * @test
+     */
+    public function rateActionWillReturnTrueOnGoodNumericRate()
+    {
+        $talk = self::$talks->first();
+        $this->asReviewer()
+            ->post('/reviewer/talks/' . $talk->id . '/rate', ['rating' => '0'])
+            ->assertSee('1')
+            ->assertSuccessful();
+    }
+
+    /**
+     * @test
+     */
+    public function rateActionWillReturnFalseOnNonIntInput()
+    {
+        $talk = self::$talks->first();
+        $this->asReviewer()
+            ->post('/reviewer/talks/' . $talk->id . '/rate', ['rating' => 'blabla'])
             ->assertNotSee('1')
             ->assertSuccessful();
     }


### PR DESCRIPTION
This PR

* [x] checks if the ratings given are numeric

Casting a string like 'blabla' to an int will make it 0 in php. Which isn't really what we want here.
