### PR TITLE
Fix: Remove dependency on BASE_PATH constant

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -40,7 +40,7 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 
     public function createApplication(): Application
     {
-        $app                 = new Application(BASE_PATH, Environment::testing());
+        $app                 = new Application(__DIR__ . '/..', Environment::testing());
         $app['session.test'] = true;
 
         return $app;

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -18,7 +18,7 @@ class ForgotControllerTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->app                 = new Application(BASE_PATH, Environment::testing());
+        $this->app                 = new Application(__DIR__ . '/../../../..', Environment::testing());
         $this->app['session.test'] = true;
         \ob_start();
         $this->app->run();

--- a/tests/Integration/phpunit.xml.dist
+++ b/tests/Integration/phpunit.xml.dist
@@ -13,9 +13,6 @@
     stopOnFailure="false"
     verbose="true"
 >
-    <php>
-        <const name="BASE_PATH" value="."/>
-    </php>
     <testsuites>
         <testsuite name="Integration Tests">
             <directory>.</directory>

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -19,7 +19,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
      */
     public function it_should_run_and_have_output()
     {
-        $this->sut                 = new Application(BASE_PATH, Environment::testing());
+        $this->sut                 = new Application(__DIR__ . '/../..', Environment::testing());
         $this->sut['session.test'] = true;
 
         // We start an output buffer because the Application sends its response to
@@ -34,7 +34,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_should_resolve_configuration_path_based_on_environment()
     {
-        $this->sut = new Application(BASE_PATH, Environment::testing());
+        $this->sut = new Application(__DIR__ . '/../..', Environment::testing());
 
         $this->assertTrue($this->sut['env']->isTesting());
         $this->assertContains('testing.yml', $this->sut['path']->configPath());
@@ -45,7 +45,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
      */
     public function itIsNotDevOrProdWhenTesting()
     {
-        $app = new Application(BASE_PATH, Environment::testing());
+        $app = new Application(__DIR__ . '/../..', Environment::testing());
 
         $this->assertTrue($app['env']->isTesting());
         $this->assertFalse($app['env']->isDevelopment());

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -22,21 +22,21 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
 
     public function testIsConsoleApplication()
     {
-        $application = new Application(new \OpenCFP\Application(BASE_PATH, Environment::testing()));
+        $application = new Application(new \OpenCFP\Application(__DIR__ . '/../../..', Environment::testing()));
 
         $this->assertInstanceOf(Console\Application::class, $application);
     }
 
     public function testConstructorSetsName()
     {
-        $application = new Application(new \OpenCFP\Application(BASE_PATH, Environment::testing()));
+        $application = new Application(new \OpenCFP\Application(__DIR__ . '/../../..', Environment::testing()));
 
         $this->assertSame('OpenCFP', $application->getName());
     }
 
     public function testConstructorAddsInputOptionForEnvironment()
     {
-        $application = new Application(new \OpenCFP\Application(BASE_PATH, Environment::testing()));
+        $application = new Application(new \OpenCFP\Application(__DIR__ . '/../../..', Environment::testing()));
 
         $inputDefinition = $application->getDefinition();
 
@@ -51,7 +51,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
 
     public function testConstructorSetsApplication()
     {
-        $baseApp     = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $baseApp     = new \OpenCFP\Application(__DIR__ . '/../../..', Environment::testing());
         $application = new Application($baseApp);
 
         $this->assertAttributeSame($baseApp, 'app', $application);
@@ -59,7 +59,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
 
     public function testHasDefaultCommands()
     {
-        $appContainer = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $appContainer = new \OpenCFP\Application(__DIR__ . '/../../..', Environment::testing());
         $application  = new Application($appContainer);
 
         $expected = [
@@ -94,7 +94,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
          */
         $accounts = Mockery::mock(AccountManagement::class);
         $accounts->shouldReceive('findByLogin')->andThrow(UserExistsException::class);
-        $app                           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app                           = new \OpenCFP\Application(__DIR__ . '/../../..', Environment::testing());
         $app[AccountManagement::class] = $accounts;
 
         // Create our command object and inject our application
@@ -118,7 +118,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $user->shouldReceive('hasAccess')->with('admin')->andReturn(false);
         $accounts = Mockery::mock(AccountManagement::class);
         $accounts->shouldReceive('findByLogin')->andReturn($user);
-        $app                           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app                           = new \OpenCFP\Application(__DIR__ . '/../../..', Environment::testing());
         $app[AccountManagement::class] = $accounts;
 
         // Create our command object and inject our application
@@ -150,7 +150,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
             ->with('test@opencfp.dev', 'Admin');
 
         // Create our command object and inject our application
-        $app                           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app                           = new \OpenCFP\Application(__DIR__ . '/../../..', Environment::testing());
         $app[AccountManagement::class] = $accounts;
         $command                       = new \OpenCFP\Console\Command\AdminDemoteCommand();
         $command->setApp($app);

--- a/tests/Unit/Console/Command/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/AdminPromoteCommandTest.php
@@ -28,7 +28,7 @@ class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
 
         $accounts = Mockery::mock(AccountManagement::class);
         $accounts->shouldReceive('findByLogin')->andThrow(new UserExistsException());
-        $app                           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app                           = new \OpenCFP\Application(__DIR__ . '/../../../..', Environment::testing());
         $app[AccountManagement::class] = $accounts;
 
         // Create our command object and inject our application
@@ -68,7 +68,7 @@ class AdminPromoteCommandTest extends \PHPUnit\Framework\TestCase
             ->with('test@opencfp.dev', 'Admin');
 
         // Create our command object and inject our application
-        $app                           = new \OpenCFP\Application(BASE_PATH, Environment::testing());
+        $app                           = new \OpenCFP\Application(__DIR__ . '/../../../..', Environment::testing());
         $app[AccountManagement::class] = $accounts;
         $command                       = new \OpenCFP\Console\Command\AdminPromoteCommand();
         $command->setApp($app);

--- a/tests/Unit/Provider/SentinelServiceProviderTest.php
+++ b/tests/Unit/Provider/SentinelServiceProviderTest.php
@@ -15,7 +15,7 @@ class SentinelServiceProviderTest extends \PHPUnit\Framework\TestCase
     {
         //The Reminder and Throttle repositories aren't set in the controller.
         //This allows us to make sure they are properly set
-        $app                 = new Application(BASE_PATH, Environment::testing());
+        $app                 = new Application(__DIR__ . '/../../..', Environment::testing());
         $app['session.test'] = true;
         /** @var Sentinel $sentinel */
         $sentinel = $app[Sentinel::class];

--- a/tests/Unit/phpunit.xml.dist
+++ b/tests/Unit/phpunit.xml.dist
@@ -13,9 +13,6 @@
     processIsolation="false"
     stopOnFailure="false"
 >
-    <php>
-        <const name="BASE_PATH" value="."/>
-    </php>
     <filter>
         <whitelist>
             <directory>../../classes</directory>


### PR DESCRIPTION
This PR

* [x] removes the dependency on the `BASE_PATH` constant in integration and unit tests

💁‍♂️ Currently cannot run a single unit tests from within PhpStorm without configuring the working directory. Also, PhpStorm doesn't provide support for constants declared within `phpunit.xml`, so this is much more helpful.