### PR TITLE
Fix: Path should be a string

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -38,11 +38,7 @@ use Twig_Environment;
 
 class Application extends SilexApplication
 {
-    /**
-     * @param array       $basePath
-     * @param Environment $environment
-     */
-    public function __construct($basePath, Environment $environment)
+    public function __construct(string $basePath, Environment $environment)
     {
         parent::__construct();
 


### PR DESCRIPTION
This PR

* [x] uses a type declaration and removes a docblock from the constructor of `OpenCFP\Application`