### PR TITLE
Fix: References to Sentry in ReviewerPromoteCommand

### DIFF
--- a/classes/Console/Command/ReviewerPromoteCommand.php
+++ b/classes/Console/Command/ReviewerPromoteCommand.php
@@ -11,8 +11,8 @@
 
 namespace OpenCFP\Console\Command;
 
-use Cartalyst\Sentry;
 use OpenCFP\Domain\Services;
+use OpenCFP\Infrastructure\Auth;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -68,7 +68,7 @@ EOF
 
         try {
             $this->accountManagement->findByLogin($email);
-        } catch (Sentry\Users\UserNotFoundException $exception) {
+        } catch (Auth\UserNotFoundException $exception) {
             $io->error(\sprintf(
                 'Could not find account with email "%s".',
                 $email

--- a/tests/Unit/Console/Command/ReviewerPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/ReviewerPromoteCommandTest.php
@@ -11,7 +11,6 @@
 
 namespace OpenCFP\Test\Unit\Console\Command;
 
-use Cartalyst\Sentry;
 use OpenCFP\Console\Command\ReviewerPromoteCommand;
 use OpenCFP\Domain\Services;
 use OpenCFP\Infrastructure\Auth;
@@ -74,7 +73,7 @@ final class ReviewerPromoteCommandTest extends Framework\TestCase
             ->expects($this->once())
             ->method('findByLogin')
             ->with($this->identicalTo($email))
-            ->willThrowException(new Sentry\Users\UserNotFoundException());
+            ->willThrowException(new Auth\UserNotFoundException());
 
         $command = new ReviewerPromoteCommand($accountManagement);
 
@@ -105,7 +104,7 @@ final class ReviewerPromoteCommandTest extends Framework\TestCase
     {
         $email = $this->getFaker()->email;
 
-        $user = $this->createSentryUserMock();
+        $user = $this->createUserMock();
 
         $accountManagement = $this->createAccountManagementMock();
 
@@ -157,10 +156,10 @@ final class ReviewerPromoteCommandTest extends Framework\TestCase
     }
 
     /**
-     * @return Auth\SentryUser|\PHPUnit_Framework_MockObject_MockObject
+     * @return Auth\UserInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function createSentryUserMock(): Auth\SentryUser
+    private function createUserMock(): Auth\UserInterface
     {
-        return $this->createMock(Auth\SentryUser::class);
+        return $this->createMock(Auth\UserInterface::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] fixes references to Sentry in `ReviewerPromoteCommand`

Follows #624.
Follows #722.

💁‍♂️ My bad, I should have updated these in #722.