### PR TITLE
Fix: Name of test class

### DIFF
--- a/tests/Integration/Http/Controller/Reviewer/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/SpeakersControllerTest.php
@@ -18,7 +18,7 @@ use OpenCFP\Test\WebTestCase;
 /**
  * @coversNothing
  */
-class SpeakerControllerTest extends WebTestCase
+class SpeakersControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 


### PR DESCRIPTION
This PR

* [x] fixes the name of a test class

💁‍♂️ The system under test is the [`SpeakersController`](https://github.com/opencfp/opencfp/blob/b607dc45cb0c58edaec1605d4ef61e18207cd44c/classes/Http/Controller/Reviewer/SpeakersController.php).