### PR TITLE
Fix: Display the airport information the speaker entered

### DIFF
--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -53,11 +53,7 @@ class SpeakersController extends BaseController
                     'country' => $airport->country,
                 ];
             } catch (EntityNotFoundException $e) {
-                $speaker['airport'] = [
-                    'code'    => null,
-                    'name'    => null,
-                    'country' => null,
-                ];
+                //Do nothing
             }
 
             $speaker['is_admin'] = \in_array($speaker['id'], $adminUserIds);
@@ -109,11 +105,7 @@ class SpeakersController extends BaseController
                 'country' => $airport->country,
             ];
         } catch (EntityNotFoundException $e) {
-            $speakerDetails->airport = [
-                'code'    => null,
-                'name'    => null,
-                'country' => null,
-            ];
+            //Do nothing
         }
 
         $talks = $speakerDetails->talks()->get();

--- a/resources/views/admin/speaker/index.twig
+++ b/resources/views/admin/speaker/index.twig
@@ -24,8 +24,10 @@
                 <div>
                     <h2 class="-mt-2">
                         <a href="{{ url('admin_speaker_view', { id: speaker.id }) }}">{{ speaker.first_name }} {{ speaker.last_name }}</a>
-                        {% if speaker.airport.code %}
+                        {% if speaker.airport.code is defined %}
                             <a href="https://www.google.com/flights/#search;f={{ speaker.airport.code|upper }};t={{ airport|upper }};d={{ arrival }};r={{ departure }}" class="ml-3 text-brand text-sm hover:underline" target="_blank"><i class="fa fa-plane mr-2"></i>Flight Cost</a>
+                        {% elseif speaker.airport%}
+                            <span class="ml-3 text-brand text-sm"><i class="fa fa-plane mr-2"></i>{{ speaker.airport }}</span>
                         {% endif %}
                     </h2>
                     <div>

--- a/resources/views/admin/speaker/view.twig
+++ b/resources/views/admin/speaker/view.twig
@@ -6,8 +6,10 @@
         <div>
             <h1 class="-mt-2">
                 {{ speaker.name }}
-                {% if speaker.airport.code %}
+                {% if speaker.airport.code is defined %}
                     <a href="https://www.google.com/flights/#search;f={{ speaker.airport.code|upper }};t={{ airport|upper }};d={{ arrival }};r={{ departure }}" class="ml-3 text-brand text-sm hover:underline" target="_blank"><i class="fa fa-plane mr-2"></i>Flight Cost</a>
+                {% elseif speaker.airport%}
+                    <span class="ml-3 text-brand text-sm"><i class="fa fa-plane mr-2"></i>{{ speaker.airport }}</span>
                 {% endif %}
             </h1>
             <div>


### PR DESCRIPTION
This PR

* [x] Changes the airport display to display what the speaker entered, even if it doesn't match an airport code
For example: 
![image](https://user-images.githubusercontent.com/14289961/33474914-b1a3fa50-d67c-11e7-954f-144eb8e4d165.png)