### PR TITLE
Fix: Hotel is actually a boolean

### DIFF
--- a/classes/Domain/Speaker/SpeakerProfile.php
+++ b/classes/Domain/Speaker/SpeakerProfile.php
@@ -171,13 +171,13 @@ class SpeakerProfile
     /**
      * @throws NotAllowedException
      *
-     * @return null|string
+     * @return bool
      */
-    public function getHotel()
+    public function getHotel(): bool
     {
         $this->assertAllowedToSee('hotel');
 
-        return $this->speaker->hotel;
+        return $this->speaker->hotel === 1;
     }
 
     /**

--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -389,9 +389,9 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getHotel();
     }
 
-    public function testGetHotelReturnsHotelIfPropertyIsNotHidden()
+    public function testGetHotelReturnsFalseIfPropertyIsNotHidden()
     {
-        $hotel = $this->getFaker()->company;
+        $hotel = 0;
 
         $speaker = $this->createUserMock([
             'hotel' => $hotel,
@@ -399,7 +399,20 @@ final class SpeakerProfileTest extends Framework\TestCase
 
         $profile = new SpeakerProfile($speaker);
 
-        $this->assertSame($hotel, $profile->getHotel());
+        $this->assertFalse($profile->getHotel());
+    }
+
+    public function testGetHotelReturnsTrueIfPropertyIsNotHidden()
+    {
+        $hotel = 1;
+
+        $speaker = $this->createUserMock([
+            'hotel' => $hotel,
+        ]);
+
+        $profile = new SpeakerProfile($speaker);
+
+        $this->assertTrue($profile->getHotel());
     }
 
     public function testGetAirportThrowsNotAllowedExceptionIfPropertyIsHidden()


### PR DESCRIPTION
This PR

* [x] adjusts `SpeakerProfile::getHotel()` to return a `bool`