### PR TITLE
Fix: Use non-nullable TINYINT for boolean fields

### DIFF
--- a/migrations/20171129142655_use_non_nullable_boolean.php
+++ b/migrations/20171129142655_use_non_nullable_boolean.php
@@ -1,0 +1,30 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+final class UseNonNullableBoolean extends AbstractMigration
+{
+    public function change()
+    {
+        $tableName = 'users';
+
+        $columnNames = [
+            'hotel',
+            'transportation',
+        ];
+
+        $table = $this->table($tableName);
+
+        foreach ($columnNames as $columnName) {
+            $sql = <<<SQL
+UPDATE users SET $columnName = 0 WHERE $columnName IS NULL;
+SQL;
+            $this->query($sql);
+
+            $table->changeColumn($columnName, 'boolean', [
+                'default' => 0,
+                'null' => false,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds a migration to turn fields which represent `bool`s in the `users` table into non-nullable `TINYINT` fields

Follows #779.
Follows https://github.com/opencfp/opencfp/pull/758#discussion_r153525414.