### PR TITLE
Enhancement: Enable phpdoc_no_alias_tag fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -45,6 +45,7 @@ return PhpCsFixer\Config::create()
         'ordered_imports' => true,
         'phpdoc_align' => true,
         'phpdoc_indent' => true,
+        'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_order' => true,

--- a/classes/ContainerAware.php
+++ b/classes/ContainerAware.php
@@ -4,7 +4,7 @@ namespace OpenCFP;
 
 /**
  * @deprecated
- * @link https://qafoo.com/blog/057_containeraware_considered_harmful.html
+ * @see https://qafoo.com/blog/057_containeraware_considered_harmful.html
  */
 trait ContainerAware
 {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_no_alias_tag` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**phpdoc_no_alias_tag** [`@Symfony`]
>
>No alias PHPDoc tags should be used.
>
>Configuration options:
>
>* `replacements` (`array`): mapping between replaced annotations with new ones; defaults to `['property-read' => 'property', 'property-write' => 'property', 'type' => 'var', 'link' => 'see']`