### PR TITLE
Fix: Catch appropriate exception

### DIFF
--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -3,6 +3,7 @@
 namespace OpenCFP\Console\Command;
 
 use OpenCFP\Domain\Services;
+use OpenCFP\Infrastructure\Auth;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -61,7 +62,7 @@ final class UserCreateCommand extends Command
                 $data['password'],
                 $data
             );
-        } catch (Sentry\Users\UserExistsException $exception) {
+        } catch (Auth\UserExistsException $exception) {
             $io->error(\sprintf(
                 'A user with the login "%s" already exists.',
                 $data['email']

--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -5,7 +5,6 @@ namespace OpenCFP\Test\Unit\Console\Command;
 use OpenCFP\Console\Command\UserCreateCommand;
 use OpenCFP\Domain\Services;
 use OpenCFP\Infrastructure\Auth;
-use OpenCFP\Infrastructure\Auth\UserExistsException;
 use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
@@ -165,7 +164,7 @@ final class UserCreateCommandTest extends Framework\TestCase
                     'password'   => $password,
                 ])
             )
-            ->willThrowException(new UserExistsException());
+            ->willThrowException(new Auth\UserExistsException());
 
         $command = new UserCreateCommand($accountManagement);
 


### PR DESCRIPTION
This PR

* [x] catches the appropriate exception in `UserCreateCommand`

Follows #624.