### PR TITLE
Fix return type of speaker profile

### DIFF
--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -69,7 +69,7 @@ class SpeakerProfile
     {
         $this->assertAllowedToSee('talks');
 
-        return $this->speaker->talks;
+        return $this->speaker->talks->toArray();
     }
 
     /**

--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -11,6 +11,7 @@
 
 namespace OpenCFP\Test\Unit\Domain\Speaker;
 
+use Illuminate\Support\Collection;
 use OpenCFP\Domain\Model;
 use OpenCFP\Domain\Speaker\NotAllowedException;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
@@ -97,9 +98,11 @@ final class SpeakerProfileTest extends Framework\TestCase
             $this->createTalkMock(),
             $this->createTalkMock(),
         ];
+        $collection = $this->createMock(Collection::class);
+        $collection->method('toArray')->willReturn($talks);
 
         $speaker = $this->createUserMock([
-            'talks' => $talks,
+            'talks' => $collection,
         ]);
 
         $profile = new SpeakerProfile($speaker);


### PR DESCRIPTION
This PR

* [x] Makes sure the ```getTalks``` function returns an ```array```

Without the toArray it would return a collection, and throw a fatal error.

Follows #760