### PR TITLE
Enhancement: Enable self_accessor fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -57,6 +57,7 @@ return PhpCsFixer\Config::create()
         'php_unit_test_class_requires_covers' => true,
         'psr0' => false,
         'return_type_declaration' => true,
+        'self_accessor' => true,
         'single_blank_line_before_namespace' => true,
         'single_quote' => true,
         'ternary_operator_spaces' => true,

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -90,7 +90,7 @@ class Environment
         return new self($type);
     }
 
-    public function equals(Environment $environment): bool
+    public function equals(self $environment): bool
     {
         return $this->type === $environment->type;
     }


### PR DESCRIPTION
This PR

* [x] enables the `self_accessor` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**self_accessor** [`@Symfony`]
>
>Inside a classy element "self" should be preferred to the class name itself.