### PR TITLE
Fix: Do not return boolean from persist()

### DIFF
--- a/classes/Domain/Speaker/SpeakerRepository.php
+++ b/classes/Domain/Speaker/SpeakerRepository.php
@@ -22,8 +22,6 @@ interface SpeakerRepository
      * Saves a speaker and their talks.
      *
      * @param $speaker
-     *
-     * @return mixed
      */
     public function persist($speaker);
 }

--- a/classes/Domain/Talk/TalkRepository.php
+++ b/classes/Domain/Talk/TalkRepository.php
@@ -6,8 +6,6 @@ interface TalkRepository
 {
     /**
      * @param $talk
-     *
-     * @return mixed
      */
     public function persist($talk);
 }

--- a/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
@@ -43,11 +43,9 @@ class IlluminateSpeakerRepository implements SpeakerRepository
      * Saves a speaker and their talks.
      *
      * @param  $speaker
-     *
-     * @return mixed
      */
     public function persist($speaker)
     {
-        return $speaker->save();
+        $speaker->save();
     }
 }

--- a/classes/Infrastructure/Persistence/IlluminateTalkRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateTalkRepository.php
@@ -9,11 +9,9 @@ class IlluminateTalkRepository implements TalkRepository
 {
     /**
      * @param Talk $talk
-     *
-     * @return mixed
      */
     public function persist($talk)
     {
-        return $talk->save();
+        $talk->save();
     }
 }

--- a/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
@@ -87,7 +87,9 @@ class IlluminateSpeakerRepositoryTest extends BaseTestCase
 
         //User hasn't been saved yet.
         $this->assertSame(0, User::count());
-        $this->assertTrue($repo->persist($user));
+
+        $repo->persist($user);
+
         $this->assertSame(1, User::count());
     }
 }


### PR DESCRIPTION
This PR

* [x] stops passing through what `save()` returns

Follows https://github.com/opencfp/opencfp/pull/744#discussion_r153315056.