### PR TITLE
Reset password template was including a non-existant layout

### DIFF
--- a/resources/views/user/reset_password.twig
+++ b/resources/views/user/reset_password.twig
@@ -1,4 +1,4 @@
-{% extends "layouts/dashboard.twig" %}
+{% extends "layouts/default.twig" %}
 {% block content %}
     <h2 class="headline">Reset My Password</h2>
     {% include "forms/_reset_password.twig" %}

--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -141,6 +141,9 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertFalse($option->isArray());
     }
 
+    /**
+     * @expectedException OpenCFP\Infrastructure\Auth\UserExistsException
+     */
     public function testExecuteFailsIfUserExists()
     {
         $faker = $this->getFaker();


### PR DESCRIPTION
This PR

* [x] fixes an error where the rest password template was including a non-existent layout
