### PR TITLE
Enhancement: Enable  native_function_invocation fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -28,6 +28,7 @@ return PhpCsFixer\Config::create()
             'use_yoda_style' => false,
         ],
         'method_separation' => true,
+        'native_function_invocation' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -53,7 +53,7 @@ class Application extends SilexApplication
         $this->bindConfiguration();
 
         if ($timezone = $this->config('application.date_timezone')) {
-            date_default_timezone_set($timezone);
+            \date_default_timezone_set($timezone);
         }
 
         // Register Gateways...
@@ -72,7 +72,7 @@ class Application extends SilexApplication
         $this->register(new MonologServiceProvider(), [
             'monolog.logfile' => $this->config('log.path') ?: "{$basePath}/log/app.log",
             'monolog.name'    => 'opencfp',
-            'monlog.level'    => strtoupper(
+            'monlog.level'    => \strtoupper(
                 $this->config('log.level') ?: 'debug'
             ),
         ]);
@@ -131,15 +131,15 @@ class Application extends SilexApplication
      */
     private function camelCaseFrom($slug)
     {
-        $parts = explode('.', $slug);
+        $parts = \explode('.', $slug);
 
-        $parts = array_map(function ($value) {
-            return ucfirst($value);
+        $parts = \array_map(function ($value) {
+            return \ucfirst($value);
         }, $parts);
 
-        $parts[0] = strtolower($parts[0]);
+        $parts[0] = \strtolower($parts[0]);
 
-        return implode('', $parts);
+        return \implode('', $parts);
     }
 
     /**
@@ -150,9 +150,9 @@ class Application extends SilexApplication
         $config = $this['path']->configPath();
         $driver = new YamlConfigDriver();
 
-        if (!file_exists($config)) {
+        if (!\file_exists($config)) {
             throw new \InvalidArgumentException(
-                sprintf("The config file '%s' does not exist.", $config)
+                \sprintf("The config file '%s' does not exist.", $config)
             );
         }
 
@@ -176,7 +176,7 @@ class Application extends SilexApplication
     {
         $cursor = $this['config'];
 
-        foreach (explode('.', $path) as $part) {
+        foreach (\explode('.', $path) as $part) {
             if (!isset($cursor[$part])) {
                 return null;
             }
@@ -196,7 +196,7 @@ class Application extends SilexApplication
     private function registerGlobalErrorHandler()
     {
         $this->error(function (\Exception $e, Request $request, $code) {
-            if (in_array('application/json', $request->getAcceptableContentTypes())) {
+            if (\in_array('application/json', $request->getAcceptableContentTypes())) {
                 $headers = [];
 
                 if ($e instanceof HttpExceptionInterface) {

--- a/classes/Console/BaseCommand.php
+++ b/classes/Console/BaseCommand.php
@@ -49,7 +49,7 @@ abstract class BaseCommand extends Command
 
         $io->title('OpenCFP');
 
-        $io->section(sprintf(
+        $io->section(\sprintf(
             'Demoting account with email %s from ' . $role,
             $email
         ));
@@ -57,7 +57,7 @@ abstract class BaseCommand extends Command
         try {
             $user = $accounts->findByLogin($email);
         } catch (\Exception $e) {
-            $io->error(sprintf(
+            $io->error(\sprintf(
                 'Could not find account with email %s.',
                 $email
             ));
@@ -66,7 +66,7 @@ abstract class BaseCommand extends Command
         }
 
         if (!$user->hasAccess(\strtolower($role))) {
-            $io->error(sprintf(
+            $io->error(\sprintf(
                 'Account with email %s is not in the Reviewer group.',
                 $email
             ));
@@ -76,7 +76,7 @@ abstract class BaseCommand extends Command
 
         $accounts->demoteFrom($user->getLogin(), $role);
 
-        $io->success(sprintf(
+        $io->success(\sprintf(
             'Removed account with email %s from the Reviewer group',
             $email
         ));
@@ -107,7 +107,7 @@ abstract class BaseCommand extends Command
 
         $io->title('OpenCFP');
 
-        $io->section(sprintf(
+        $io->section(\sprintf(
             'Promoting account with email %s to ' . $role,
             $email
         ));
@@ -115,7 +115,7 @@ abstract class BaseCommand extends Command
         try {
             $user = $accounts->findByLogin($email);
         } catch (\Exception $e) {
-            $io->error(sprintf(
+            $io->error(\sprintf(
                 'Could not find account with email %s.',
                 $email
             ));
@@ -125,7 +125,7 @@ abstract class BaseCommand extends Command
 
         $accounts->promoteTo($user->getLogin(), $role);
 
-        $io->success(sprintf(
+        $io->success(\sprintf(
             'Added account with email %s to the ' . $role . ' group',
             $email
         ));

--- a/classes/Console/Command/ClearCacheCommand.php
+++ b/classes/Console/Command/ClearCacheCommand.php
@@ -32,10 +32,10 @@ class ClearCacheCommand extends BaseCommand
             $this->app['path']->cacheTwigPath(),
         ];
 
-        array_walk($paths, function ($path) use ($io) {
-            passthru(sprintf('rm -rf %s/*', $path));
+        \array_walk($paths, function ($path) use ($io) {
+            \passthru(\sprintf('rm -rf %s/*', $path));
 
-            $io->writeln(sprintf(
+            $io->writeln(\sprintf(
                 '  * %s',
                 $path
             ));

--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -63,7 +63,7 @@ final class UserCreateCommand extends Command
                 $data
             );
         } catch (Sentry\Users\UserExistsException $exception) {
-            $io->error(sprintf(
+            $io->error(\sprintf(
                 'A user with the login "%s" already exists.',
                 $data['email']
             ));
@@ -71,7 +71,7 @@ final class UserCreateCommand extends Command
             return 1;
         }
 
-        $io->writeln(sprintf(
+        $io->writeln(\sprintf(
             ' * created user with login <info>%s</info>',
             $data['email']
         ));
@@ -88,7 +88,7 @@ final class UserCreateCommand extends Command
             $roles[] = 'reviewer';
         }
 
-        if (count($roles)) {
+        if (\count($roles)) {
             foreach ($roles as $role) {
                 if ($user->hasAccess($role)) {
                     continue;
@@ -99,7 +99,7 @@ final class UserCreateCommand extends Command
                     $role
                 );
 
-                $io->writeln(sprintf(
+                $io->writeln(\sprintf(
                     ' * promoted user to <info>%s</info>',
                     $role
                 ));

--- a/classes/Domain/Services/Pagination.php
+++ b/classes/Domain/Services/Pagination.php
@@ -29,7 +29,7 @@ class Pagination
         $routeGenerator = function ($page) use ($queryParams, $baseUrl) {
             $queryParams['page'] = $page;
 
-            return $baseUrl . http_build_query($queryParams);
+            return $baseUrl . \http_build_query($queryParams);
         };
 
         $view = new DefaultView();

--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -75,12 +75,12 @@ class ProfileImageProcessor
             $speakerPhoto->crop($this->size, $this->size);
 
             if ($speakerPhoto->save($this->publishDir . '/' . $publishFilename)) {
-                unlink($this->publishDir . '/' . $tempFilename);
+                \unlink($this->publishDir . '/' . $tempFilename);
             }
 
             return $publishFilename;
         } catch (\Exception $e) {
-            unlink($this->publishDir . '/' . $tempFilename);
+            \unlink($this->publishDir . '/' . $tempFilename);
 
             throw $e;
         }

--- a/classes/Domain/Services/TalkRating/TalkRatingContext.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingContext.php
@@ -9,7 +9,7 @@ class TalkRatingContext
 {
     public static function getTalkStrategy(string $strategy, Authentication $auth): TalkRatingStrategy
     {
-        $strategy = strtolower($strategy);
+        $strategy = \strtolower($strategy);
         switch ($strategy) {
             case 'yesno':
                 return new YesNoRating(new TalkMeta(), $auth);

--- a/classes/Domain/Services/TalkRating/TalkRatingException.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingException.php
@@ -6,6 +6,6 @@ class TalkRatingException extends \RuntimeException
 {
     public static function invalidRating($rating): self
     {
-        return new self(sprintf('Invalid talk rating: %s', $rating));
+        return new self(\sprintf('Invalid talk rating: %s', $rating));
     }
 }

--- a/classes/Domain/Speaker/NotAllowedException.php
+++ b/classes/Domain/Speaker/NotAllowedException.php
@@ -6,6 +6,6 @@ class NotAllowedException extends \Exception
 {
     public static function notAllowedToView(string $property): self
     {
-        return new self(sprintf('Not allowed to view %s. Hidden property', $property));
+        return new self(\sprintf('Not allowed to view %s. Hidden property', $property));
     }
 }

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -34,7 +34,7 @@ class SpeakerProfile
 
     public function isAllowedToSee(string $property): bool
     {
-        return !in_array($property, $this->hiddenProperties);
+        return !\in_array($property, $this->hiddenProperties);
     }
 
     private function assertAllowedToSee(string $property)

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -55,7 +55,7 @@ class TalkFilter
         if ($filter === null) {
             return $this->talk;
         }
-        switch (strtolower($filter)) {
+        switch (\strtolower($filter)) {
             case 'selected':
                 return $this->talk->selected();
 
@@ -92,14 +92,14 @@ class TalkFilter
      */
     private function getSortOptions(array $options, array $defaultOptions)
     {
-        if (!isset($options['order_by']) || !in_array($options['order_by'], $this->orderByWhiteList)) {
+        if (!isset($options['order_by']) || !\in_array($options['order_by'], $this->orderByWhiteList)) {
             $options['order_by'] = $defaultOptions['order_by'];
         }
 
-        if (!isset($options['sort']) || !in_array($options['sort'], ['ASC', 'DESC'])) {
+        if (!isset($options['sort']) || !\in_array($options['sort'], ['ASC', 'DESC'])) {
             $options['sort'] = $defaultOptions['sort'];
         }
 
-        return array_merge($defaultOptions, $options);
+        return \array_merge($defaultOptions, $options);
     }
 }

--- a/classes/Domain/Talk/TalkSubmission.php
+++ b/classes/Domain/Talk/TalkSubmission.php
@@ -25,7 +25,7 @@ class TalkSubmission
 
     public function toTalk(): Talk
     {
-        $data = array_merge([
+        $data = \array_merge([
             'title'       => '',
             'description' => '',
             'type'        => '',
@@ -47,7 +47,7 @@ class TalkSubmission
             throw new InvalidTalkSubmissionException('The title of the talk must be provided.');
         }
 
-        if (strlen($data['title']) > 100) {
+        if (\strlen($data['title']) > 100) {
             throw new InvalidTalkSubmissionException('The title of the talk must be 100 characters or less.');
         }
     }
@@ -83,7 +83,7 @@ class TalkSubmission
      */
     private function isValidTalkType($type)
     {
-        return in_array($type, ['regular', 'tutorial']);
+        return \in_array($type, ['regular', 'tutorial']);
     }
 
     private function guardLevelIsValid($data)
@@ -99,7 +99,7 @@ class TalkSubmission
 
     private function isValidLevel($level)
     {
-        return in_array($level, ['entry', 'mid', 'advanced']);
+        return \in_array($level, ['entry', 'mid', 'advanced']);
     }
 
     private function guardCategoryIsValid($data)
@@ -115,7 +115,7 @@ class TalkSubmission
 
     private function isValidCategory($category)
     {
-        return in_array($category, [
+        return \in_array($category, [
             'development',
             'framework',
             'database',

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -28,10 +28,10 @@ class Environment
             self::TYPE_TESTING,
         ];
 
-        if (!in_array($type, $types)) {
-            throw new \InvalidArgumentException(sprintf(
+        if (!\in_array($type, $types)) {
+            throw new \InvalidArgumentException(\sprintf(
                 'Environment needs to be one of "%s"; got "%s" instead.',
-                implode('", "', $types),
+                \implode('", "', $types),
                 $type
             ));
         }

--- a/classes/Http/API/ApiController.php
+++ b/classes/Http/API/ApiController.php
@@ -102,7 +102,7 @@ class ApiController
     public function respondWithError($message)
     {
         if ($this->statusCode === Response::HTTP_OK) {
-            trigger_error(
+            \trigger_error(
                 'You need to stellar reason to error with a 200 HTTP status code, Mr. Spock.',
                 E_USER_WARNING
             );

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -82,14 +82,14 @@ class ExportsController extends BaseController
 
     private function startsWith($haystack, string $needle): bool
     {
-        $length = strlen($needle);
+        $length = \strlen($needle);
 
-        return substr($haystack, 0, $length) === $needle;
+        return \substr($haystack, 0, $length) === $needle;
     }
 
     private function csvReturn(array $contents, string $filename = 'data')
     {
-        if (count($contents) === 0) {
+        if (\count($contents) === 0) {
             $this->service('session')->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
@@ -99,12 +99,12 @@ class ExportsController extends BaseController
             return $this->redirectTo('admin');
         }
 
-        $keys   = implode(',', array_keys($contents[0]));
+        $keys   = \implode(',', \array_keys($contents[0]));
         $output = $keys . "\n";
 
         foreach ($contents as $content) {
-            $content = array_map([$this, 'csvFormat'], $content);
-            $output  = $output . implode(',', $content) . "\n";
+            $content = \array_map([$this, 'csvFormat'], $content);
+            $output  = $output . \implode(',', $content) . "\n";
         }
 
         return $this->export($output, $filename . '.csv');

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -24,9 +24,9 @@ class SpeakersController extends BaseController
         /** @var AccountManagement $accounts */
         $accounts        = $this->service(AccountManagement::class);
         $adminUsers      = $accounts->findByRole('Admin');
-        $adminUserIds    = array_column($adminUsers, 'id');
+        $adminUserIds    = \array_column($adminUsers, 'id');
         $reviewerUsers   = $accounts->findByRole('Reviewer');
-        $reviewerUserIds = array_column($reviewerUsers, 'id');
+        $reviewerUserIds = \array_column($reviewerUsers, 'id');
 
         $rawSpeakers = User::search($search)->get();
 
@@ -48,8 +48,8 @@ class SpeakersController extends BaseController
                 ];
             }
 
-            $speaker['is_admin'] = in_array($speaker['id'], $adminUserIds);
-            $speaker['is_reviewer'] = in_array($speaker['id'], $reviewerUserIds);
+            $speaker['is_admin'] = \in_array($speaker['id'], $adminUserIds);
+            $speaker['is_reviewer'] = \in_array($speaker['id'], $reviewerUserIds);
 
             return $speaker;
         })->toArray();
@@ -61,8 +61,8 @@ class SpeakersController extends BaseController
 
         $templateData = [
             'airport'    => $this->app->config('application.airport'),
-            'arrival'    => date('Y-m-d', $this->app->config('application.arrival')),
-            'departure'  => date('Y-m-d', $this->app->config('application.departure')),
+            'arrival'    => \date('Y-m-d', $this->app->config('application.arrival')),
+            'departure'  => \date('Y-m-d', $this->app->config('application.departure')),
             'pagination' => $pagination,
             'speakers'   => $pagerfanta->getFanta(),
             'page'       => $pagerfanta->getCurrentPage(),
@@ -109,8 +109,8 @@ class SpeakersController extends BaseController
         // Build and render the template
         $templateData = [
             'airport'    => $this->app->config('application.airport'),
-            'arrival'    => date('Y-m-d', $this->app->config('application.arrival')),
-            'departure'  => date('Y-m-d', $this->app->config('application.departure')),
+            'arrival'    => \date('Y-m-d', $this->app->config('application.arrival')),
+            'departure'  => \date('Y-m-d', $this->app->config('application.departure')),
             'speaker'    => new SpeakerProfile($speaker_details),
             'talks'      => $talks,
             'photo_path' => '/uploads/',
@@ -195,7 +195,7 @@ class SpeakersController extends BaseController
 
         try {
             $user = $accounts->findById($req->get('id'));
-            if ($user->hasAccess(strtolower($role))) {
+            if ($user->hasAccess(\strtolower($role))) {
                 $this->service('session')->set('flash', [
                     'type'  => 'error',
                     'short' => 'Error',

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -43,7 +43,7 @@ class TalksController extends BaseController
             'talks'        => $pagerfanta->getFanta(),
             'page'         => $pagerfanta->getCurrentPage(),
             'current_page' => $req->getRequestUri(),
-            'totalRecords' => count($formattedTalks),
+            'totalRecords' => \count($formattedTalks),
             'filter'       => $req->get('filter'),
             'per_page'     => $per_page,
             'sort'         => $req->get('sort'),

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -84,7 +84,7 @@ class ProfileController extends BaseController
         $this->service('session')->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
-                'ext'   => implode('<br>', $form->getErrorMessages()),
+                'ext'   => \implode('<br>', $form->getErrorMessages()),
             ]);
 
         $form_data['formAction'] = $this->url('user_update');
@@ -119,7 +119,7 @@ class ProfileController extends BaseController
             $this->service('session')->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
-                'ext'   => implode('<br>', $form->getErrorMessages()),
+                'ext'   => \implode('<br>', $form->getErrorMessages()),
             ]);
 
             return $this->redirectTo('password_edit');
@@ -186,7 +186,7 @@ class ProfileController extends BaseController
     private function transformSanitizedData(array $sanitizedData): array
     {
         // Remove leading @ for twitter
-        $sanitizedData['twitter'] = preg_replace('/^@/', '', $sanitizedData['twitter']);
+        $sanitizedData['twitter'] = \preg_replace('/^@/', '', $sanitizedData['twitter']);
 
         $sanitizedData['bio'] = $sanitizedData['speaker_bio'];
         unset($sanitizedData['speaker_bio']);

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -36,7 +36,7 @@ class TalksController extends BaseController
             'talks'        => $pagerfanta->getFanta(),
             'page'         => $pagerfanta->getCurrentPage(),
             'current_page' => $req->getRequestUri(),
-            'totalRecords' => count($formattedTalks),
+            'totalRecords' => \count($formattedTalks),
             'filter'       => $req->get('filter'),
             'per_page'     => $per_page,
             'sort'         => $req->get('sort'),

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -50,7 +50,7 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        return $this->render('talk/view.twig', compact('talkId', 'talk'));
+        return $this->render('talk/view.twig', \compact('talkId', 'talk'));
     }
 
     public function editAction(Request $req)
@@ -88,8 +88,8 @@ class TalkController extends BaseController
             'talkTypes'      => $helper->getTalkTypes(),
             'talkLevels'     => $helper->getTalkLevels(),
             'id'             => $talkId,
-            'title'          => html_entity_decode($talk['title']),
-            'description'    => html_entity_decode($talk['description']),
+            'title'          => \html_entity_decode($talk['title']),
+            'description'    => \html_entity_decode($talk['description']),
             'type'           => $talk['type'],
             'level'          => $talk['level'],
             'category'       => $talk['category'],
@@ -211,7 +211,7 @@ class TalkController extends BaseController
         $this->service('session')->set('flash', [
             'type'  => 'error',
             'short' => 'Error',
-            'ext'   => implode('<br>', $form->getErrorMessages()),
+            'ext'   => \implode('<br>', $form->getErrorMessages()),
         ]);
         $data['flash'] = $this->service('session')->get('flash');
 
@@ -292,7 +292,7 @@ class TalkController extends BaseController
         $this->service('session')->set('flash', [
             'type'  => 'error',
             'short' => 'Error',
-            'ext'   => implode('<br>', $form->getErrorMessages()),
+            'ext'   => \implode('<br>', $form->getErrorMessages()),
         ]);
 
         $data['flash'] = $this->service('session')->get('flash');

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -47,7 +47,7 @@ abstract class Form
     {
         // The $_taintedData property might have been already set by
         // the populate() method.
-        $this->_taintedData = array_merge($this->_taintedData, (array) $data);
+        $this->_taintedData = \array_merge($this->_taintedData, (array) $data);
     }
 
     /**
@@ -58,8 +58,8 @@ abstract class Form
      */
     public function hasRequiredFields(): bool
     {
-        $dataKeys    = array_keys($this->_taintedData);
-        $foundFields = array_intersect($this->_fieldList, $dataKeys);
+        $dataKeys    = \array_keys($this->_taintedData);
+        $foundFields = \array_intersect($this->_fieldList, $dataKeys);
 
         return $foundFields == $this->_fieldList;
     }
@@ -147,7 +147,7 @@ abstract class Form
      */
     public function hasErrors(): bool
     {
-        return count($this->_messages) > 0;
+        return \count($this->_messages) > 0;
     }
 
     /**
@@ -158,7 +158,7 @@ abstract class Form
      */
     protected function _addErrorMessage($message)
     {
-        if (!in_array($message, $this->_messages)) {
+        if (!\in_array($message, $this->_messages)) {
             $this->_messages[] = $message;
         }
     }
@@ -181,7 +181,7 @@ abstract class Form
     protected function internalSanitize(array $taintedData): array
     {
         $purifier  = $this->_purifier;
-        $filtered  = array_map(
+        $filtered  = \array_map(
             function ($field) use ($purifier) {
                 return $purifier->purify($field);
             },

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -102,7 +102,7 @@ class SignupForm extends Form
         }
 
         // Check if photo is in the mime-type white list
-        if (!in_array($this->_taintedData['speaker_photo']->getMimeType(), $allowedMimeTypes)) {
+        if (!\in_array($this->_taintedData['speaker_photo']->getMimeType(), $allowedMimeTypes)) {
             $this->_addErrorMessage('Speaker photo must be a jpg or png');
 
             return false;
@@ -126,7 +126,7 @@ class SignupForm extends Form
             return false;
         }
 
-        $response = filter_var($this->_taintedData['email'], FILTER_VALIDATE_EMAIL);
+        $response = \filter_var($this->_taintedData['email'], FILTER_VALIDATE_EMAIL);
 
         if (!$response) {
             $this->_addErrorMessage('Invalid email address format');
@@ -159,13 +159,13 @@ class SignupForm extends Form
             return false;
         }
 
-        if (strlen($passwd) < 5 && strlen($passwd2) < 5) {
+        if (\strlen($passwd) < 5 && \strlen($passwd2) < 5) {
             $this->_addErrorMessage('The submitted password must be at least 5 characters long');
 
             return false;
         }
 
-        if ($passwd !== str_replace(' ', '', $passwd)) {
+        if ($passwd !== \str_replace(' ', '', $passwd)) {
             $this->_addErrorMessage('The submitted password contains invalid characters');
 
             return false;
@@ -189,7 +189,7 @@ class SignupForm extends Form
             $validation_response = false;
         }
 
-        if (strlen($first_name) > 255) {
+        if (\strlen($first_name) > 255) {
             $this->_addErrorMessage('First name cannot exceed 255 characters');
             $validation_response = false;
         }
@@ -217,7 +217,7 @@ class SignupForm extends Form
             $validation_response = false;
         }
 
-        if (strlen($last_name) > 255) {
+        if (\strlen($last_name) > 255) {
             $this->_addErrorMessage('Last name cannot exceed 255 characters');
             $validation_response = false;
         }
@@ -244,7 +244,7 @@ class SignupForm extends Form
 
     public function validateUrl(): bool
     {
-        if (preg_match('/https:\/\/joind\.in\/user\/[a-zA-Z0-9]{1,25}/', $this->_cleanData['url'])
+        if (\preg_match('/https:\/\/joind\.in\/user\/[a-zA-Z0-9]{1,25}/', $this->_cleanData['url'])
             || !isset($this->_cleanData['url'])
             || $this->_cleanData['url'] == ''
         ) {
@@ -262,12 +262,12 @@ class SignupForm extends Form
      */
     public function validateSpeakerInfo(): bool
     {
-        $speakerInfo = filter_var(
+        $speakerInfo = \filter_var(
             $this->_cleanData['speaker_info'],
             FILTER_SANITIZE_STRING
         );
         $validation_response = true;
-        $speakerInfo         = strip_tags($speakerInfo);
+        $speakerInfo         = \strip_tags($speakerInfo);
         $speakerInfo         = $this->_purifier->purify($speakerInfo);
 
         if (empty($speakerInfo)) {
@@ -285,12 +285,12 @@ class SignupForm extends Form
      */
     public function validateSpeakerBio(): bool
     {
-        $speaker_bio = filter_var(
+        $speaker_bio = \filter_var(
             $this->_cleanData['speaker_bio'],
             FILTER_SANITIZE_STRING
         );
         $validation_response = true;
-        $speaker_bio         = strip_tags($speaker_bio);
+        $speaker_bio         = \strip_tags($speaker_bio);
         $speaker_bio         = $this->_purifier->purify($speaker_bio);
 
         if (empty($speaker_bio)) {
@@ -319,7 +319,7 @@ class SignupForm extends Form
 
         // Remove leading @ for twitter
         if (isset($this->_taintedData['twitter'])) {
-            $this->_cleanData['twitter'] = preg_replace(
+            $this->_cleanData['twitter'] = \preg_replace(
                 '/^@/',
                 '',
                 $this->_taintedData['twitter']

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -23,11 +23,11 @@ class TalkForm extends Form
 
     public function __construct(array $data, \HTMLPurifier $purifier, array $options = [])
     {
-        if (!array_key_exists('desired', $data) || $data['desired'] === null) {
+        if (!\array_key_exists('desired', $data) || $data['desired'] === null) {
             $data['desired'] = 0;
         }
 
-        if (!array_key_exists('sponsor', $data) || $data['sponsor'] === null) {
+        if (!\array_key_exists('sponsor', $data) || $data['sponsor'] === null) {
             $data['sponsor'] = 0;
         }
 
@@ -44,7 +44,7 @@ class TalkForm extends Form
         parent::sanitize();
 
         foreach ($this->_cleanData as $key => $value) {
-            $this->_cleanData[$key] = strip_tags($value);
+            $this->_cleanData[$key] = \strip_tags($value);
         }
     }
 
@@ -81,7 +81,7 @@ class TalkForm extends Form
 
         $title = $this->_cleanData['title'];
 
-        if (strlen($title) > 100) {
+        if (\strlen($title) > 100) {
             $this->_addErrorMessage('Your talk title has to be 100 characters or less');
 
             return false;

--- a/classes/Infrastructure/Auth/SentryAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentryAccountManagement.php
@@ -37,7 +37,7 @@ class SentryAccountManagement implements AccountManagement
 
     public function create($email, $password, array $data = []): UserInterface
     {
-        $user = $this->sentry->createUser(array_merge([
+        $user = $this->sentry->createUser(\array_merge([
             'email'    => $email,
             'password' => $password,
         ], $data));

--- a/classes/Infrastructure/Crypto/PseudoRandomStringGenerator.php
+++ b/classes/Infrastructure/Crypto/PseudoRandomStringGenerator.php
@@ -8,6 +8,6 @@ class PseudoRandomStringGenerator implements RandomStringGenerator
 {
     public function generate($length = 40)
     {
-        return substr(bin2hex(random_bytes($length)), 0, $length);
+        return \substr(\bin2hex(\random_bytes($length)), 0, $length);
     }
 }

--- a/classes/Infrastructure/OAuth/AccessTokenStorage.php
+++ b/classes/Infrastructure/OAuth/AccessTokenStorage.php
@@ -19,7 +19,7 @@ class AccessTokenStorage extends AbstractStorage implements AccessTokenInterface
                             ->where('access_token', $token)
                             ->get();
 
-        if (count($result) === 1) {
+        if (\count($result) === 1) {
             $token = (new AccessTokenEntity($this->server))
                         ->setId($result[0]['access_token'])
                         ->setExpireTime($result[0]['expire_time']);
@@ -41,7 +41,7 @@ class AccessTokenStorage extends AbstractStorage implements AccessTokenInterface
 
         $response = [];
 
-        if (count($result) > 0) {
+        if (\count($result) > 0) {
             foreach ($result as $row) {
                 $scope = (new ScopeEntity($this->server))->hydrate([
                     'id'            => $row['id'],

--- a/classes/Infrastructure/OAuth/AuthCodeStorage.php
+++ b/classes/Infrastructure/OAuth/AuthCodeStorage.php
@@ -17,10 +17,10 @@ class AuthCodeStorage extends AbstractStorage implements AuthCodeInterface
     {
         $result = Capsule::table('oauth_auth_codes')
                             ->where('auth_code', $code)
-                            ->where('expire_time', '>=', time())
+                            ->where('expire_time', '>=', \time())
                             ->get();
 
-        if (count($result) === 1) {
+        if (\count($result) === 1) {
             $token = new AuthCodeEntity($this->server);
             $token->setId($result[0]['auth_code']);
             $token->setRedirectUri($result[0]['client_redirect_uri']);
@@ -54,7 +54,7 @@ class AuthCodeStorage extends AbstractStorage implements AuthCodeInterface
 
         $response = [];
 
-        if (count($result) > 0) {
+        if (\count($result) > 0) {
             foreach ($result as $row) {
                 $scope = (new ScopeEntity($this->server))->hydrate([
                     'id'            => $row['id'],

--- a/classes/Infrastructure/OAuth/ClientStorage.php
+++ b/classes/Infrastructure/OAuth/ClientStorage.php
@@ -31,7 +31,7 @@ class ClientStorage extends AbstractStorage implements ClientInterface
 
         $result = $query->get();
 
-        if (count($result) === 1) {
+        if (\count($result) === 1) {
             $client = new ClientEntity($this->server);
 
             $clientData = [
@@ -60,7 +60,7 @@ class ClientStorage extends AbstractStorage implements ClientInterface
                             ->where('oauth_sessions.id', $session->getId())
                             ->get();
 
-        if (count($result) === 1) {
+        if (\count($result) === 1) {
             $client = new ClientEntity($this->server);
             $client->hydrate([
                 'id'    => $result[0]['id'],

--- a/classes/Infrastructure/OAuth/RefreshTokenStorage.php
+++ b/classes/Infrastructure/OAuth/RefreshTokenStorage.php
@@ -18,7 +18,7 @@ class RefreshTokenStorage extends AbstractStorage implements RefreshTokenInterfa
                             ->where('refresh_token', $token)
                             ->get();
 
-        if (count($result) === 1) {
+        if (\count($result) === 1) {
             $token = (new RefreshTokenEntity($this->server))
                         ->setId($result[0]['refresh_token'])
                         ->setExpireTime($result[0]['expire_time'])

--- a/classes/Infrastructure/OAuth/ScopeStorage.php
+++ b/classes/Infrastructure/OAuth/ScopeStorage.php
@@ -18,7 +18,7 @@ class ScopeStorage extends AbstractStorage implements ScopeInterface
                                 ->where('id', $scope)
                                 ->get();
 
-        if (count($result) === 0) {
+        if (\count($result) === 0) {
             return;
         }
 

--- a/classes/Infrastructure/OAuth/SessionStorage.php
+++ b/classes/Infrastructure/OAuth/SessionStorage.php
@@ -23,7 +23,7 @@ class SessionStorage extends AbstractStorage implements SessionInterface
                             ->where('oauth_access_tokens.access_token', $accessToken->getId())
                             ->get();
 
-        if (count($result) === 1) {
+        if (\count($result) === 1) {
             $session = new SessionEntity($this->server);
             $session->setId($result[0]['id']);
             $session->setOwner($result[0]['owner_type'], $result[0]['owner_id']);
@@ -43,7 +43,7 @@ class SessionStorage extends AbstractStorage implements SessionInterface
                             ->where('oauth_auth_codes.auth_code', $authCode->getId())
                             ->get();
 
-        if (count($result) === 1) {
+        if (\count($result) === 1) {
             $session = new SessionEntity($this->server);
             $session->setId($result[0]['id']);
             $session->setOwner($result[0]['owner_type'], $result[0]['owner_id']);

--- a/classes/Provider/ControllerResolver.php
+++ b/classes/Provider/ControllerResolver.php
@@ -16,7 +16,7 @@ class ControllerResolver extends \Silex\ControllerResolver
      */
     protected function createController($controller)
     {
-        if (strpos($controller, '::') !== false) {
+        if (\strpos($controller, '::') !== false) {
             $instance = parent::createController($controller);
 
             // Injects container from side rather than constructor.
@@ -27,14 +27,14 @@ class ControllerResolver extends \Silex\ControllerResolver
             return $instance;
         }
 
-        if (strpos($controller, ':') === false) {
-            throw new \LogicException(sprintf('Unable to parse the controller name "%s".', $controller));
+        if (\strpos($controller, ':') === false) {
+            throw new \LogicException(\sprintf('Unable to parse the controller name "%s".', $controller));
         }
 
-        list($service, $method) = explode(':', $controller, 2);
+        list($service, $method) = \explode(':', $controller, 2);
 
         if (!isset($this->app[$service])) {
-            throw new \InvalidArgumentException(sprintf('Service "%s" does not exist.', $controller));
+            throw new \InvalidArgumentException(\sprintf('Service "%s" does not exist.', $controller));
         }
 
         return [$this->app[$service], $method];

--- a/classes/Provider/Gateways/ApiGatewayProvider.php
+++ b/classes/Provider/Gateways/ApiGatewayProvider.php
@@ -33,9 +33,9 @@ class ApiGatewayProvider implements ServiceProviderInterface, BootableProviderIn
         $api->before(function (Request $request) {
             $request->headers->set('Accept', 'application/json');
 
-            if (strpos($request->headers->get('Content-Type'), 'application/json') === 0) {
-                $data = json_decode($request->getContent(), true);
-                $request->request->replace(is_array($data) ? $data : []);
+            if (\strpos($request->headers->get('Content-Type'), 'application/json') === 0) {
+                $data = \json_decode($request->getContent(), true);
+                $request->request->replace(\is_array($data) ? $data : []);
             }
         });
 

--- a/classes/Provider/Gateways/OAuthGatewayProvider.php
+++ b/classes/Provider/Gateways/OAuthGatewayProvider.php
@@ -68,9 +68,9 @@ class OAuthGatewayProvider implements ServiceProviderInterface, BootableProvider
         $oauth->before(function (Request $request, Application $app) {
             $request->headers->set('Accept', 'application/json');
 
-            if (strpos($request->headers->get('Content-Type'), 'application/json') === 0) {
-                $data = json_decode($request->getContent(), true);
-                $request->request->replace(is_array($data) ? $data : []);
+            if (\strpos($request->headers->get('Content-Type'), 'application/json') === 0) {
+                $data = \json_decode($request->getContent(), true);
+                $request->request->replace(\is_array($data) ? $data : []);
             }
         });
 

--- a/classes/Provider/Gateways/RequestCleaner.php
+++ b/classes/Provider/Gateways/RequestCleaner.php
@@ -35,10 +35,10 @@ class RequestCleaner
         $sanitized = [];
 
         foreach ($data as $key => $value) {
-            if (is_array($value)) {
+            if (\is_array($value)) {
                 $sanitized[$key] = $this->clean($value);
             } else {
-                $sanitized[$key] = preg_replace(
+                $sanitized[$key] = \preg_replace(
                     ['/&amp;/', '/&lt;\b/', '/\b&gt;/'],
                     ['&', '<', '>'],
                     $this->purifier->purify($value)

--- a/classes/Provider/HtmlPurifierServiceProvider.php
+++ b/classes/Provider/HtmlPurifierServiceProvider.php
@@ -22,8 +22,8 @@ class HtmlPurifierServiceProvider implements ServiceProviderInterface
                 $config->set('Cache.SerializerPermissions', $cachePermissions);
                 $cacheDirectory = $app['path']->cachePurifierPath();
 
-                if (!is_dir($cacheDirectory)) {
-                    mkdir($cacheDirectory, $cachePermissions, true);
+                if (!\is_dir($cacheDirectory)) {
+                    \mkdir($cacheDirectory, $cachePermissions, true);
                 }
 
                 $config->set('Cache.SerializerPath', $cacheDirectory);

--- a/classes/Provider/YamlConfigDriver.php
+++ b/classes/Provider/YamlConfigDriver.php
@@ -8,16 +8,16 @@ class YamlConfigDriver
 {
     public function load($filename)
     {
-        if (!class_exists('Symfony\\Component\\Yaml\\Yaml')) {
+        if (!\class_exists('Symfony\\Component\\Yaml\\Yaml')) {
             throw new \RuntimeException('Unable to read yaml as the Symfony Yaml Component is not installed.');
         }
-        $config = Yaml::parse(file_get_contents($filename));
+        $config = Yaml::parse(\file_get_contents($filename));
 
         return $config ?: [];
     }
 
     public function supports($filename)
     {
-        return (bool) preg_match('#\.ya?ml(\.dist)?$#', $filename);
+        return (bool) \preg_match('#\.ya?ml(\.dist)?$#', $filename);
     }
 }

--- a/factories/Common.php
+++ b/factories/Common.php
@@ -4,7 +4,7 @@
 $factory->define(\OpenCFP\Domain\Model\User::class, function (\Faker\Generator $faker) {
     return [
         'email'          => $faker->unique()->safeEmail,
-        'password'       => password_hash('secret', PASSWORD_BCRYPT),
+        'password'       => \password_hash('secret', PASSWORD_BCRYPT),
         'activated'      => 1,
         'first_name'     => $faker->firstName,
         'last_name'      => $faker->lastName,

--- a/server.php
+++ b/server.php
@@ -1,9 +1,9 @@
 <?php
 
-define('WEB_PATH', __DIR__ . '/web/');
+\define('WEB_PATH', __DIR__ . '/web/');
 
 $path = WEB_PATH . $_SERVER['REQUEST_URI'];
-if (is_file($path)) {
+if (\is_file($path)) {
     return false;
 }
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -56,7 +56,7 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      */
     public function runBeforeTestTraits()
     {
-        $uses = array_flip(class_uses_recursive(static::class));
+        $uses = \array_flip(class_uses_recursive(static::class));
 
         if (isset($uses[DataBaseInteraction::class])) {
             $this->resetDatabase();
@@ -68,7 +68,7 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      */
     protected static function runBeforeClassTraits()
     {
-        $uses = array_flip(class_uses_recursive(static::class));
+        $uses = \array_flip(class_uses_recursive(static::class));
 
         if (isset($uses[RefreshDatabase::class])) {
             static::setUpDatabase();

--- a/tests/Helper/DataBaseInteraction.php
+++ b/tests/Helper/DataBaseInteraction.php
@@ -8,7 +8,7 @@ trait DataBaseInteraction
 {
     protected function resetDatabase()
     {
-        $this->getCapsule()->getConnection()->unprepared(file_get_contents(__DIR__ . '/../dump.sql'));
+        $this->getCapsule()->getConnection()->unprepared(\file_get_contents(__DIR__ . '/../dump.sql'));
     }
 
     protected function getCapsule(): Manager

--- a/tests/Helper/RefreshDatabase.php
+++ b/tests/Helper/RefreshDatabase.php
@@ -8,7 +8,7 @@ trait RefreshDatabase
 {
     protected static function setUpDatabase()
     {
-        self::createCapsule()->getConnection()->unprepared(file_get_contents(__DIR__ . '/../dump.sql'));
+        self::createCapsule()->getConnection()->unprepared(\file_get_contents(__DIR__ . '/../dump.sql'));
     }
 
     protected static function createCapsule(): Manager

--- a/tests/Integration/Domain/Model/UserTest.php
+++ b/tests/Integration/Domain/Model/UserTest.php
@@ -113,12 +113,12 @@ class UserTest extends BaseTestCase
     private static function makeKnownUsers()
     {
         $userInfo = [
-            'password'         => password_hash('secret', PASSWORD_BCRYPT),
+            'password'         => \password_hash('secret', PASSWORD_BCRYPT),
             'activated'        => 1,
             'has_made_profile' => 1,
         ];
 
-        $user = User::create(array_merge([
+        $user = User::create(\array_merge([
             'email'      => 'henk@example.com',
             'first_name' => 'Henk',
             'last_name'  => 'de Vries',
@@ -126,25 +126,25 @@ class UserTest extends BaseTestCase
         self::giveUserThreeTalks($user);
         self::giveUserRelations($user);
 
-        User::create(array_merge([
+        User::create(\array_merge([
             'email'      => 'speaker@cfp.org',
             'first_name' => 'Speaker',
             'last_name'  => 'de Vries',
         ], $userInfo));
 
-        User::create(array_merge([
+        User::create(\array_merge([
             'email'      => 'Vries@cfp.org',
             'first_name' => 'Vries',
             'last_name'  => 'van Henk',
         ], $userInfo));
 
-        User::create(array_merge([
+        User::create(\array_merge([
             'email'      => 'd20@mail.com',
             'first_name' => 'Arthur',
             'last_name'  => 'Hunter',
         ], $userInfo));
 
-        User::create(array_merge([
+        User::create(\array_merge([
             'email'      => 'hunter@hunter.xx',
             'first_name' => 'Gon',
             'last_name'  => 'Freecss',

--- a/tests/Integration/Domain/Services/TalkFormatterTest.php
+++ b/tests/Integration/Domain/Services/TalkFormatterTest.php
@@ -62,7 +62,7 @@ class TalkFormatterTest extends BaseTestCase
         $formatter = new TalkFormatter();
         $talks     = Talk::all();
         $formatted = $formatter->formatList($talks, 2);
-        $this->assertEquals(count($talks), count($formatted));
+        $this->assertEquals(\count($talks), \count($formatted));
         $this->assertInstanceOf(Collection::class, $formatted);
     }
 

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -20,9 +20,9 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
     {
         $this->app                 = new Application(BASE_PATH, Environment::testing());
         $this->app['session.test'] = true;
-        ob_start();
+        \ob_start();
         $this->app->run();
-        ob_end_clean();
+        \ob_end_clean();
     }
 
     /**

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -89,7 +89,7 @@ class TestResponse
     public function assertFlashContains(string $flash): self
     {
         $fullFlash = $this->app['session']->get('flash');
-        $fullFlash = is_array($fullFlash) ? $fullFlash : [];
+        $fullFlash = \is_array($fullFlash) ? $fullFlash : [];
         Assert::assertContains($flash, $fullFlash);
 
         return $this;

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -24,9 +24,9 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
 
         // We start an output buffer because the Application sends its response to
         // the output buffer as a Symfony Response.
-        ob_start();
+        \ob_start();
         $this->sut->run();
-        $output = ob_get_clean();
+        $output = \ob_get_clean();
 
         $this->assertNotEmpty($output);
     }

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -71,12 +71,12 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
             Command\ClearCacheCommand::class,
         ];
 
-        $actual = array_map(function (Console\Command\Command $command) {
-            return get_class($command);
+        $actual = \array_map(function (Console\Command\Command $command) {
+            return \get_class($command);
         }, $application->getDefaultCommands());
 
-        sort($expected);
-        sort($actual);
+        \sort($expected);
+        \sort($actual);
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -180,7 +180,7 @@ final class UserCreateCommandTest extends Framework\TestCase
 
         $this->assertSame(1, $commandTester->getStatusCode());
 
-        $message = sprintf(
+        $message = \sprintf(
             'A user with the login "%s" already exists.',
             $email
         );
@@ -235,7 +235,7 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertSame(0, $commandTester->getStatusCode());
         $this->assertContains('Creating User', $commandTester->getDisplay());
 
-        $creationMessage = sprintf(
+        $creationMessage = \sprintf(
             ' * created user with login %s',
             $email
         );
@@ -285,7 +285,7 @@ final class UserCreateCommandTest extends Framework\TestCase
 
         $commandTester = new Console\Tester\CommandTester($command);
 
-        $options = array_merge([
+        $options = \array_merge([
             '--first_name' => $firstName,
             '--last_name'  => $lastName,
             '--email'      => $email,
@@ -297,15 +297,15 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertSame(0, $commandTester->getStatusCode());
         $this->assertContains('Creating User', $commandTester->getDisplay());
 
-        $creationMessage = sprintf(
+        $creationMessage = \sprintf(
             ' * created user with login %s',
             $email
         );
 
         $this->assertContains($creationMessage, $commandTester->getDisplay());
 
-        $promotionMessage = implode(PHP_EOL, array_map(function (string $role) {
-            return sprintf(
+        $promotionMessage = \implode(PHP_EOL, \array_map(function (string $role) {
+            return \sprintf(
                 ' * promoted user to %s',
                 $role
             );

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
@@ -26,7 +26,7 @@ final class TalkRatingExceptionTest extends Framework\TestCase
         $this->assertInstanceOf(TalkRatingException::class, $exception);
         $this->assertSame(0, $exception->getCode());
 
-        $message = sprintf(
+        $message = \sprintf(
             'Invalid talk rating: %s',
             $rating
         );

--- a/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
+++ b/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
@@ -26,7 +26,7 @@ final class NotAllowedExceptionTest extends Framework\TestCase
         $this->assertInstanceOf(NotAllowedException::class, $exception);
         $this->assertSame(0, $exception->getCode());
 
-        $message = sprintf(
+        $message = \sprintf(
             'Not allowed to view %s. Hidden property',
             $property
         );

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -123,9 +123,9 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         ];
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf(
+        $this->expectExceptionMessage(\sprintf(
             'Environment needs to be one of "%s"; got "%s" instead.',
-            implode('", "', $types),
+            \implode('", "', $types),
             $type
         ));
 

--- a/tests/Unit/Http/Controller/FlashableTraitTest.php
+++ b/tests/Unit/Http/Controller/FlashableTraitTest.php
@@ -79,7 +79,7 @@ class FlashableTraitTest extends \PHPUnit\Framework\TestCase
             ->expects($this->any())
             ->method('offsetGet')
             ->willReturnCallback(function ($alias) use ($items) {
-                if (array_key_exists($alias, $items)) {
+                if (\array_key_exists($alias, $items)) {
                     return $items[$alias];
                 }
             });

--- a/tests/Unit/Http/Form/TalkFormTest.php
+++ b/tests/Unit/Http/Form/TalkFormTest.php
@@ -30,13 +30,13 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      */
     public function correctlyDetectsRequiredFields($rawData, $response)
     {
-        $data = unserialize($rawData);
+        $data = \unserialize($rawData);
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
 
         $this->assertEquals(
             $response,
             $form->hasRequiredFields(),
-            sprintf(
+            \sprintf(
                 '%s::hasRequired() did not work correctly',
                 \OpenCFP\Http\Form\TalkForm::class
             )
@@ -70,9 +70,9 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $extendedData['extra'] = 'Extra data in $_POST but we ignore it';
 
         return [
-            [serialize($badData), false],
-            [serialize($goodData), true],
-            [serialize($extendedData), true],
+            [\serialize($badData), false],
+            [\serialize($goodData), true],
+            [\serialize($extendedData), true],
         ];
     }
 
@@ -88,12 +88,12 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
      */
     public function submitsTalkWhenNoDesiredOrSponrosIncluded($rawData, $response)
     {
-        $data = unserialize($rawData);
+        $data = \unserialize($rawData);
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
         $this->assertEquals(
             $response,
             $form->hasRequiredFields(),
-            sprintf(
+            \sprintf(
                 '%s::hasRequired() did not work correctly',
                 \OpenCFP\Http\Form\TalkForm::class
             )
@@ -119,7 +119,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         ];
 
         return [
-            [serialize($goodData), true],
+            [\serialize($goodData), true],
         ];
     }
 
@@ -141,7 +141,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $expectedResponse,
             $form->validateTitle(),
-            sprintf(
+            \sprintf(
                 '%s::validateTitle() did not apply validation rules correctly',
                 \OpenCFP\Http\Form\TalkForm::class
             )
@@ -158,7 +158,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $faker = $this->getFaker();
 
         return [
-            [substr($faker->text(90), 0, 90), true],
+            [\substr($faker->text(90), 0, 90), true],
             [null, false],
             ['This is a string that could be more than 100 characters long but will we really know for sure until I check it out?', false],
             ['A little bit of this & that', true],
@@ -183,7 +183,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $expectedResponse,
             $form->validateDescription(),
-            sprintf(
+            \sprintf(
                 '%s::validateDescription() did not apply validation rules correctly',
                 \OpenCFP\Http\Form\TalkForm::class
             )
@@ -228,7 +228,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $expectedResponse,
             $form->validateType(),
-            sprintf(
+            \sprintf(
                 '%s::validateType() did not apply validation rules correctly',
                 \OpenCFP\Http\Form\TalkForm::class
             )
@@ -271,7 +271,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $expectedResponse,
             $form->validateCategory(),
-            sprintf(
+            \sprintf(
                 '%s::validateType() did not apply validation rules correctly',
                 \OpenCFP\Http\Form\TalkForm::class
             )
@@ -339,7 +339,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $expectedResponse,
             $form->validateLevel(),
-            sprintf(
+            \sprintf(
                 '%s::validateType() did not apply validation rules correctly',
                 \OpenCFP\Http\Form\TalkForm::class
             )

--- a/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -22,9 +22,9 @@ class PseudoRandomStringGeneratorTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_should_generate_a_random_string_of_given_length()
     {
-        $this->assertEquals(10, strlen($this->sut->generate(10)));
-        $this->assertEquals(18, strlen($this->sut->generate(18)));
-        $this->assertEquals(35, strlen($this->sut->generate(35)));
-        $this->assertEquals(40, strlen($this->sut->generate(40)));
+        $this->assertEquals(10, \strlen($this->sut->generate(10)));
+        $this->assertEquals(18, \strlen($this->sut->generate(18)));
+        $this->assertEquals(35, \strlen($this->sut->generate(35)));
+        $this->assertEquals(40, \strlen($this->sut->generate(40)));
     }
 }

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -48,7 +48,7 @@ abstract class WebTestCase extends BaseTestCase
      */
     public function withHeaders(array $headers): self
     {
-        $this->headers = array_merge($this->headers, $headers);
+        $this->headers = \array_merge($this->headers, $headers);
 
         return $this;
     }
@@ -90,7 +90,7 @@ abstract class WebTestCase extends BaseTestCase
             $parameters,
             $cookies,
             $files,
-            array_replace($this->server, $server),
+            \array_replace($this->server, $server),
             $content
         );
 

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Eloquent\Factory;
 
-if (!function_exists('factory')) {
+if (!\function_exists('factory')) {
     /**
      * Create a model factory builder for a given class, name, and amount.
      *
@@ -16,8 +16,8 @@ if (!function_exists('factory')) {
 
         $factory = Factory::construct($faker, __DIR__ . '/../factories');
 
-        $arguments = func_get_args();
-        if (isset($arguments[1]) && is_string($arguments[1])) {
+        $arguments = \func_get_args();
+        if (isset($arguments[1]) && \is_string($arguments[1])) {
             return $factory->of($arguments[0], $arguments[1])->times($arguments[2] ?? null);
         }
         if (isset($arguments[1])) {

--- a/web/index.php
+++ b/web/index.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use OpenCFP\Application;
 use OpenCFP\Environment;
 
-$basePath    = realpath(dirname(__DIR__));
+$basePath    = \realpath(\dirname(__DIR__));
 $environment = Environment::fromServer($_SERVER);
 
 $app = new Application($basePath, $environment);

--- a/web/index_dev.php
+++ b/web/index_dev.php
@@ -1,7 +1,7 @@
 <?php
 
-$filename = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
-if (PHP_SAPI === 'cli-server' && is_file($filename)) {
+$filename = __DIR__ . \preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
+if (PHP_SAPI === 'cli-server' && \is_file($filename)) {
     return false;
 }
 


### PR DESCRIPTION
This PR

* [x] enables the ```native_function_invocation``` fixer
* [x] runs ```make cs```


:tipping_hand_man: For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

> * ```native_function_invocation```
Add leading ```\``` before function invocation of internal function to speed up resolving.
*Risky rule: risky when any of the functions are overridden.*
Configuration options:
 ```exclude (array)```: list of functions to ignore; defaults to ```[]```

See also : https://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/