### PR TITLE
Update PHPMD rule set

### DIFF
--- a/PHPMDRuleSet.xml
+++ b/PHPMDRuleSet.xml
@@ -8,10 +8,4 @@
     <rule ref="rulesets/cleancode.xml">
         <exclude name="StaticAccess"/>
     </rule>
-
-    <rule ref="rulesets/cleancode.xml/StaticAccess">
-        <properties>
-            <property name="exceptions" value="\OpenCFP\Domain\Model\Airport,\OpenCFP\Domain\Model\Favorite,\OpenCFP\Domain\Model\Group,\OpenCFP\Domain\Model\Talk,\OpenCFP\Domain\Model\TalkComment,\OpenCFP\Domain\Model\TalkMeta,\OpenCFP\Domain\Model\User,\OpenCFP\Environment" />
-        </properties>
-    </rule>
 </ruleset>


### PR DESCRIPTION
This PR

* [x] Removes the static access rule from PHP MD

So far every instance of this rule being broken is logical, so this makes more sense than adding every single exception/model to a list.

Somewhat related to #763 

I'm making sure this actually does what i expect it to before assigning a reviewer.