### PR TITLE
Enhancement: Do not exclude migrations from php-cs-fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,9 +11,7 @@ the LICENSE file that was distributed with this source code.
 @see https://github.com/opencfp/opencfp
 TXT;
 
-$finder = PhpCsFixer\Finder::create()
-    ->exclude('migrations')
-    ->in(__DIR__);
+$finder = PhpCsFixer\Finder::create()->in(__DIR__);
 
 return PhpCsFixer\Config::create()
     ->setUsingCache(true)

--- a/migrations/0_schema.php
+++ b/migrations/0_schema.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class Schema extends AbstractMigration

--- a/migrations/20140823091041_favorites.php
+++ b/migrations/20140823091041_favorites.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class Favorites extends AbstractMigration

--- a/migrations/20140828144530_add_id_to_speaker_table.php
+++ b/migrations/20140828144530_add_id_to_speaker_table.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class AddIdToSpeakerTable extends AbstractMigration

--- a/migrations/20140828145029_add_hotel_and_transportation_cost_fields.php
+++ b/migrations/20140828145029_add_hotel_and_transportation_cost_fields.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class AddHotelAndTransportationCostFields extends AbstractMigration

--- a/migrations/20140902174929_remove_speaker_table.php
+++ b/migrations/20140902174929_remove_speaker_table.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class RemoveSpeakerTable extends AbstractMigration
@@ -11,17 +22,17 @@ class RemoveSpeakerTable extends AbstractMigration
         // Add speaker columns to the users table
         $users->addColumn('info', 'text');
         $users->addColumn('bio', 'text');
-        $users->addColumn('photo_path', 'string', array('limit' => 255));
+        $users->addColumn('photo_path', 'string', ['limit' => 255]);
         $users->save();
 
         // Migrate data from speakers to users
         $rows = $this->fetchAll('SELECT * FROM speakers');
 
         foreach ($rows as $row) {
-            $info = filter_var($row['info'], FILTER_SANITIZE_MAGIC_QUOTES);
-            $bio = filter_var($row['bio'], FILTER_SANITIZE_MAGIC_QUOTES);
-            $photo_path = filter_var($row['photo_path'], FILTER_SANITIZE_MAGIC_QUOTES);
-            $sql = "UPDATE users SET info = '{$info}', bio = '{$bio}', photo_path = '{$photo_path}' WHERE id = {$row['user_id']}";
+            $info       = \filter_var($row['info'], FILTER_SANITIZE_MAGIC_QUOTES);
+            $bio        = \filter_var($row['bio'], FILTER_SANITIZE_MAGIC_QUOTES);
+            $photo_path = \filter_var($row['photo_path'], FILTER_SANITIZE_MAGIC_QUOTES);
+            $sql        = "UPDATE users SET info = '{$info}', bio = '{$bio}', photo_path = '{$photo_path}' WHERE id = {$row['user_id']}";
             $this->execute($sql);
         }
 
@@ -45,17 +56,17 @@ class RemoveSpeakerTable extends AbstractMigration
         $speakers->addColumn('user_id', 'integer');
         $speakers->addColumn('info', 'text');
         $speakers->addColumn('bio', 'text');
-        $speakers->addColumn('photo_path', 'string', array('limit' => 255));
+        $speakers->addColumn('photo_path', 'string', ['limit' => 255]);
         $speakers->create();
 
         // Migrate data back from users to speakers
         $rows = $this->fetchAll('SELECT id, info, bio, photo_path FROM users');
 
         foreach ($rows as $row) {
-            $info = filter_var($row['info'], FILTER_SANITIZE_MAGIC_QUOTES);
-            $bio = filter_var($row['bio'], FILTER_SANITIZE_MAGIC_QUOTES);
-            $photo_path = filter_var($row['photo_path'], FILTER_SANITIZE_MAGIC_QUOTES);
-            $sql = "INSERT INTO speakers (user_id, info, bio, photo_path)
+            $info       = \filter_var($row['info'], FILTER_SANITIZE_MAGIC_QUOTES);
+            $bio        = \filter_var($row['bio'], FILTER_SANITIZE_MAGIC_QUOTES);
+            $photo_path = \filter_var($row['photo_path'], FILTER_SANITIZE_MAGIC_QUOTES);
+            $sql        = "INSERT INTO speakers (user_id, info, bio, photo_path)
                 VALUES ({$row['user_id']}, '{$info}', '{$bio}', '{$photo_path}')";
             $this->execute($sql);
         }

--- a/migrations/20141121173412_add_talk_meta.php
+++ b/migrations/20141121173412_add_talk_meta.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class AddTalkMeta extends AbstractMigration
@@ -18,5 +29,4 @@ class AddTalkMeta extends AbstractMigration
             ->addIndex(['admin_user_id', 'talk_id'], ['name' => 'talk_meta__admin_user_id__talk_id', 'unique' => true])
             ->create();
     }
-
 }

--- a/migrations/20141122213222_create_talk_comment.php
+++ b/migrations/20141122213222_create_talk_comment.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class CreateTalkComment extends AbstractMigration

--- a/migrations/20141201172522_alter_user_column_defaults.php
+++ b/migrations/20141201172522_alter_user_column_defaults.php
@@ -1,10 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class AlterUserColumnDefaults extends AbstractMigration
 {
-
     /**
      * Migrate Up.
      */

--- a/migrations/20141203111136_alter_talk_column_defaults.php
+++ b/migrations/20141203111136_alter_talk_column_defaults.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class AlterTalkColumnDefaults extends AbstractMigration

--- a/migrations/20150518024706_create_league_oauth_tables.php
+++ b/migrations/20150518024706_create_league_oauth_tables.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class CreateLeagueOauthTables extends AbstractMigration

--- a/migrations/20150702132854_fix_defaults_for_users_table.php
+++ b/migrations/20150702132854_fix_defaults_for_users_table.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class FixDefaultsForUsersTable extends AbstractMigration

--- a/migrations/20151012165609_alter_talk_columns_allow_null.php
+++ b/migrations/20151012165609_alter_talk_columns_allow_null.php
@@ -1,4 +1,16 @@
 <?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class AlterTalkColumnsAllowNull extends AbstractMigration
@@ -13,6 +25,7 @@ class AlterTalkColumnsAllowNull extends AbstractMigration
             ->changeColumn('slides', 'string', ['null' => true])
             ->save();
     }
+
     /**
      * Migrate Down.
      */

--- a/migrations/20151214140200_airports.php
+++ b/migrations/20151214140200_airports.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class Airports extends AbstractMigration

--- a/migrations/20160106061843_fix_zero_dates.php
+++ b/migrations/20160106061843_fix_zero_dates.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class FixZeroDates extends AbstractMigration
@@ -7,14 +18,14 @@ class FixZeroDates extends AbstractMigration
     private $tables = [
         'talks' => [
             'created_at',
-            'updated_at'
+            'updated_at',
         ],
         'users' => [
             'activated_at',
             'created_at',
             'updated_at',
             'last_login',
-        ]
+        ],
     ];
 
     public function up()
@@ -55,9 +66,9 @@ class FixZeroDates extends AbstractMigration
 
     private function run($sql)
     {
-        array_walk($this->tables, function ($columnNames, $tableName) use ($sql) {
-            array_walk($columnNames, function ($columnName) use ($tableName, $sql) {
-                $this->execute(sprintf(
+        \array_walk($this->tables, function ($columnNames, $tableName) use ($sql) {
+            \array_walk($columnNames, function ($columnName) use ($tableName, $sql) {
+                $this->execute(\sprintf(
                     $sql,
                     $tableName,
                     $columnName,

--- a/migrations/20161224211743_talks_tags_migration.php
+++ b/migrations/20161224211743_talks_tags_migration.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class TalksTagsMigration extends AbstractMigration

--- a/migrations/20171019025925_add_needs_profile_flag.php
+++ b/migrations/20171019025925_add_needs_profile_flag.php
@@ -1,5 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
 
 use Phinx\Migration\AbstractMigration;
 

--- a/migrations/20171107125309_reviewer_role_migration.php
+++ b/migrations/20171107125309_reviewer_role_migration.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class ReviewerRoleMigration extends AbstractMigration

--- a/migrations/20171120102354_sentinel_migration.php
+++ b/migrations/20171120102354_sentinel_migration.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 /**
@@ -8,7 +19,6 @@ use Phinx\Migration\AbstractMigration;
  */
 class SentinelMigration extends AbstractMigration
 {
-
     public function up()
     {
         $this->activationsTable();
@@ -35,7 +45,7 @@ class SentinelMigration extends AbstractMigration
             ->addColumn('user_id', 'integer')
             ->addColumn('code', 'string')
             ->addColumn('completed', 'boolean', ['default' => 0])
-            ->addColumn('completed_at','timestamp', ['null' => true])
+            ->addColumn('completed_at', 'timestamp', ['null' => true])
             ->addColumn('created_at', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
             ->addColumn('updated_at', 'timestamp', ['null' => true])
             ->create();
@@ -45,7 +55,7 @@ class SentinelMigration extends AbstractMigration
     {
         $this->table('persistences')
             ->addColumn('user_id', 'integer')
-            ->addColumn('code','string')
+            ->addColumn('code', 'string')
             ->addColumn('created_at', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
             ->addColumn('updated_at', 'timestamp', ['null' => true])
             ->create();
@@ -90,7 +100,7 @@ class SentinelMigration extends AbstractMigration
     {
         $this->table('throttle')
             ->renameColumn('ip_address', 'ip')
-            ->changeColumn('ip','string', ['null' => true])
+            ->changeColumn('ip', 'string', ['null' => true])
             ->changeColumn('user_id', 'integer', ['null' => true])
             ->addColumn('type', 'string')
             ->update();
@@ -103,5 +113,4 @@ class SentinelMigration extends AbstractMigration
             ->removeColumn('type')
             ->update();
     }
-
 }

--- a/migrations/20171120112704_activate_user_migration.php
+++ b/migrations/20171120112704_activate_user_migration.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Cartalyst\Sentinel\Native\Facades\Sentinel;
 use Cartalyst\Sentinel\Users\EloquentUser;
 use Illuminate\Database\Capsule\Manager as Capsule;
@@ -15,13 +26,14 @@ class ActivateUserMigration extends AbstractMigration
     /** @var Capsule $capsule */
     public $capsule;
 
-    public function bootEloquent()  {
-        $adapter = $this->getAdapter()->getAdapter();
-        $options = $adapter->getOptions();
-        $this->capsule = new Capsule;
+    public function bootEloquent()
+    {
+        $adapter       = $this->getAdapter()->getAdapter();
+        $options       = $adapter->getOptions();
+        $this->capsule = new Capsule();
         $this->capsule->addConnection([
             'driver'    => 'mysql',
-            'database'  => $options['name']
+            'database'  => $options['name'],
         ]);
         $this->capsule->getConnection()->setPdo($adapter->getConnection());
         $this->capsule->bootEloquent();
@@ -38,6 +50,7 @@ class ActivateUserMigration extends AbstractMigration
             $activations->complete($user, $activation->getCode());
         });
     }
+
     public function down()
     {
         $this->bootEloquent();

--- a/migrations/20171120122725_roles_migration.php
+++ b/migrations/20171120122725_roles_migration.php
@@ -1,15 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class RolesMigration extends AbstractMigration
 {
     public function up()
     {
-        $speaker_permissions = '{"talk.update":true,"talk.review":false,"user.delete":false}';
+        $speaker_permissions  = '{"talk.update":true,"talk.review":false,"user.delete":false}';
         $reviewer_permissions = '{"talk.update":true,"talk.review":true,"user.delete":false}';
-        $admin_permissions = '{"talk.update":true,"talk.review":true,"user.delete":true}';
-        $role_data = [
+        $admin_permissions    = '{"talk.update":true,"talk.review":true,"user.delete":true}';
+        $role_data            = [
             ['name' => 'Speaker', 'slug' => 'speaker', 'permissions' => $speaker_permissions],
             ['name' => 'Reviewer', 'slug' => 'reviewer', 'permissions' => $reviewer_permissions],
             ['name' => 'Admin', 'slug' => 'admin', 'permissions' => $admin_permissions],
@@ -17,8 +28,8 @@ class RolesMigration extends AbstractMigration
         $this->insert('roles', $role_data);
     }
 
-   public function down()
-   {
-       $this->table('roles')->truncate();
-   }
+    public function down()
+    {
+        $this->table('roles')->truncate();
+    }
 }

--- a/migrations/20171120123411_user_roles_migration.php
+++ b/migrations/20171120123411_user_roles_migration.php
@@ -1,21 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+use Cartalyst\Sentinel\Native\Facades\Sentinel;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Phinx\Migration\AbstractMigration;
-use Cartalyst\Sentinel\Native\Facades\Sentinel;
 
 class UserRolesMigration extends AbstractMigration
 {
     /** @var Capsule $capsule */
     public $capsule;
 
-    public function bootEloquent()  {
-        $adapter = $this->getAdapter()->getAdapter();
-        $options = $adapter->getOptions();
-        $this->capsule = new Capsule;
+    public function bootEloquent()
+    {
+        $adapter       = $this->getAdapter()->getAdapter();
+        $options       = $adapter->getOptions();
+        $this->capsule = new Capsule();
         $this->capsule->addConnection([
             'driver'    => 'mysql',
-            'database'  => $options['name']
+            'database'  => $options['name'],
         ]);
         $this->capsule->getConnection()->setPdo($adapter->getConnection());
         $this->capsule->bootEloquent();
@@ -46,26 +58,26 @@ class UserRolesMigration extends AbstractMigration
     private function getRoleIds($role)
     {
         try {
-            $con = $this->capsule->getConnection();
+            $con       = $this->capsule->getConnection();
             $roleGroup = $con->query()->from('groups')->where('name', $role)->first();
-            $roleIds = $con->query()->from('users_groups')->where('group_id', $roleGroup->id)->get();
+            $roleIds   = $con->query()->from('users_groups')->where('group_id', $roleGroup->id)->get();
+
             return $roleIds->transform(function ($role) {
                 return $role->user_id;
             })->toArray();
-        }catch (\Exception $e) {
+        } catch (\Exception $e) {
             return [];
         }
     }
 
     private function promoteSpeakers()
     {
-        $roleIds = array_merge($this->getRoleIds('Admin'), $this->getRoleIds('Reviewer'));
-        $users = \Cartalyst\Sentinel\Users\EloquentUser::all();
-        $users = $users->whereNotIn('id', $roleIds);
-        $role = Sentinel::findRoleByName('Speaker');
+        $roleIds = \array_merge($this->getRoleIds('Admin'), $this->getRoleIds('Reviewer'));
+        $users   = \Cartalyst\Sentinel\Users\EloquentUser::all();
+        $users   = $users->whereNotIn('id', $roleIds);
+        $role    = Sentinel::findRoleByName('Speaker');
         foreach ($users as $user) {
             $role->users()->attach($user->id);
         }
     }
-
 }

--- a/migrations/20171128134740_remove_useless_items_migration.php
+++ b/migrations/20171128134740_remove_useless_items_migration.php
@@ -1,10 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 use Phinx\Migration\AbstractMigration;
 
 class RemoveUselessItemsMigration extends AbstractMigration
 {
-
     public function up()
     {
         $this->dropTable('tags');


### PR DESCRIPTION
This PR

* [x] removes `migrations/` from exclusions for `php-cs-fixer`
* [x] runs `make cs`

💁‍♂️ I can't think of a reason why the same rules should not apply to migrations.