### PR TITLE
Enhancement: Enable declare_strict_types fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -33,6 +33,7 @@ return PhpCsFixer\Config::create()
         'concat_space' => [
             'spacing' => 'one',
         ],
+        'declare_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'header_comment' => [

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Application/NotAuthorizedException.php
+++ b/classes/Application/NotAuthorizedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Application/Speakers.php
+++ b/classes/Application/Speakers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Console/BaseCommand.php
+++ b/classes/Console/BaseCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Console/Command/ClearCacheCommand.php
+++ b/classes/Console/Command/ClearCacheCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Console/Command/ReviewerDemoteCommand.php
+++ b/classes/Console/Command/ReviewerDemoteCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Console/Command/ReviewerPromoteCommand.php
+++ b/classes/Console/Command/ReviewerPromoteCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/ContainerAware.php
+++ b/classes/ContainerAware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/CallForProposal.php
+++ b/classes/Domain/CallForProposal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/EntityNotFoundException.php
+++ b/classes/Domain/EntityNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Model/Airport.php
+++ b/classes/Domain/Model/Airport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Model/Eloquent.php
+++ b/classes/Domain/Model/Eloquent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Model/Favorite.php
+++ b/classes/Domain/Model/Favorite.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Model/TalkComment.php
+++ b/classes/Domain/Model/TalkComment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Model/TalkMeta.php
+++ b/classes/Domain/Model/TalkMeta.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Model/User.php
+++ b/classes/Domain/Model/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/AccountManagement.php
+++ b/classes/Domain/Services/AccountManagement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/AirportInformationDatabase.php
+++ b/classes/Domain/Services/AirportInformationDatabase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/Authentication.php
+++ b/classes/Domain/Services/Authentication.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/AuthenticationException.php
+++ b/classes/Domain/Services/AuthenticationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/EventDispatcher.php
+++ b/classes/Domain/Services/EventDispatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/IdentityProvider.php
+++ b/classes/Domain/Services/IdentityProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/NotAuthenticatedException.php
+++ b/classes/Domain/Services/NotAuthenticatedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/Pagination.php
+++ b/classes/Domain/Services/Pagination.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/ProfileImageProcessor.php
+++ b/classes/Domain/Services/ProfileImageProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/RandomStringGenerator.php
+++ b/classes/Domain/Services/RandomStringGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/RequestValidator.php
+++ b/classes/Domain/Services/RequestValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/ResetEmailer.php
+++ b/classes/Domain/Services/ResetEmailer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/TalkFormat.php
+++ b/classes/Domain/Services/TalkFormat.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/TalkRating/TalkRating.php
+++ b/classes/Domain/Services/TalkRating/TalkRating.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/TalkRating/TalkRatingContext.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/TalkRating/TalkRatingException.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
+++ b/classes/Domain/Services/TalkRating/TalkRatingStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/TalkRating/YesNoRating.php
+++ b/classes/Domain/Services/TalkRating/YesNoRating.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Services/UserAccess.php
+++ b/classes/Domain/Services/UserAccess.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Speaker/NotAllowedException.php
+++ b/classes/Domain/Speaker/NotAllowedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Speaker/SpeakerRepository.php
+++ b/classes/Domain/Speaker/SpeakerRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Talk/InvalidTalkSubmissionException.php
+++ b/classes/Domain/Talk/InvalidTalkSubmissionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Talk/TalkHandler.php
+++ b/classes/Domain/Talk/TalkHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Talk/TalkProfile.php
+++ b/classes/Domain/Talk/TalkProfile.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Talk/TalkRepository.php
+++ b/classes/Domain/Talk/TalkRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Talk/TalkSubmission.php
+++ b/classes/Domain/Talk/TalkSubmission.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/Talk/TalkWasSubmitted.php
+++ b/classes/Domain/Talk/TalkWasSubmitted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Domain/ValidationException.php
+++ b/classes/Domain/ValidationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Environment.php
+++ b/classes/Environment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -80,6 +80,10 @@ class ExportsController extends BaseController
      */
     private function csvFormat($info)
     {
+        if (!\is_string($info)) {
+            return $info;
+        }
+        
         if ($this->startsWith($info, '=')
                 || $this->startsWith($info, '+')
                 || $this->startsWith($info, '-')

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -166,8 +166,9 @@ class SpeakersController extends BaseController
         /** @var AccountManagement $accounts */
         $accounts = $this->service(AccountManagement::class);
         $role     = $req->get('role');
+        $id       = (int) $req->get('id');
 
-        if ($this->service(Authentication::class)->userId() == $req->get('id')) {
+        if ($this->service(Authentication::class)->userId() == $id) {
             $this->service('session')->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
@@ -178,7 +179,7 @@ class SpeakersController extends BaseController
         }
 
         try {
-            $user = $accounts->findById($req->get('id'));
+            $user = $accounts->findById($id);
             $accounts->demoteFrom($user->getLogin(), $role);
 
             $this->service('session')->set('flash', [
@@ -202,9 +203,10 @@ class SpeakersController extends BaseController
         /* @var AccountManagement $accounts */
         $accounts = $this->service(AccountManagement::class);
         $role     = $req->get('role');
+        $id       = (int) $req->get('id');
 
         try {
-            $user = $accounts->findById($req->get('id'));
+            $user = $accounts->findById($id);
             if ($user->hasAccess(\strtolower($role))) {
                 $this->service('session')->set('flash', [
                     'type'  => 'error',

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -69,7 +69,7 @@ class TalksController extends BaseController
     {
         /** @var TalkHandler $handler */
         $handler = $this->service(TalkHandler::class)
-            ->grabTalk($req->get('id'));
+            ->grabTalk((int) $req->get('id'));
 
         if (!$handler->view()) {
             $this->service('session')->set('flash', [

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/BaseController.php
+++ b/classes/Http/Controller/BaseController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/FlashableTrait.php
+++ b/classes/Http/Controller/FlashableTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/PagesController.php
+++ b/classes/Http/Controller/PagesController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/Reviewer/DashboardController.php
+++ b/classes/Http/Controller/Reviewer/DashboardController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Form/ForgotForm.php
+++ b/classes/Http/Form/ForgotForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Form/ResetForm.php
+++ b/classes/Http/Form/ResetForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Http/View/TalkHelper.php
+++ b/classes/Http/View/TalkHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/CsrfValidator.php
+++ b/classes/Infrastructure/Auth/CsrfValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/RoleAccess.php
+++ b/classes/Infrastructure/Auth/RoleAccess.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/SentinelAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentinelAccountManagement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/SentinelAuthentication.php
+++ b/classes/Infrastructure/Auth/SentinelAuthentication.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/SentinelIdentityProvider.php
+++ b/classes/Infrastructure/Auth/SentinelIdentityProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/SentinelUser.php
+++ b/classes/Infrastructure/Auth/SentinelUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/SpeakerAccess.php
+++ b/classes/Infrastructure/Auth/SpeakerAccess.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/UserExistsException.php
+++ b/classes/Infrastructure/Auth/UserExistsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/UserInterface.php
+++ b/classes/Infrastructure/Auth/UserInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Auth/UserNotFoundException.php
+++ b/classes/Infrastructure/Auth/UserNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Crypto/PseudoRandomStringGenerator.php
+++ b/classes/Infrastructure/Crypto/PseudoRandomStringGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateSpeakerRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Infrastructure/Persistence/IlluminateTalkRepository.php
+++ b/classes/Infrastructure/Persistence/IlluminateTalkRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Path.php
+++ b/classes/Path.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/CallForProposalProvider.php
+++ b/classes/Provider/CallForProposalProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/ControllerResolver.php
+++ b/classes/Provider/ControllerResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/ControllerResolverServiceProvider.php
+++ b/classes/Provider/ControllerResolverServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/Gateways/RequestCleaner.php
+++ b/classes/Provider/Gateways/RequestCleaner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/HtmlPurifierServiceProvider.php
+++ b/classes/Provider/HtmlPurifierServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/ImageProcessorProvider.php
+++ b/classes/Provider/ImageProcessorProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/ResetEmailerServiceProvider.php
+++ b/classes/Provider/ResetEmailerServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/SentinelServiceProvider.php
+++ b/classes/Provider/SentinelServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/SymfonySentinelSession.php
+++ b/classes/Provider/SymfonySentinelSession.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/TalkFilterProvider.php
+++ b/classes/Provider/TalkFilterProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/TalkHandlerProvider.php
+++ b/classes/Provider/TalkHandlerProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/TalkHelperProvider.php
+++ b/classes/Provider/TalkHelperProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/TalkRatingProvider.php
+++ b/classes/Provider/TalkRatingProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/classes/Provider/YamlConfigDriver.php
+++ b/classes/Provider/YamlConfigDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/factories/Common.php
+++ b/factories/Common.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/server.php
+++ b/server.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Helper/DataBaseInteraction.php
+++ b/tests/Helper/DataBaseInteraction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Helper/Faker/GeneratorTrait.php
+++ b/tests/Helper/Faker/GeneratorTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Helper/RefreshDatabase.php
+++ b/tests/Helper/RefreshDatabase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Domain/Model/AirportTest.php
+++ b/tests/Integration/Domain/Model/AirportTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Domain/Model/Interaction/TalkTest.php
+++ b/tests/Integration/Domain/Model/Interaction/TalkTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Domain/Model/Interaction/UserTest.php
+++ b/tests/Integration/Domain/Model/Interaction/UserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Domain/Model/TalkMetaTest.php
+++ b/tests/Integration/Domain/Model/TalkMetaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Domain/Model/TalkTest.php
+++ b/tests/Integration/Domain/Model/TalkTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Domain/Model/UserTest.php
+++ b/tests/Integration/Domain/Model/UserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Domain/Services/TalkFormatterTest.php
+++ b/tests/Integration/Domain/Services/TalkFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Integration/Domain/Talk/TalkHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/DashboardControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/PagesControllerTest.php
+++ b/tests/Integration/Http/Controller/PagesControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/ProfileControllerTest.php
+++ b/tests/Integration/Http/Controller/ProfileControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/Reviewer/SpeakerControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/SpeakerControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/SignupControllerTest.php
+++ b/tests/Integration/Http/Controller/SignupControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Infrastructure/Auth/SentinelUserTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelUserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Integration/MigrationsTest.php
+++ b/tests/Integration/MigrationsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Application/NotAuthorizedExceptionTest.php
+++ b/tests/Unit/Application/NotAuthorizedExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Console/Command/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/AdminPromoteCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Console/Command/ReviewerPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/ReviewerPromoteCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/ContainerAwareFake.php
+++ b/tests/Unit/ContainerAwareFake.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/ContainerAwareTest.php
+++ b/tests/Unit/ContainerAwareTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/CallForProposalTest.php
+++ b/tests/Unit/Domain/CallForProposalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/EntityNotFoundExceptionTest.php
+++ b/tests/Unit/Domain/EntityNotFoundExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
+++ b/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Services/NotAuthenticatedExceptionTest.php
+++ b/tests/Unit/Domain/Services/NotAuthenticatedExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Services/PaginationTest.php
+++ b/tests/Unit/Domain/Services/PaginationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Services/ResetEmailerTest.php
+++ b/tests/Unit/Domain/Services/ResetEmailerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
@@ -65,12 +65,9 @@ class TalkRatingContextTest extends \PHPUnit\Framework\TestCase
     public function strategyProvider(): array
     {
         return [
-            [1],
             ['asdf'],
             [''],
             ['NULL'],
-            [false],
-            [true],
         ];
     }
 

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -48,12 +48,7 @@ class YesNoRatingTest extends \PHPUnit\Framework\TestCase
             [-2, false],
             [10, false],
             [PHP_INT_MAX, false],
-            ['3', false],
-            ['-1', true],
-            ['0', true],
-            ['1', true],
             [-0, true],
-            ['-0', true],
         ];
     }
 }

--- a/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
+++ b/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Talk/InvalidTalkSubmissionExceptionTest.php
+++ b/tests/Unit/Domain/Talk/InvalidTalkSubmissionExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Talk/TalkFilterTest.php
+++ b/tests/Unit/Domain/Talk/TalkFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Talk/TalkProfileTest.php
+++ b/tests/Unit/Domain/Talk/TalkProfileTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/Unit/Domain/Talk/TalkSubmissionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Domain/ValidationExceptionTest.php
+++ b/tests/Unit/Domain/ValidationExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Faker/GeneratorTest.php
+++ b/tests/Unit/Faker/GeneratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Http/Controller/FlashableTraitFake.php
+++ b/tests/Unit/Http/Controller/FlashableTraitFake.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Http/Controller/FlashableTraitTest.php
+++ b/tests/Unit/Http/Controller/FlashableTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Http/Form/TalkFormTest.php
+++ b/tests/Unit/Http/Form/TalkFormTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
+++ b/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Persistence/IlluminateSpeakerRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Persistence/IlluminateTalkRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/PathTest.php
+++ b/tests/Unit/PathTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Provider/SentinelServiceProviderTest.php
+++ b/tests/Unit/Provider/SentinelServiceProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/Unit/Provider/SymfonySentinelSessionTest.php
+++ b/tests/Unit/Provider/SymfonySentinelSessionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/web/index.php
+++ b/web/index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *

--- a/web/index_dev.php
+++ b/web/index_dev.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2013-2017 OpenCFP
  *


### PR DESCRIPTION
This PR

* [x] enables the `declare_strict_types` fixer
* [x] runs `make cs`
* [x] fixes failing tests

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.3#usage:

>**declare_strict_types** [`@PHP70Migration:risky`, `@PHP71Migration:risky`]
>
>Force strict types declaration in all files. Requires PHP >= 7.0.
>
>*Risky rule: forcing strict types will stop non strict code from working.*