### PR TITLE
Enhancement: Enable phpdoc_annotation_without_dot fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -46,6 +46,7 @@ return PhpCsFixer\Config::create()
         'no_useless_return' => true,
         'ordered_imports' => true,
         'phpdoc_align' => true,
+        'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,

--- a/classes/Domain/CallForProposal.php
+++ b/classes/Domain/CallForProposal.php
@@ -26,7 +26,7 @@ class CallForProposal
     /**
      * @param \DateTimeInterface $currentTime
      *
-     * @return bool true if CFP is open, false otherwise.
+     * @return bool true if CFP is open, false otherwise
      */
     public function isOpen(\DateTimeInterface $currentTime = null): bool
     {

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -41,7 +41,7 @@ class Talk extends Eloquent
     /**
      * Returns the most recent talks
      *
-     * @param int $limit maximum ammount of entries to return.
+     * @param int $limit maximum ammount of entries to return
      */
     public function scopeRecent(Builder $query, int $limit = 10): Builder
     {
@@ -176,7 +176,7 @@ class Talk extends Eloquent
      *
      * @param int  $userId
      * @param bool $willCreate on true it will create a new model if it doesn't exists, on false
-     *                         it will throw an error.
+     *                         it will throw an error
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      *

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -24,7 +24,7 @@ class SpeakerProfile
 
     /**
      * @param $speaker
-     * @param array $hiddenProperties This is a blacklist, telling the view what fields it isn't allowed to show.
+     * @param array $hiddenProperties this is a blacklist, telling the view what fields it isn't allowed to show
      */
     public function __construct(User $speaker, array $hiddenProperties = [])
     {

--- a/classes/Domain/Speaker/SpeakerRepository.php
+++ b/classes/Domain/Speaker/SpeakerRepository.php
@@ -14,7 +14,7 @@ interface SpeakerRepository
      *
      * @throws EntityNotFoundException
      *
-     * @return User the speaker that matches given identifier.
+     * @return User the speaker that matches given identifier
      */
     public function findById($speakerId);
 

--- a/classes/Domain/Talk/TalkSubmission.php
+++ b/classes/Domain/Talk/TalkSubmission.php
@@ -79,7 +79,7 @@ class TalkSubmission
      *
      * @param $type
      *
-     * @return bool true if it is valid, false otherwise.
+     * @return bool true if it is valid, false otherwise
      */
     private function isValidTalkType($type)
     {

--- a/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
@@ -26,7 +26,7 @@ class IlluminateSpeakerRepository implements SpeakerRepository
      *
      * @throws EntityNotFoundException
      *
-     * @return User the speaker that matches given identifier.
+     * @return User the speaker that matches given identifier
      */
     public function findById($speakerId)
     {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_annotation_without_dot` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**phpdoc_annotation_without_dot** [`@Symfony`]
>
>Phpdocs annotation descriptions should not be a sentence.