### PR TITLE
Fix: Remove default value

### DIFF
--- a/classes/Domain/Services/AccountManagement.php
+++ b/classes/Domain/Services/AccountManagement.php
@@ -25,7 +25,7 @@ interface AccountManagement
 
     public function activate($email);
 
-    public function promoteTo($email, $role = 'Admin');
+    public function promoteTo($email, $role);
 
-    public function demoteFrom($email, $role = 'Admin');
+    public function demoteFrom($email, $role);
 }

--- a/classes/Infrastructure/Auth/SentinelAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentinelAccountManagement.php
@@ -101,7 +101,7 @@ final class SentinelAccountManagement implements AccountManagement
         return $this->sentinel->getActivationRepository()->complete($user, $activationCode);
     }
 
-    public function promoteTo($email, $role = 'Admin')
+    public function promoteTo($email, $role)
     {
         $this->sentinel
             ->getRoleRepository()
@@ -110,7 +110,7 @@ final class SentinelAccountManagement implements AccountManagement
             ->attach($this->findByLogin($email)->getId());
     }
 
-    public function demoteFrom($email, $role = 'Admin')
+    public function demoteFrom($email, $role)
     {
         $this->sentinel
             ->getRoleRepository()

--- a/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -19,12 +19,14 @@ use OpenCFP\Infrastructure\Auth\SentinelAccountManagement;
 use OpenCFP\Infrastructure\Auth\SentinelUser;
 use OpenCFP\Infrastructure\Auth\UserExistsException;
 use OpenCFP\Infrastructure\Auth\UserNotFoundException;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentinelAccountManagement
  */
 class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
 {
+    use GeneratorTrait;
     use MockeryPHPUnitIntegration;
 
     public function testIsFinal()
@@ -127,23 +129,27 @@ class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testPromoteToIsVoid()
     {
+        $role = $this->getFaker()->word;
+
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $user->shouldReceive('getUserId')->andReturn(2);
         $sentinel = Mockery::mock(Sentinel::class);
         $sentinel->shouldReceive('getUserRepository->findByCredentials')->andReturn($user);
         $sentinel->shouldReceive('getRoleRepository->findByName->users->attach')->andReturn(true);
         $account = new SentinelAccountManagement($sentinel);
-        $this->assertNull($account->promoteTo('mail@mail.mail'));
+        $this->assertNull($account->promoteTo('mail@mail.mail', $role));
     }
 
     public function testDemoteFromIsVoid()
     {
+        $role = $this->getFaker()->word;
+
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $user->shouldReceive('getUserId')->andReturn(2);
         $sentinel = Mockery::mock(Sentinel::class);
         $sentinel->shouldReceive('getUserRepository->findByCredentials')->andReturn($user);
         $sentinel->shouldReceive('getRoleRepository->findByName->users->detach')->andReturn(true);
         $account = new SentinelAccountManagement($sentinel);
-        $this->assertNull($account->demoteFrom('mail@mail.mail'));
+        $this->assertNull($account->demoteFrom('mail@mail.mail', $role));
     }
 }


### PR DESCRIPTION
This PR

* [x] removes a default value from `AccountManagement::promoteTo()` and `AccountManagement::demoteFrom()`

💁‍♂️ `Admin` doesn't really seem like a default value that makes sense.