### PR TITLE
Fix: Add return type declarations

### DIFF
--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -56,7 +56,7 @@ class SpeakerProfile
      *
      * @return Talk[]
      */
-    public function getTalks()
+    public function getTalks(): array
     {
         $this->assertAllowedToSee('talks');
 
@@ -152,7 +152,7 @@ class SpeakerProfile
      *
      * @return bool
      */
-    public function getTransportation()
+    public function getTransportation(): bool
     {
         $this->assertAllowedToSee('transportation');
 


### PR DESCRIPTION
This PR

* [x] adds return type declarations to `SpeakerProfile` where possible

Follows #755.