### PR TITLE
Enhancement: Enable header_comment fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,16 @@
 <?php
 
+$year = date('Y');
+
+$header = <<<TXT
+Copyright (c) 2013-$year OpenCFP
+
+For the full copyright and license information, please view
+the LICENSE file that was distributed with this source code.
+
+@see https://github.com/opencfp/opencfp
+TXT;
+
 $finder = PhpCsFixer\Finder::create()
     ->exclude('migrations')
     ->in(__DIR__);
@@ -24,6 +35,10 @@ return PhpCsFixer\Config::create()
         ],
         'function_to_constant' => true,
         'function_typehint_space' => true,
+        'header_comment' => [
+            'commentType' => 'PHPDoc',
+            'header' => $header,
+        ],
         'increment_style' => true,
         'is_null' => [
             'use_yoda_style' => false,

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP;
 
 use Illuminate\Database\Capsule\Manager as Capsule;

--- a/classes/Application/NotAuthorizedException.php
+++ b/classes/Application/NotAuthorizedException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Application;
 
 class NotAuthorizedException extends \Exception

--- a/classes/Application/Speakers.php
+++ b/classes/Application/Speakers.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Application;
 
 use OpenCFP\Domain\CallForProposal;

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Console;
 
 use OpenCFP\Application as ApplicationContainer;

--- a/classes/Console/BaseCommand.php
+++ b/classes/Console/BaseCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Console;
 
 use OpenCFP\Application as ApplicationContainer;

--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Console\Command;
 
 use OpenCFP\Console\BaseCommand;

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Console\Command;
 
 use OpenCFP\Console\BaseCommand;

--- a/classes/Console/Command/ClearCacheCommand.php
+++ b/classes/Console/Command/ClearCacheCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Console\Command;
 
 use OpenCFP\Console\BaseCommand;

--- a/classes/Console/Command/ReviewerDemoteCommand.php
+++ b/classes/Console/Command/ReviewerDemoteCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Console\Command;
 
 use OpenCFP\Console\BaseCommand;

--- a/classes/Console/Command/ReviewerPromoteCommand.php
+++ b/classes/Console/Command/ReviewerPromoteCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Console\Command;
 
 use OpenCFP\Console\BaseCommand;

--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Console\Command;
 
 use OpenCFP\Domain\Services;

--- a/classes/ContainerAware.php
+++ b/classes/ContainerAware.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP;
 
 /**

--- a/classes/Domain/CallForProposal.php
+++ b/classes/Domain/CallForProposal.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain;
 
 /**

--- a/classes/Domain/EntityNotFoundException.php
+++ b/classes/Domain/EntityNotFoundException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain;
 
 class EntityNotFoundException extends \Exception

--- a/classes/Domain/Model/Airport.php
+++ b/classes/Domain/Model/Airport.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Model;
 
 use OpenCFP\Domain\Services\AirportInformationDatabase;

--- a/classes/Domain/Model/Eloquent.php
+++ b/classes/Domain/Model/Eloquent.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Model;

--- a/classes/Domain/Model/Favorite.php
+++ b/classes/Domain/Model/Favorite.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Builder;

--- a/classes/Domain/Model/TalkComment.php
+++ b/classes/Domain/Model/TalkComment.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/classes/Domain/Model/TalkMeta.php
+++ b/classes/Domain/Model/TalkMeta.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Model;
 
 use Illuminate\Database\Eloquent\Builder;

--- a/classes/Domain/Services/AccountManagement.php
+++ b/classes/Domain/Services/AccountManagement.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use OpenCFP\Infrastructure\Auth\UserInterface;

--- a/classes/Domain/Services/AirportInformationDatabase.php
+++ b/classes/Domain/Services/AirportInformationDatabase.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use OpenCFP\Domain\Model\Airport;

--- a/classes/Domain/Services/Authentication.php
+++ b/classes/Domain/Services/Authentication.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use OpenCFP\Infrastructure\Auth\UserInterface;

--- a/classes/Domain/Services/AuthenticationException.php
+++ b/classes/Domain/Services/AuthenticationException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 class AuthenticationException extends \Exception

--- a/classes/Domain/Services/EventDispatcher.php
+++ b/classes/Domain/Services/EventDispatcher.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyEventDispatcher;

--- a/classes/Domain/Services/IdentityProvider.php
+++ b/classes/Domain/Services/IdentityProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use OpenCFP\Domain\Model\User;

--- a/classes/Domain/Services/NotAuthenticatedException.php
+++ b/classes/Domain/Services/NotAuthenticatedException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 class NotAuthenticatedException extends \Exception

--- a/classes/Domain/Services/Pagination.php
+++ b/classes/Domain/Services/Pagination.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use Pagerfanta\Pagerfanta;

--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use Intervention\Image\ImageManagerStatic as Image;

--- a/classes/Domain/Services/RandomStringGenerator.php
+++ b/classes/Domain/Services/RandomStringGenerator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 interface RandomStringGenerator

--- a/classes/Domain/Services/RequestValidator.php
+++ b/classes/Domain/Services/RequestValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use Symfony\Component\HttpFoundation\Request;

--- a/classes/Domain/Services/ResetEmailer.php
+++ b/classes/Domain/Services/ResetEmailer.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 class ResetEmailer

--- a/classes/Domain/Services/TalkFormat.php
+++ b/classes/Domain/Services/TalkFormat.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use Illuminate\Support\Collection;

--- a/classes/Domain/Services/TalkRating/TalkRating.php
+++ b/classes/Domain/Services/TalkRating/TalkRating.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services\TalkRating;
 
 use Illuminate\Database\Eloquent\Model;

--- a/classes/Domain/Services/TalkRating/TalkRatingContext.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingContext.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services\TalkRating;
 
 use OpenCFP\Domain\Model\TalkMeta;

--- a/classes/Domain/Services/TalkRating/TalkRatingException.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services\TalkRating;
 
 class TalkRatingException extends \RuntimeException

--- a/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services\TalkRating;
 
 interface TalkRatingStrategy

--- a/classes/Domain/Services/TalkRating/YesNoRating.php
+++ b/classes/Domain/Services/TalkRating/YesNoRating.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services\TalkRating;
 
 class YesNoRating extends TalkRating

--- a/classes/Domain/Services/UserAccess.php
+++ b/classes/Domain/Services/UserAccess.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Services;
 
 use Silex\Application;

--- a/classes/Domain/Speaker/NotAllowedException.php
+++ b/classes/Domain/Speaker/NotAllowedException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Speaker;
 
 class NotAllowedException extends \Exception

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Speaker;
 
 use OpenCFP\Domain\Model\Talk;

--- a/classes/Domain/Speaker/SpeakerRepository.php
+++ b/classes/Domain/Speaker/SpeakerRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Speaker;
 
 use OpenCFP\Domain\EntityNotFoundException;

--- a/classes/Domain/Talk/InvalidTalkSubmissionException.php
+++ b/classes/Domain/Talk/InvalidTalkSubmissionException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Talk;
 
 use OpenCFP\Domain\ValidationException;

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Talk;
 
 use OpenCFP\Domain\Model\Talk;

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Talk;
 
 use Illuminate\Support\Collection;

--- a/classes/Domain/Talk/TalkHandler.php
+++ b/classes/Domain/Talk/TalkHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Talk;
 
 use OpenCFP\Domain\Model\Favorite;

--- a/classes/Domain/Talk/TalkProfile.php
+++ b/classes/Domain/Talk/TalkProfile.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Talk;
 
 use Illuminate\Support\Collection;

--- a/classes/Domain/Talk/TalkRepository.php
+++ b/classes/Domain/Talk/TalkRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Talk;
 
 use OpenCFP\Domain\Model\Talk;

--- a/classes/Domain/Talk/TalkSubmission.php
+++ b/classes/Domain/Talk/TalkSubmission.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Talk;
 
 use OpenCFP\Domain\Model\Talk;

--- a/classes/Domain/Talk/TalkWasSubmitted.php
+++ b/classes/Domain/Talk/TalkWasSubmitted.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain\Talk;
 
 use OpenCFP\Domain\Model\Talk;

--- a/classes/Domain/ValidationException.php
+++ b/classes/Domain/ValidationException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Domain;
 
 class ValidationException extends \Exception

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP;
 
 class Environment

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller\Admin;
 
 use Illuminate\Database\Eloquent\Collection;

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Talk;

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller\Admin;
 
 use Illuminate\Database\Capsule\Manager as Capsule;

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Domain\Services\Authentication;

--- a/classes/Http/Controller/BaseController.php
+++ b/classes/Http/Controller/BaseController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller;
 
 use Illuminate\Container\Container;

--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Application\Speakers;

--- a/classes/Http/Controller/FlashableTrait.php
+++ b/classes/Http/Controller/FlashableTrait.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller;
 
 use Silex\Application;

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Domain\Services\AccountManagement;

--- a/classes/Http/Controller/PagesController.php
+++ b/classes/Http/Controller/PagesController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Domain\Model\Talk;

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Domain\Model\User;

--- a/classes/Http/Controller/Reviewer/DashboardController.php
+++ b/classes/Http/Controller/Reviewer/DashboardController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller\Reviewer;
 
 use Illuminate\Support\Collection;

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller\Reviewer;
 
 use OpenCFP\Domain\Model\User;

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller\Reviewer;
 
 use OpenCFP\Domain\Services\Authentication;

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Domain\Services\Authentication;

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Domain\Services\AccountManagement;

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Application\NotAuthorizedException;

--- a/classes/Http/Form/ForgotForm.php
+++ b/classes/Http/Form/ForgotForm.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Form;
 
 abstract class Form

--- a/classes/Http/Form/ResetForm.php
+++ b/classes/Http/Form/ResetForm.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Form;
 
 /**

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\Form;
 
 /**

--- a/classes/Http/View/TalkHelper.php
+++ b/classes/Http/View/TalkHelper.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Http\View;
 
 class TalkHelper

--- a/classes/Infrastructure/Auth/CsrfValidator.php
+++ b/classes/Infrastructure/Auth/CsrfValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use OpenCFP\Domain\Services\RequestValidator;

--- a/classes/Infrastructure/Auth/RoleAccess.php
+++ b/classes/Infrastructure/Auth/RoleAccess.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use OpenCFP\Domain\Services\Authentication;

--- a/classes/Infrastructure/Auth/SentinelAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentinelAccountManagement.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/classes/Infrastructure/Auth/SentinelAuthentication.php
+++ b/classes/Infrastructure/Auth/SentinelAuthentication.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/classes/Infrastructure/Auth/SentinelIdentityProvider.php
+++ b/classes/Infrastructure/Auth/SentinelIdentityProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/classes/Infrastructure/Auth/SentinelUser.php
+++ b/classes/Infrastructure/Auth/SentinelUser.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/classes/Infrastructure/Auth/SentryAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentryAccountManagement.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;

--- a/classes/Infrastructure/Auth/SentryAuthentication.php
+++ b/classes/Infrastructure/Auth/SentryAuthentication.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;

--- a/classes/Infrastructure/Auth/SentryIdentityProvider.php
+++ b/classes/Infrastructure/Auth/SentryIdentityProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;

--- a/classes/Infrastructure/Auth/SentryUser.php
+++ b/classes/Infrastructure/Auth/SentryUser.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 class SentryUser implements UserInterface

--- a/classes/Infrastructure/Auth/SpeakerAccess.php
+++ b/classes/Infrastructure/Auth/SpeakerAccess.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 use OpenCFP\Domain\Services\Authentication;

--- a/classes/Infrastructure/Auth/UserExistsException.php
+++ b/classes/Infrastructure/Auth/UserExistsException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 class UserExistsException extends \UnexpectedValueException

--- a/classes/Infrastructure/Auth/UserInterface.php
+++ b/classes/Infrastructure/Auth/UserInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 /**

--- a/classes/Infrastructure/Auth/UserNotFoundException.php
+++ b/classes/Infrastructure/Auth/UserNotFoundException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Auth;
 
 final class UserNotFoundException extends \RuntimeException

--- a/classes/Infrastructure/Crypto/PseudoRandomStringGenerator.php
+++ b/classes/Infrastructure/Crypto/PseudoRandomStringGenerator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Crypto;
 
 use OpenCFP\Domain\Services\RandomStringGenerator;

--- a/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Persistence;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;

--- a/classes/Infrastructure/Persistence/IlluminateTalkRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateTalkRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Infrastructure\Persistence;
 
 use OpenCFP\Domain\Model\Talk;

--- a/classes/Path.php
+++ b/classes/Path.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP;
 
 final class Path

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/classes/Provider/CallForProposalProvider.php
+++ b/classes/Provider/CallForProposalProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use OpenCFP\Domain\CallForProposal;

--- a/classes/Provider/ControllerResolver.php
+++ b/classes/Provider/ControllerResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use OpenCFP\Http\Controller\BaseController;

--- a/classes/Provider/ControllerResolverServiceProvider.php
+++ b/classes/Provider/ControllerResolverServiceProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use Pimple\Container;

--- a/classes/Provider/Gateways/RequestCleaner.php
+++ b/classes/Provider/Gateways/RequestCleaner.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider\Gateways;
 
 use HTMLPurifier;

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider\Gateways;
 
 use OpenCFP\Domain\Services\Authentication;

--- a/classes/Provider/HtmlPurifierServiceProvider.php
+++ b/classes/Provider/HtmlPurifierServiceProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use HTMLPurifier;

--- a/classes/Provider/ImageProcessorProvider.php
+++ b/classes/Provider/ImageProcessorProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use OpenCFP\Domain\Services\ProfileImageProcessor;

--- a/classes/Provider/ResetEmailerServiceProvider.php
+++ b/classes/Provider/ResetEmailerServiceProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use OpenCFP\Domain\Services\ResetEmailer;

--- a/classes/Provider/SentinelServiceProvider.php
+++ b/classes/Provider/SentinelServiceProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use Cartalyst\Sentinel\Activations\IlluminateActivationRepository;

--- a/classes/Provider/SentryServiceProvider.php
+++ b/classes/Provider/SentryServiceProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use Cartalyst\Sentry\Facades\Native\Sentry;

--- a/classes/Provider/SymfonySentinelSession.php
+++ b/classes/Provider/SymfonySentinelSession.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use Cartalyst\Sentinel\Sessions\SessionInterface as SentinelSessionInterface;

--- a/classes/Provider/SymfonySentrySession.php
+++ b/classes/Provider/SymfonySentrySession.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use Cartalyst\Sentry\Sessions\SessionInterface as SentrySessionInterface;

--- a/classes/Provider/TalkFilterProvider.php
+++ b/classes/Provider/TalkFilterProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use OpenCFP\Domain\Model\Talk;

--- a/classes/Provider/TalkHandlerProvider.php
+++ b/classes/Provider/TalkHandlerProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use OpenCFP\Domain\Services\Authentication;

--- a/classes/Provider/TalkHelperProvider.php
+++ b/classes/Provider/TalkHelperProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use OpenCFP\Http\View\TalkHelper;

--- a/classes/Provider/TalkRatingProvider.php
+++ b/classes/Provider/TalkRatingProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use OpenCFP\Domain\Services\Authentication;

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use Aptoma\Twig\Extension\MarkdownEngine;

--- a/classes/Provider/YamlConfigDriver.php
+++ b/classes/Provider/YamlConfigDriver.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Provider;
 
 use Symfony\Component\Yaml\Yaml;

--- a/factories/Common.php
+++ b/factories/Common.php
@@ -1,6 +1,14 @@
 <?php
 
-/** @var $factory \Illuminate\Database\Eloquent\Factory */
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 $factory->define(\OpenCFP\Domain\Model\User::class, function (\Faker\Generator $faker) {
     return [
         'email'          => $faker->unique()->safeEmail,

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 return [
 
     /*

--- a/server.php
+++ b/server.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 \define('WEB_PATH', __DIR__ . '/web/');
 
 $path = WEB_PATH . $_SERVER['REQUEST_URI'];

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/tests/Helper/DataBaseInteraction.php
+++ b/tests/Helper/DataBaseInteraction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Helper;
 
 use Illuminate\Database\Capsule\Manager;

--- a/tests/Helper/Faker/GeneratorTrait.php
+++ b/tests/Helper/Faker/GeneratorTrait.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Helper\Faker;
 
 use Faker\Factory;

--- a/tests/Helper/RefreshDatabase.php
+++ b/tests/Helper/RefreshDatabase.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Helper;
 
 use Illuminate\Database\Capsule\Manager;

--- a/tests/Helper/SentryTestHelpers.php
+++ b/tests/Helper/SentryTestHelpers.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Helper;
 
 use OpenCFP\Provider\SymfonySentrySession;

--- a/tests/Integration/Domain/Model/AirportTest.php
+++ b/tests/Integration/Domain/Model/AirportTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Domain\Model;
 
 use OpenCFP\Domain\Model\Airport;

--- a/tests/Integration/Domain/Model/Interaction/TalkTest.php
+++ b/tests/Integration/Domain/Model/Interaction/TalkTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Domain\Model\Interaction;
 
 use OpenCFP\Domain\Model\Favorite;

--- a/tests/Integration/Domain/Model/Interaction/UserTest.php
+++ b/tests/Integration/Domain/Model/Interaction/UserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Domain\Model\Interaction;
 
 use OpenCFP\Domain\Model\Talk;

--- a/tests/Integration/Domain/Model/TalkMetaTest.php
+++ b/tests/Integration/Domain/Model/TalkMetaTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Domain\Model;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/tests/Integration/Domain/Model/TalkTest.php
+++ b/tests/Integration/Domain/Model/TalkTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Domain\Model;
 
 use OpenCFP\Domain\Model\Favorite;

--- a/tests/Integration/Domain/Model/UserTest.php
+++ b/tests/Integration/Domain/Model/UserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Domain\Model;
 
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/tests/Integration/Domain/Services/TalkFormatterTest.php
+++ b/tests/Integration/Domain/Services/TalkFormatterTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Domain\Services;
 
 use Illuminate\Support\Collection;

--- a/tests/Integration/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Integration/Domain/Talk/TalkHandlerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Domain\Talk;
 
 use Mockery;

--- a/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Talk;

--- a/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Talk;

--- a/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller\Admin;
 
 use Mockery;

--- a/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Talk;

--- a/tests/Integration/Http/Controller/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/DashboardControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller;
 
 use Mockery as m;

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller;
 
 use Mockery as m;

--- a/tests/Integration/Http/Controller/PagesControllerTest.php
+++ b/tests/Integration/Http/Controller/PagesControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller;
 
 use OpenCFP\Test\WebTestCase;

--- a/tests/Integration/Http/Controller/ProfileControllerTest.php
+++ b/tests/Integration/Http/Controller/ProfileControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller;
 
 use OpenCFP\Domain\Model\User;

--- a/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller\Reviewer;
 
 use OpenCFP\Domain\Model\Talk;

--- a/tests/Integration/Http/Controller/Reviewer/SpeakerControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/SpeakerControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller\Reviewer;
 
 use OpenCFP\Domain\Model\User;

--- a/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller\Reviewer;
 
 use OpenCFP\Domain\Model\Talk;

--- a/tests/Integration/Http/Controller/SignupControllerTest.php
+++ b/tests/Integration/Http/Controller/SignupControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller;
 
 use OpenCFP\Test\Helper\RefreshDatabase;

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Http\Controller;
 
 use Mockery as m;

--- a/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Native\Facades\Sentinel;

--- a/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Native\Facades\Sentinel;

--- a/tests/Integration/Infrastructure/Auth/SentinelUserTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelUserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Native\Facades\Sentinel;

--- a/tests/Integration/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Infrastructure\Auth;
 
 use OpenCFP\Infrastructure\Auth\SentryAccountManagement;

--- a/tests/Integration/Infrastructure/Auth/SentryAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentryAuthenticationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Infrastructure\Auth;
 
 use OpenCFP\Infrastructure\Auth\SentryAccountManagement;

--- a/tests/Integration/Infrastructure/Auth/SentryUserTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentryUserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Infrastructure\Auth;
 
 use OpenCFP\Domain\Model\User;

--- a/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Infrastructure\Persistence;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;

--- a/tests/Integration/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration\Infrastructure\Persistence;
 
 use OpenCFP\Domain\Model\Talk;

--- a/tests/Integration/MigrationsTest.php
+++ b/tests/Integration/MigrationsTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Integration;
 
 use Illuminate\Database\Capsule\Manager as Capsule;

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test;
 
 use OpenCFP\Application;

--- a/tests/Unit/Application/NotAuthorizedExceptionTest.php
+++ b/tests/Unit/Application/NotAuthorizedExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Application;
 
 use OpenCFP\Application\NotAuthorizedException;

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Application;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit;
 
 use OpenCFP\Application;

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Console;
 
 use Mockery;

--- a/tests/Unit/Console/Command/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/AdminPromoteCommandTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Console\Command;
 
 use Mockery;

--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Console\Command;
 
 use OpenCFP\Console\Command\UserCreateCommand;

--- a/tests/Unit/ContainerAwareFake.php
+++ b/tests/Unit/ContainerAwareFake.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit;
 
 use OpenCFP\ContainerAware;

--- a/tests/Unit/ContainerAwareTest.php
+++ b/tests/Unit/ContainerAwareTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit;
 
 use Mockery as m;

--- a/tests/Unit/Domain/CallForProposalTest.php
+++ b/tests/Unit/Domain/CallForProposalTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain;
 
 use OpenCFP\Domain\CallForProposal;

--- a/tests/Unit/Domain/EntityNotFoundExceptionTest.php
+++ b/tests/Unit/Domain/EntityNotFoundExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain;
 
 use OpenCFP\Domain\EntityNotFoundException;

--- a/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
+++ b/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Services;
 
 use OpenCFP\Domain\Services\AuthenticationException;

--- a/tests/Unit/Domain/Services/NotAuthenticatedExceptionTest.php
+++ b/tests/Unit/Domain/Services/NotAuthenticatedExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Services;
 
 use OpenCFP\Domain\Services\NotAuthenticatedException;

--- a/tests/Unit/Domain/Services/PaginationTest.php
+++ b/tests/Unit/Domain/Services/PaginationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Services;
 
 use OpenCFP\Domain\Services\Pagination;

--- a/tests/Unit/Domain/Services/ResetEmailerTest.php
+++ b/tests/Unit/Domain/Services/ResetEmailerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Services;
 
 use Mockery;

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Services\TalkRating;
 
 use Mockery;

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Services\TalkRating;
 
 use OpenCFP\Domain\Services\TalkRating\TalkRatingException;

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Services\TalkRating;
 
 use Mockery;

--- a/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Services\TalkRating;
 
 use Mockery;

--- a/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
+++ b/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Speaker;
 
 use OpenCFP\Domain\Speaker\NotAllowedException;

--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Speaker;
 
 use OpenCFP\Domain\Model;

--- a/tests/Unit/Domain/Talk/InvalidTalkSubmissionExceptionTest.php
+++ b/tests/Unit/Domain/Talk/InvalidTalkSubmissionExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Talk;
 
 use OpenCFP\Domain\Talk\InvalidTalkSubmissionException;

--- a/tests/Unit/Domain/Talk/TalkFilterTest.php
+++ b/tests/Unit/Domain/Talk/TalkFilterTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Talk;
 
 use Mockery;

--- a/tests/Unit/Domain/Talk/TalkProfileTest.php
+++ b/tests/Unit/Domain/Talk/TalkProfileTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Talk;
 
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/tests/Unit/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/Unit/Domain/Talk/TalkSubmissionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain\Talk;
 
 use OpenCFP\Domain\Talk\TalkSubmission;

--- a/tests/Unit/Domain/ValidationExceptionTest.php
+++ b/tests/Unit/Domain/ValidationExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Domain;
 
 use OpenCFP\Domain\ValidationException;

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit;
 
 use OpenCFP\Environment;

--- a/tests/Unit/Faker/GeneratorTest.php
+++ b/tests/Unit/Faker/GeneratorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Faker;
 
 use Faker\Generator;

--- a/tests/Unit/Http/Controller/FlashableTraitFake.php
+++ b/tests/Unit/Http/Controller/FlashableTraitFake.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Http\Controller;
 
 use OpenCFP\Http\Controller\FlashableTrait;

--- a/tests/Unit/Http/Controller/FlashableTraitTest.php
+++ b/tests/Unit/Http/Controller/FlashableTraitTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Http\Controller;
 
 use OpenCFP\Application;

--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Http\Form;
 
 use Mockery as m;

--- a/tests/Unit/Http/Form/TalkFormTest.php
+++ b/tests/Unit/Http/Form/TalkFormTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Http\Form;
 
 use OpenCFP\Test\Helper\Faker\GeneratorTrait;

--- a/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
+++ b/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Mockery;

--- a/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Mockery;

--- a/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/tests/Unit/Infrastructure/Auth/SentryAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentryAccountManagementTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;

--- a/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentryIdentityProviderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Cartalyst\Sentry\Sentry;

--- a/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Mockery;

--- a/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use OpenCFP\Infrastructure\Auth\UserExistsException;

--- a/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use OpenCFP\Infrastructure\Auth\UserNotFoundException;

--- a/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Crypto;
 
 use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;

--- a/tests/Unit/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Persistence;
 
 use Illuminate\Database\Eloquent;

--- a/tests/Unit/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Infrastructure\Persistence;
 
 use OpenCFP\Domain\Model;

--- a/tests/Unit/PathTest.php
+++ b/tests/Unit/PathTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit;
 
 use OpenCFP\Environment;

--- a/tests/Unit/Provider/SentinelServiceProviderTest.php
+++ b/tests/Unit/Provider/SentinelServiceProviderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Provider;
 
 use Cartalyst\Sentinel\Sentinel;

--- a/tests/Unit/Provider/SymfonySentinelSessionTest.php
+++ b/tests/Unit/Provider/SymfonySentinelSessionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Provider;
 
 use Mockery;

--- a/tests/Unit/Provider/SymfonySentrySessionTest.php
+++ b/tests/Unit/Provider/SymfonySentrySessionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test\Unit\Provider;
 
 use OpenCFP\Provider\SymfonySentrySession;

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 namespace OpenCFP\Test;
 
 use Mockery;

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Illuminate\Database\Eloquent\Factory;
 
 if (!\function_exists('factory')) {

--- a/web/index.php
+++ b/web/index.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use OpenCFP\Application;

--- a/web/index_dev.php
+++ b/web/index_dev.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 $filename = __DIR__ . \preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
 if (PHP_SAPI === 'cli-server' && \is_file($filename)) {
     return false;


### PR DESCRIPTION
This PR

* [x] enables the `header_comment` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.2#usage:

>**header_comment**
>
>Add, replace or remove header comment.
>
>Configuration options:
>
>* `commentType` (`'comment'`, `'PHPDoc'`): comment syntax type; defaults to `'comment'`
* `header` (`string`): proper header content; required
* `location` (`'after_declare_strict'`, `'after_open'`): the location of the inserted header; defaults to `'after_declare_strict'`
* `separate` (`'both'`, `'bottom'`, `'none'`, `'top'`): whether the header should be separated from the file content with a new line; defaults to `'both'`

@chartjes @mdwheele 

If you want to enable this, this mostly required input from your side what you would like the header comment to look like.