### PR TITLE
Bugfix: Allow talks to be deleted again

### DIFF
--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -308,7 +308,7 @@ class TalkController extends BaseController
         }
 
         $userId = $this->service(Authentication::class)->userId();
-        $talk   = Talk::find($req->get('tid'), ['user_id']);
+        $talk   = Talk::find($req->get('tid'));
 
         if ((int) $talk->user_id !==  $userId) {
             return $this->app->json(['delete' => 'no']);


### PR DESCRIPTION
This PR

* [x] Fixes the bug that made a speaker unable to delete their own talk

The bug was introduced in https://github.com/opencfp/opencfp/commit/b0563ebef6acbac6a0ccb90750390a5a376c290b (by me)