### PR TITLE
Enhancement: Enable no_multiline_whitespace_around_double_arrow fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -51,6 +51,7 @@ return PhpCsFixer\Config::create()
         'no_blank_lines_after_phpdoc' => true,
         'no_empty_phpdoc' => true,
         'no_extra_consecutive_blank_lines' => true,
+        'no_multiline_whitespace_around_double_arrow' => true,
         'no_multiline_whitespace_before_semicolons' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_superfluous_elseif' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_multiline_whitespace_around_double_arrow` fixer

Related to https://github.com/opencfp/opencfp/pull/771#discussion_r153736272.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.3#usage:

>**no_multiline_whitespace_around_double_arrow** [`@Symfony`]
>
>Operator `=>` should not be surrounded by multi-line whitespaces.