### PR TITLE
Fix: capitalization error

### DIFF
--- a/classes/Http/Controller/Reviewer/DashboardController.php
+++ b/classes/Http/Controller/Reviewer/DashboardController.php
@@ -10,7 +10,7 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Http\Controller\BaseController;
 
-class DashBoardController extends BaseController
+class DashboardController extends BaseController
 {
     public function indexAction()
     {

--- a/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
@@ -26,8 +26,8 @@ class DashboardControllerTest extends WebTestCase
      */
     public function indexDisplaysListOfTalks()
     {
-        $this->asAdmin()
-            ->get('/admin/')
+        $this->asReviewer()
+            ->get('/reviewer/')
             ->assertSee(self::$talks->first()->title)
             ->assertSuccessful()
             ->assertNoFlashSet();


### PR DESCRIPTION
This PR

* [x] Fixes a capitalisation error in the reviewer dashboard controller filename & class name
 
Some deployment environments would error because they couldn't find the class as described in the web gateway provider.

This also fixes the reviewers dashboard controller test which was checking the admin controller instead.