### PR TITLE
Enhancement: Enable combine_consecutive_unsets fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -18,6 +18,7 @@ return PhpCsFixer\Config::create()
         'blank_line_after_opening_tag' => true,
         'blank_line_before_statement' => true,
         'cast_spaces' => true,
+        'combine_consecutive_unsets' => true,
         'concat_space' => [
             'spacing' => 'one',
         ],

--- a/classes/Http/Controller/BaseController.php
+++ b/classes/Http/Controller/BaseController.php
@@ -109,7 +109,6 @@ abstract class BaseController
             throw ValidationException::withErrors(array_flatten($validator->errors()->toArray()));
         }
 
-        unset($validation);
-        unset($validator);
+        unset($validation, $validator);
     }
 }


### PR DESCRIPTION
This PR

* [x] enables the `combine_consecutive_unsets` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**combine_consecutive_unsets**
>
>Calling `unset` on multiple items should be done in one call.