### PR TITLE
Fix: Remove unnecessary ternary

### DIFF
--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -79,7 +79,7 @@ class SpeakerProfile
     {
         $this->assertAllowedToSee('company');
 
-        return $this->speaker->company ?: null;
+        return $this->speaker->company;
     }
 
     public function getTwitter()


### PR DESCRIPTION
This PR

* [x] removes an unnecessary ternary

Follows #755.
