### PR TITLE
Enhancement: Decouple AdminPromoteCommand from application container

### DIFF
--- a/bin/opencfp
+++ b/bin/opencfp
@@ -23,6 +23,7 @@ $accountManagement = $container[Services\AccountManagement::class];
 $app = new Application($container);
 
 $app->addCommands([
+    new Command\AdminPromoteCommand($accountManagement),
     new Command\ReviewerDemoteCommand($accountManagement),
     new Command\ReviewerPromoteCommand($accountManagement),
     new Command\UserCreateCommand($accountManagement),

--- a/classes/Console/Application.php
+++ b/classes/Console/Application.php
@@ -15,7 +15,6 @@ namespace OpenCFP\Console;
 
 use OpenCFP\Application as ApplicationContainer;
 use OpenCFP\Console\Command\AdminDemoteCommand;
-use OpenCFP\Console\Command\AdminPromoteCommand;
 use OpenCFP\Console\Command\ClearCacheCommand;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Command\HelpCommand;
@@ -49,7 +48,6 @@ class Application extends ConsoleApplication
         return [
             new HelpCommand(),
             new ListCommand(),
-            new AdminPromoteCommand(),
             new AdminDemoteCommand(),
             new ClearCacheCommand(),
         ];

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -77,7 +77,6 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
             Console\Command\HelpCommand::class,
             Console\Command\ListCommand::class,
             Command\AdminDemoteCommand::class,
-            Command\AdminPromoteCommand::class,
             Command\ClearCacheCommand::class,
         ];
 


### PR DESCRIPTION
This PR

* [x] decouples the `AdminPromoteCommand` from the application container

Follows #717.
