### PR TITLE
Fix: Rename CallForProposals to CallForPapers

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -15,7 +15,7 @@ namespace OpenCFP;
 
 use Illuminate\Database\Capsule\Manager as Capsule;
 use OpenCFP\Provider\ApplicationServiceProvider;
-use OpenCFP\Provider\CallForProposalProvider;
+use OpenCFP\Provider\CallForPapersProvider;
 use OpenCFP\Provider\ControllerResolverServiceProvider;
 use OpenCFP\Provider\Gateways\WebGatewayProvider;
 use OpenCFP\Provider\HtmlPurifierServiceProvider;
@@ -89,7 +89,7 @@ class Application extends SilexApplication
             ],
         ]);
 
-        $this->register(new CallForProposalProvider());
+        $this->register(new CallForPapersProvider());
         $this->register(new SentinelServiceProvider());
         $app = $this;
         $this->register(new TwigServiceProvider($app));

--- a/classes/Application/Speakers.php
+++ b/classes/Application/Speakers.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Application;
 
-use OpenCFP\Domain\CallForProposal;
+use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Services\EventDispatcher;
 use OpenCFP\Domain\Services\IdentityProvider;
@@ -25,8 +25,8 @@ use OpenCFP\Domain\Talk\TalkWasSubmitted;
 
 class Speakers
 {
-    /** @var CallForProposal */
-    private $callForProposal;
+    /** @var CallForPapers */
+    private $callForPapers;
 
     /** @var IdentityProvider */
     private $identityProvider;
@@ -41,7 +41,7 @@ class Speakers
     private $dispatcher;
 
     public function __construct(
-        CallForProposal $callForProposal,
+        CallForPapers $callForPapers,
         IdentityProvider $identityProvider,
         SpeakerRepository $speakers,
         TalkRepository $talks,
@@ -50,7 +50,7 @@ class Speakers
         $this->speakers         = $speakers;
         $this->identityProvider = $identityProvider;
         $this->talks            = $talks;
-        $this->callForProposal  = $callForProposal;
+        $this->callForPapers    = $callForPapers;
         $this->dispatcher       = $dispatcher;
     }
 
@@ -111,7 +111,7 @@ class Speakers
      */
     public function submitTalk(TalkSubmission $submission)
     {
-        if (!$this->callForProposal->isOpen()) {
+        if (!$this->callForPapers->isOpen()) {
             throw new \Exception('You cannot create talks once the call for papers has ended.');
         }
 

--- a/classes/Domain/CallForPapers.php
+++ b/classes/Domain/CallForPapers.php
@@ -19,7 +19,7 @@ namespace OpenCFP\Domain;
  * CFP is open. This is useful in service-layer testing as you can easily modify the temporal
  * aspect.
  */
-class CallForProposal
+class CallForPapers
 {
     /**
      * @var \DateTimeInterface

--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Application\Speakers;
-use OpenCFP\Domain\CallForProposal;
+use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
 
 class DashboardController extends BaseController
@@ -35,8 +35,8 @@ class DashboardController extends BaseController
         try {
             $profile = $speakers->findProfile();
 
-            /** @var CallForProposal $cfp */
-            $cfp = $this->service('callforproposal');
+            /** @var CallForPapers $cfp */
+            $cfp = $this->service('callforpapers');
 
             return $this->render('dashboard.twig', [
                 'profile'  => $profile,

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -30,7 +30,7 @@ class SignupController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        $cfp = $this->service('callforproposal');
+        $cfp = $this->service('callforpapers');
 
         if (!$cfp->isOpen()) {
             $this->service('session')->set('flash', [

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -69,7 +69,7 @@ class TalkController extends BaseController
         $talkId      = (int) $req->get('id');
         // You can only edit talks while the CfP is open
         // This will redirect to "view" the talk in a read-only template
-        if (!$this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforpapers')->isOpen()) {
             $this->service('session')->set(
                 'flash',
                 [
@@ -118,7 +118,7 @@ class TalkController extends BaseController
     public function createAction(Request $req)
     {
         // You can only create talks while the CfP is open
-        if (!$this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforpapers')->isOpen()) {
             $this->service('session')->set(
                 'flash',
                 [
@@ -155,7 +155,7 @@ class TalkController extends BaseController
     public function processCreateAction(Request $req)
     {
         // You can only create talks while the CfP is open
-        if (!$this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforpapers')->isOpen()) {
             $this->service('session')->set(
                 'flash',
                 [
@@ -232,7 +232,7 @@ class TalkController extends BaseController
 
     public function updateAction(Request $req)
     {
-        if (!$this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforpapers')->isOpen()) {
             $this->service('session')->set(
                 'flash',
                 [
@@ -315,7 +315,7 @@ class TalkController extends BaseController
     public function deleteAction(Request $req)
     {
         // You can only delete talks while the CfP is open
-        if (!$this->service('callforproposal')->isOpen()) {
+        if (!$this->service('callforpapers')->isOpen()) {
             return $this->app->json(['delete' => 'no']);
         }
 

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -17,7 +17,7 @@ use Cartalyst\Sentinel\Sentinel;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use OpenCFP\Application;
 use OpenCFP\Application\Speakers;
-use OpenCFP\Domain\CallForProposal;
+use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Model\Airport;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\AccountManagement;
@@ -82,7 +82,7 @@ class ApplicationServiceProvider implements ServiceProviderInterface
 
         $app['application.speakers'] = function ($app) {
             return new Speakers(
-                new CallForProposal(new \DateTimeImmutable($app->config('application.enddate'))),
+                new CallForPapers(new \DateTimeImmutable($app->config('application.enddate'))),
                 $app[IdentityProvider::class],
                 $app[SpeakerRepository::class],
                 new IlluminateTalkRepository(),

--- a/classes/Provider/CallForPapersProvider.php
+++ b/classes/Provider/CallForPapersProvider.php
@@ -13,21 +13,21 @@ declare(strict_types=1);
 
 namespace OpenCFP\Provider;
 
-use OpenCFP\Domain\CallForProposal;
+use OpenCFP\Domain\CallForPapers;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Silex\Application;
 
-class CallForProposalProvider implements ServiceProviderInterface
+class CallForPapersProvider implements ServiceProviderInterface
 {
     /**
      * {@inheritdoc}
      */
     public function register(Container $app)
     {
-        $cfp = new CallForProposal(new \DateTimeImmutable($app->config('application.enddate')));
+        $cfp = new CallForPapers(new \DateTimeImmutable($app->config('application.enddate')));
 
-        $app['callforproposal'] = $cfp;
+        $app['callforpapers'] = $cfp;
     }
 
     /**

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -45,7 +45,7 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
             $twig = $app['twig'];
 
             $twig->addGlobal('current_page', $request->getRequestUri());
-            $twig->addGlobal('cfp_open', $app['callforproposal']->isOpen());
+            $twig->addGlobal('cfp_open', $app['callforpapers']->isOpen());
 
             $twig->addFunction(new Twig_SimpleFunction('active', function ($route) use ($app, $request) {
                 return $app['url_generator']->generate($route) == $request->getRequestUri();

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -15,7 +15,7 @@ namespace OpenCFP\Test\Integration\Http\Controller;
 
 use Mockery as m;
 use OpenCFP\Application\Speakers;
-use OpenCFP\Domain\CallForProposal;
+use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Test\Helper\RefreshDatabase;
@@ -87,7 +87,7 @@ class TalkControllerTest extends WebTestCase
         // Previously, this fails because it checked midnight
         // for the current date. `isCfpOpen` now uses 11:59pm current date.
         $now = new \DateTime();
-        $this->swap('callforproposal', new CallForProposal(new \DateTimeImmutable($now->format('M. jS, Y'))));
+        $this->swap('callforpapers', new CallForPapers(new \DateTimeImmutable($now->format('M. jS, Y'))));
 
         /*
          * This should not have a flash message. The fact that this

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -17,7 +17,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use Mockery\MockInterface;
 use OpenCFP\Application\Speakers;
-use OpenCFP\Domain\CallForProposal;
+use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\EventDispatcher;
@@ -47,8 +47,8 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
     /** @var IdentityProvider | MockInterface */
     private $identityProvider;
 
-    /** @var CallForProposal | MockInterface */
-    private $callForProposal;
+    /** @var CallForPapers | MockInterface */
+    private $callForPapers;
 
     /** @var EventDispatcher | MockInterface */
     private $dispatcher;
@@ -58,10 +58,10 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
         $this->identityProvider  = m::mock(\OpenCFP\Domain\Services\IdentityProvider::class);
         $this->speakerRepository = m::mock(\OpenCFP\Domain\Speaker\SpeakerRepository::class);
         $this->talkRepository    = m::mock(\OpenCFP\Domain\Talk\TalkRepository::class);
-        $this->callForProposal   = m::mock(\OpenCFP\Domain\CallForProposal::class);
+        $this->callForPapers     = m::mock(\OpenCFP\Domain\CallForPapers::class);
         $this->dispatcher        = m::mock(\OpenCFP\Domain\Services\EventDispatcher::class);
 
-        $this->sut = new Speakers($this->callForProposal, $this->identityProvider, $this->speakerRepository, $this->talkRepository, $this->dispatcher);
+        $this->sut = new Speakers($this->callForPapers, $this->identityProvider, $this->speakerRepository, $this->talkRepository, $this->dispatcher);
     }
 
     //
@@ -152,7 +152,7 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_should_allow_authenticated_speakers_to_submit_talks()
     {
-        $this->callForProposal->shouldReceive('isOpen')
+        $this->callForPapers->shouldReceive('isOpen')
             ->once()
             ->andReturn(true);
 
@@ -191,7 +191,7 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
      */
     public function it_doesnt_allow_talk_submissions_after_cfp_has_ended()
     {
-        $this->callForProposal->shouldReceive('isOpen')
+        $this->callForPapers->shouldReceive('isOpen')
             ->once()
             ->andReturn(false);
         $submission = TalkSubmission::fromNative([

--- a/tests/Unit/Domain/CallForPapersTest.php
+++ b/tests/Unit/Domain/CallForPapersTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace OpenCFP\Test\Unit\Domain;
 
-use OpenCFP\Domain\CallForProposal;
+use OpenCFP\Domain\CallForPapers;
 
 /**
- * @covers \OpenCFP\Domain\CallForProposal
+ * @covers \OpenCFP\Domain\CallForPapers
  */
-class CallForProposalTest extends \PHPUnit\Framework\TestCase
+class CallForPapersTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test
@@ -26,7 +26,7 @@ class CallForProposalTest extends \PHPUnit\Framework\TestCase
      */
     public function it_should_tell_whether_or_not_the_cfp_is_open($endDate)
     {
-        $cfp = new CallForProposal(new \DateTimeImmutable($endDate));
+        $cfp = new CallForPapers(new \DateTimeImmutable($endDate));
         $this->assertTrue($cfp->isOpen());
     }
 
@@ -41,7 +41,7 @@ class CallForProposalTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_should_say_cfp_is_closed_after_end_date_has_passed()
     {
-        $cfp = new CallForProposal(new \DateTimeImmutable('-1 day'));
+        $cfp = new CallForPapers(new \DateTimeImmutable('-1 day'));
         $this->assertFalse($cfp->isOpen());
     }
 }

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Test;
 
 use Mockery;
-use OpenCFP\Domain\CallForProposal;
+use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\RequestValidator;
 use OpenCFP\Infrastructure\Auth\CsrfValidator;
@@ -135,9 +135,9 @@ abstract class WebTestCase extends BaseTestCase
 
     public function callForPapersIsOpen(): self
     {
-        $cfp = Mockery::mock(CallForProposal::class);
+        $cfp = Mockery::mock(CallForPapers::class);
         $cfp->shouldReceive('isOpen')->andReturn(true);
-        $this->swap('callforproposal', $cfp);
+        $this->swap('callforpapers', $cfp);
         $this->app['twig']->addGlobal('cfp_open', true);
 
         return $this;
@@ -145,9 +145,9 @@ abstract class WebTestCase extends BaseTestCase
 
     public function callForPapersIsClosed(): self
     {
-        $cfp = Mockery::mock(CallForProposal::class);
+        $cfp = Mockery::mock(CallForPapers::class);
         $cfp->shouldReceive('isOpen')->andReturn(false);
-        $this->swap('callforproposal', $cfp);
+        $this->swap('callforpapers', $cfp);
         $this->app['twig']->addGlobal('cfp_open', false);
 
         return $this;


### PR DESCRIPTION
This PR

* [x] renames `CallForProposals` to `CallForPapers`

💁‍♂️ Running

```
$ git grep -i callforproposal
```

after this change yields nothing now.