### PR TITLE
Enhancement: Enable php_unit_strict fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -62,6 +62,7 @@ return PhpCsFixer\Config::create()
         'ordered_imports' => true,
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,
+        'php_unit_strict' => true,
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,

--- a/tests/Integration/Domain/Model/AirportTest.php
+++ b/tests/Integration/Domain/Model/AirportTest.php
@@ -42,9 +42,9 @@ class AirportTest extends BaseTestCase
     {
         $airport = $this->airports->withCode('AAC');
 
-        $this->assertEquals('AAC', $airport->code);
-        $this->assertEquals('Al Arish', $airport->name);
-        $this->assertEquals('Egypt', $airport->country);
+        $this->assertSame('AAC', $airport->code);
+        $this->assertSame('Al Arish', $airport->name);
+        $this->assertSame('Egypt', $airport->country);
     }
 
     /**

--- a/tests/Integration/Domain/Model/TalkTest.php
+++ b/tests/Integration/Domain/Model/TalkTest.php
@@ -47,7 +47,7 @@ class TalkTest extends BaseTestCase
     {
         $selected = Talk::selected()->get();
         $this->assertCount(1, $selected);
-        $this->assertEquals('talks title NO 2', $selected->first()->title);
+        $this->assertSame('talks title NO 2', $selected->first()->title);
     }
 
     /**
@@ -70,7 +70,7 @@ class TalkTest extends BaseTestCase
         $favorited = Talk::favoritedBy(1)->get();
 
         $this->assertCount(1, $favorited);
-        $this->assertEquals('talks title', $favorited->first()->title);
+        $this->assertSame('talks title', $favorited->first()->title);
 
         $favoritedByOther = Talk::viewedBy(25)->get();
         $this->assertCount(0, $favoritedByOther);
@@ -84,7 +84,7 @@ class TalkTest extends BaseTestCase
         $ratedPlusOne = Talk::ratedPlusOneBy(1)->get();
 
         $this->assertCount(1, $ratedPlusOne);
-        $this->assertEquals('talks title NO 2', $ratedPlusOne->first()->title);
+        $this->assertSame('talks title NO 2', $ratedPlusOne->first()->title);
 
         $ratedPlusOneByOther = Talk::ratedPlusOneBy(25)->get();
         $this->assertCount(0, $ratedPlusOneByOther);
@@ -116,7 +116,7 @@ class TalkTest extends BaseTestCase
         $notViewed = Talk::notViewedBy(1)->get();
 
         $this->assertCount(1, $notViewed);
-        $this->assertEquals('talks title NO 3', $notViewed->first()->title);
+        $this->assertSame('talks title NO 3', $notViewed->first()->title);
 
         $notViewedByOther = Talk::notViewedBy(2)->get();
 
@@ -129,7 +129,7 @@ class TalkTest extends BaseTestCase
     public function topRatedSortsOnBestRatings()
     {
         $topRated = Talk::topRated()->get();
-        $this->assertEquals('talks title NO 2', $topRated->first()->title);
+        $this->assertSame('talks title NO 2', $topRated->first()->title);
         $this->assertCount(2, $topRated);
     }
 

--- a/tests/Integration/Domain/Services/TalkFormatterTest.php
+++ b/tests/Integration/Domain/Services/TalkFormatterTest.php
@@ -47,7 +47,7 @@ class TalkFormatterTest extends BaseTestCase
         $this->assertSame('One talk to rule them all', $format->getTitle());
         $this->assertSame('api', $format->getCategory());
         $this->assertSame(0, $format->getRating());
-        $this->assertSame(0, $format->isViewedByMe());
+        $this->assertFalse($format->isViewedByMe());
     }
 
     /**
@@ -62,7 +62,7 @@ class TalkFormatterTest extends BaseTestCase
         $secondFormat =$formatter->createdFormattedOutput($talk->first(), 2);
 
         $this->assertSame(1, $secondFormat->getRating());
-        $this->assertSame(1, $secondFormat->isViewedByMe());
+        $this->assertTrue($secondFormat->isViewedByMe());
     }
 
     /**

--- a/tests/Integration/Domain/Services/TalkFormatterTest.php
+++ b/tests/Integration/Domain/Services/TalkFormatterTest.php
@@ -44,10 +44,10 @@ class TalkFormatterTest extends BaseTestCase
 
         $format =$formatter->createdFormattedOutput($talk->first(), 1);
 
-        $this->assertEquals('One talk to rule them all', $format->getTitle());
-        $this->assertEquals('api', $format->getCategory());
-        $this->assertEquals(0, $format->getRating());
-        $this->assertEquals(0, $format->isViewedByMe());
+        $this->assertSame('One talk to rule them all', $format->getTitle());
+        $this->assertSame('api', $format->getCategory());
+        $this->assertSame(0, $format->getRating());
+        $this->assertSame(0, $format->isViewedByMe());
     }
 
     /**
@@ -61,8 +61,8 @@ class TalkFormatterTest extends BaseTestCase
         // Now to see if the meta gets put in correctly
         $secondFormat =$formatter->createdFormattedOutput($talk->first(), 2);
 
-        $this->assertEquals(1, $secondFormat->getRating());
-        $this->assertEquals(1, $secondFormat->isViewedByMe());
+        $this->assertSame(1, $secondFormat->getRating());
+        $this->assertSame(1, $secondFormat->isViewedByMe());
     }
 
     /**
@@ -73,7 +73,7 @@ class TalkFormatterTest extends BaseTestCase
         $formatter = new TalkFormatter();
         $talks     = Talk::all();
         $formatted = $formatter->formatList($talks, 2);
-        $this->assertEquals(\count($talks), \count($formatted));
+        $this->assertSame(\count($talks), \count($formatted));
         $this->assertInstanceOf(Collection::class, $formatted);
     }
 

--- a/tests/Integration/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Integration/Domain/Talk/TalkHandlerTest.php
@@ -77,13 +77,13 @@ class TalkHandlerTest extends BaseTestCase
         $talk        = self::$talk;
         $talkHandler = new TalkHandler($this->authentication, $this->ratingSystem);
         $talkHandler->with($talk);
-        $this->assertEquals(0, $talk->selected);
+        $this->assertSame(0, $talk->selected);
 
         $this->assertTrue($talkHandler->select());
-        $this->assertEquals(1, $talk->selected);
+        $this->assertSame(1, $talk->selected);
 
         $this->assertTrue($talkHandler->select(false));
-        $this->assertEquals(0, $talk->selected);
+        $this->assertSame(0, $talk->selected);
     }
 
     /**
@@ -101,13 +101,13 @@ class TalkHandlerTest extends BaseTestCase
         //The handler should have favorited the talk now.
         $favorite = $talk->favorites()->get();
         $this->assertCount(1, $favorite);
-        $this->assertEquals(1, $favorite->first()->admin_user_id);
+        $this->assertSame(1, $favorite->first()->admin_user_id);
         
         //Calling favorite again doesn't do anything
         $this->assertTrue($talkHandler->setFavorite());
         $favoriteAgain = $talk->favorites()->get();
         $this->assertCount(1, $favoriteAgain);
-        $this->assertEquals(1, $favoriteAgain->first()->admin_user_id);
+        $this->assertSame(1, $favoriteAgain->first()->admin_user_id);
 
         //Now to delete the favorite
         $this->assertTrue($talkHandler->setFavorite(false));
@@ -175,10 +175,10 @@ class TalkHandlerTest extends BaseTestCase
         $talkHandler->with($talk);
 
         $this->assertTrue($talkHandler->view());
-        $this->assertEquals(1, $talk->viewed);
+        $this->assertSame(1, $talk->viewed);
         //Calling it again doesn't do anything funky
         $this->assertTrue($talkHandler->view());
-        $this->assertEquals(1, $talk->viewed);
+        $this->assertSame(1, $talk->viewed);
     }
 
     /**
@@ -192,7 +192,7 @@ class TalkHandlerTest extends BaseTestCase
         $talkHandler->with($talk);
 
         $this->assertFalse($talkHandler->view());
-        $this->assertNotEquals(1, $talk->viewed);
+        $this->assertNotSame(1, $talk->viewed);
     }
 
     /**
@@ -243,6 +243,6 @@ class TalkHandlerTest extends BaseTestCase
         $profile = $talkHandler->getProfile();
         $this->assertInstanceOf(TalkProfile::class, $profile);
         //Check the talk got set correctly in the profile.
-        $this->assertEquals($talk->title, $profile->getTitle());
+        $this->assertSame($talk->title, $profile->getTitle());
     }
 }

--- a/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -55,7 +55,7 @@ class SentinelAccountManagementTest extends BaseTestCase
         ]);
 
         $user = $this->sut->findByLogin('test@example.com');
-        $this->assertEquals('Test Account', "{$user->getUser()->first_name} {$user->getUser()->last_name}");
+        $this->assertSame('Test Account', "{$user->getUser()->first_name} {$user->getUser()->last_name}");
     }
 
     public function testCreatingDuplicateUserThrowsError()

--- a/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -51,7 +51,7 @@ class SentinelAuthenticationTest extends BaseTestCase
 
         $user = $this->sut->user();
 
-        $this->assertEquals('test@example.com', $user->getLogin());
+        $this->assertSame('test@example.com', $user->getLogin());
     }
 
     /**

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -77,8 +77,8 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
         $profile = $this->sut->findProfile();
 
         $this->assertInstanceOf(\OpenCFP\Domain\Speaker\SpeakerProfile::class, $profile);
-        $this->assertEquals($speaker->email, $profile->getEmail());
-        $this->assertEquals($speaker->first_name . ' ' . $speaker->last_name, $profile->getName());
+        $this->assertSame($speaker->email, $profile->getEmail());
+        $this->assertSame($speaker->first_name . ' ' . $speaker->last_name, $profile->getName());
     }
 
     /**
@@ -102,7 +102,7 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
 
         $talk = $this->sut->getTalk(1);
 
-        $this->assertEquals('Testy Talk', $talk->title);
+        $this->assertSame('Testy Talk', $talk->title);
     }
 
     /**
@@ -128,9 +128,9 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
 
         $talks = $this->sut->getTalks();
 
-        $this->assertEquals('Testy Talk', $talks[0]->title);
-        $this->assertEquals('Another Talk', $talks[1]->title);
-        $this->assertEquals('Yet Another Talk', $talks[2]->title);
+        $this->assertSame('Testy Talk', $talks[0]->title);
+        $this->assertSame('Another Talk', $talks[1]->title);
+        $this->assertSame('Yet Another Talk', $talks[2]->title);
     }
 
     /**
@@ -182,8 +182,8 @@ class SpeakersTest extends \PHPUnit\Framework\TestCase
          * an event when a talk is submitted.
          */
         $talk = $this->sut->submitTalk($submission);
-        $this->assertEquals($talk->title, 'Sample Talk');
-        $this->assertEquals($talk->description, 'Some example talk for our submission');
+        $this->assertSame($talk->title, 'Sample Talk');
+        $this->assertSame($talk->description, 'Some example talk for our submission');
     }
 
     /**

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -83,7 +83,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         \sort($expected);
         \sort($actual);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     protected function createInputInterfaceWithEmail($email): \Symfony\Component\Console\Input\InputInterface

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
@@ -53,6 +53,6 @@ class TalkRatingTest extends \PHPUnit\Framework\TestCase
 
         $sut->rate(7, 1);
 
-        $this->assertEquals(1, $metaMock->rating);
+        $this->assertSame(1, $metaMock->rating);
     }
 }

--- a/tests/Unit/Domain/Talk/TalkFilterTest.php
+++ b/tests/Unit/Domain/Talk/TalkFilterTest.php
@@ -45,7 +45,7 @@ class TalkFilterTest extends Framework\TestCase
     {
         $filter = new TalkFilter(new TalkFormatter(), $this->talk);
         $talk   = $filter->getFilteredTalks(1);
-        $this->assertEquals($this->talk, $talk);
+        $this->assertSame($this->talk, $talk);
     }
 
     /**
@@ -55,7 +55,7 @@ class TalkFilterTest extends Framework\TestCase
     {
         $filter = new TalkFilter(new TalkFormatter(), $this->talk);
         $talk   = $filter->getFilteredTalks(1, 'secrets');
-        $this->assertEquals($this->talk, $talk);
+        $this->assertSame($this->talk, $talk);
     }
 
     /**
@@ -66,7 +66,7 @@ class TalkFilterTest extends Framework\TestCase
         $this->talk->shouldReceive('selected')->andReturn('gotSelected');
         $filter = new TalkFilter(new TalkFormatter(), $this->talk);
         $talk   = $filter->getFilteredTalks(1, 'selEcteD');
-        $this->assertEquals('gotSelected', $talk);
+        $this->assertSame('gotSelected', $talk);
     }
 
     /**
@@ -77,7 +77,7 @@ class TalkFilterTest extends Framework\TestCase
         $this->talk->shouldReceive('topRated')->andReturn('gotTopRated');
         $filter = new TalkFilter(new TalkFormatter(), $this->talk);
         $talk   = $filter->getFilteredTalks(1, 'toprated');
-        $this->assertEquals('gotTopRated', $talk);
+        $this->assertSame('gotTopRated', $talk);
     }
 
     /**
@@ -91,13 +91,13 @@ class TalkFilterTest extends Framework\TestCase
         $this->talk->shouldReceive('favoritedBy')->andReturn('gotfavorited');
         $filter = new TalkFilter(new TalkFormatter(), $this->talk);
         $talk   = $filter->getFilteredTalks(1, 'notrated');
-        $this->assertEquals('gotnotrated', $talk);
+        $this->assertSame('gotnotrated', $talk);
         $talk = $filter->getFilteredTalks(1, 'plusone');
-        $this->assertEquals('gotplusone', $talk);
+        $this->assertSame('gotplusone', $talk);
         $talk = $filter->getFilteredTalks(1, 'viewed');
-        $this->assertEquals('gotviewed', $talk);
+        $this->assertSame('gotviewed', $talk);
         $talk = $filter->getFilteredTalks(1, 'favorited');
-        $this->assertEquals('gotfavorited', $talk);
+        $this->assertSame('gotfavorited', $talk);
     }
 
     /**

--- a/tests/Unit/Domain/Talk/TalkProfileTest.php
+++ b/tests/Unit/Domain/Talk/TalkProfileTest.php
@@ -47,7 +47,7 @@ class TalkProfileTest extends \PHPUnit\Framework\TestCase
         $talk        = m::mock(Talk::class)->makePartial();
         $talk->id    = 2;
         $talkProfile = new TalkProfile($talk);
-        $this->assertEquals($talk->id, $talkProfile->getId());
+        $this->assertSame($talk->id, $talkProfile->getId());
     }
 
     /**

--- a/tests/Unit/Domain/Talk/TalkSubmissionTest.php
+++ b/tests/Unit/Domain/Talk/TalkSubmissionTest.php
@@ -39,11 +39,11 @@ class TalkSubmissionTest extends \PHPUnit\Framework\TestCase
         // Responsible for creating data-mapper Talk entity from cleaned inputs.
         $talk = $submission->toTalk();
 
-        $this->assertEquals('Happy Path Submission', $talk->title);
-        $this->assertEquals('I play by the rules.', $talk->description);
-        $this->assertEquals('regular', $talk->type);
-        $this->assertEquals('entry', $talk->level);
-        $this->assertEquals('api', $talk->category);
+        $this->assertSame('Happy Path Submission', $talk->title);
+        $this->assertSame('I play by the rules.', $talk->description);
+        $this->assertSame('regular', $talk->type);
+        $this->assertSame('entry', $talk->level);
+        $this->assertSame('api', $talk->category);
         $this->assertEmpty($talk->slides);
     }
 

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -35,7 +35,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($environment->isProduction());
         $this->assertFalse($environment->isDevelopment());
         $this->assertFalse($environment->isTesting());
-        $this->assertEquals(Environment::TYPE_PRODUCTION, $environment);
+        $this->assertSame(Environment::TYPE_PRODUCTION, $environment);
     }
 
     public function testDevelopmentReturnsEnvironment()
@@ -46,7 +46,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($environment->isProduction());
         $this->assertTrue($environment->isDevelopment());
         $this->assertFalse($environment->isTesting());
-        $this->assertEquals(Environment::TYPE_DEVELOPMENT, $environment);
+        $this->assertSame(Environment::TYPE_DEVELOPMENT, $environment);
     }
 
     public function testTestingReturnsEnvironment()
@@ -57,7 +57,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($environment->isProduction());
         $this->assertFalse($environment->isDevelopment());
         $this->assertTrue($environment->isTesting());
-        $this->assertEquals(Environment::TYPE_TESTING, $environment);
+        $this->assertSame(Environment::TYPE_TESTING, $environment);
     }
 
     /**
@@ -73,7 +73,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $environment = Environment::fromEnvironmentVariable();
 
         $this->assertInstanceOf(Environment::class, $environment);
-        $this->assertEquals($type, $environment);
+        $this->assertSame($type, $environment);
     }
 
     /**
@@ -88,7 +88,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertInstanceOf(Environment::class, $environment);
-        $this->assertEquals($type, $environment);
+        $this->assertSame($type, $environment);
     }
 
     /**
@@ -102,7 +102,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $environment = Environment::fromString($type);
 
         $this->assertInstanceOf(Environment::class, $environment);
-        $this->assertEquals($type, $environment);
+        $this->assertSame($type, $environment);
     }
 
     public function providerEnvironment(): \Generator

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -35,7 +35,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($environment->isProduction());
         $this->assertFalse($environment->isDevelopment());
         $this->assertFalse($environment->isTesting());
-        $this->assertSame(Environment::TYPE_PRODUCTION, $environment);
+        $this->assertSame(Environment::TYPE_PRODUCTION, (string) $environment);
     }
 
     public function testDevelopmentReturnsEnvironment()
@@ -46,7 +46,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($environment->isProduction());
         $this->assertTrue($environment->isDevelopment());
         $this->assertFalse($environment->isTesting());
-        $this->assertSame(Environment::TYPE_DEVELOPMENT, $environment);
+        $this->assertSame(Environment::TYPE_DEVELOPMENT, (string) $environment);
     }
 
     public function testTestingReturnsEnvironment()
@@ -57,7 +57,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($environment->isProduction());
         $this->assertFalse($environment->isDevelopment());
         $this->assertTrue($environment->isTesting());
-        $this->assertSame(Environment::TYPE_TESTING, $environment);
+        $this->assertSame(Environment::TYPE_TESTING, (string) $environment);
     }
 
     /**
@@ -73,7 +73,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $environment = Environment::fromEnvironmentVariable();
 
         $this->assertInstanceOf(Environment::class, $environment);
-        $this->assertSame($type, $environment);
+        $this->assertSame($type, (string) $environment);
     }
 
     /**
@@ -88,7 +88,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertInstanceOf(Environment::class, $environment);
-        $this->assertSame($type, $environment);
+        $this->assertSame($type, (string) $environment);
     }
 
     /**
@@ -102,7 +102,7 @@ class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $environment = Environment::fromString($type);
 
         $this->assertInstanceOf(Environment::class, $environment);
-        $this->assertSame($type, $environment);
+        $this->assertSame($type, (string) $environment);
     }
 
     public function providerEnvironment(): \Generator

--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -76,7 +76,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     {
         $data = ['email' => $email];
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
-        $this->assertEquals(
+        $this->assertSame(
             $form->validateEmail(),
             $expectedResponse,
             "Did not validate {$email} as expected"
@@ -176,7 +176,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $form->sanitize();
         $testResponse = $form->validatePasswords();
 
-        $this->assertEquals($expectedResponse, $testResponse);
+        $this->assertSame($expectedResponse, $testResponse);
         $this->assertContains(
             $expectedMessage,
             $form->getErrorMessages(),
@@ -214,7 +214,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $form               = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateFirstName(),
             'Did not validate first name as expected'
@@ -258,7 +258,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $form              = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateLastName(),
             'Did not validate last name as expected'
@@ -300,7 +300,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function validateAllWorksCorrectly($data, $expectedResponse)
     {
         $form = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateAll(),
             'All submitted data did not validate as expected'
@@ -346,7 +346,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $form                 = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateSpeakerInfo(),
             'Speaker info was not validated as expected'
@@ -367,7 +367,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $data['speaker_bio'] = $speakerBio;
         $form                = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
         $form->sanitize();
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateSpeakerBio(),
             'Speaker bio was not validated as expected'
@@ -401,7 +401,7 @@ class SignupFormTest extends \PHPUnit\Framework\TestCase
         $form = new \OpenCFP\Http\Form\SignupForm($inputData, $this->purifier);
         $form->sanitize();
         $sanitizedData = $form->getCleanData();
-        $this->assertEquals(
+        $this->assertSame(
             $expectedData,
             $sanitizedData,
             'Data was not sanitized properly'

--- a/tests/Unit/Http/Form/TalkFormTest.php
+++ b/tests/Unit/Http/Form/TalkFormTest.php
@@ -44,7 +44,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $data = \unserialize($rawData);
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
 
-        $this->assertEquals(
+        $this->assertSame(
             $response,
             $form->hasRequiredFields(),
             \sprintf(
@@ -101,7 +101,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
     {
         $data = \unserialize($rawData);
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
-        $this->assertEquals(
+        $this->assertSame(
             $response,
             $form->hasRequiredFields(),
             \sprintf(
@@ -149,7 +149,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
         $form->sanitize();
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateTitle(),
             \sprintf(
@@ -191,7 +191,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
         $form->sanitize();
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateDescription(),
             \sprintf(
@@ -236,7 +236,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         );
         $form->sanitize();
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateType(),
             \sprintf(
@@ -279,7 +279,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
         $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier, ['categories' => ['test1' => 'Test 1', 'test2' => 'Test 2']]);
         $form->sanitize();
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateCategory(),
             \sprintf(
@@ -347,7 +347,7 @@ class TalkFormTest extends \PHPUnit\Framework\TestCase
             ['levels' => ['entry' => 'Entry', 'advanced' => 'Advanced']]
         );
         $form->sanitize();
-        $this->assertEquals(
+        $this->assertSame(
             $expectedResponse,
             $form->validateLevel(),
             \sprintf(

--- a/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -85,7 +85,7 @@ class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $sentinel = Mockery::mock(Sentinel::class);
         $sentinel->shouldReceive('getRoleRepository->findByName->getUsers->toArray')->andReturn([]);
         $accounts = new SentinelAccountManagement($sentinel);
-        $this->assertEquals([], $accounts->findByRole('blabla'));
+        $this->assertSame([], $accounts->findByRole('blabla'));
     }
 
     public function testCreateThrowsCorrectErrorWhenUserAlreadyExists()

--- a/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -33,9 +33,9 @@ class PseudoRandomStringGeneratorTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_should_generate_a_random_string_of_given_length()
     {
-        $this->assertEquals(10, \strlen($this->sut->generate(10)));
-        $this->assertEquals(18, \strlen($this->sut->generate(18)));
-        $this->assertEquals(35, \strlen($this->sut->generate(35)));
-        $this->assertEquals(40, \strlen($this->sut->generate(40)));
+        $this->assertSame(10, \strlen($this->sut->generate(10)));
+        $this->assertSame(18, \strlen($this->sut->generate(18)));
+        $this->assertSame(35, \strlen($this->sut->generate(35)));
+        $this->assertSame(40, \strlen($this->sut->generate(40)));
     }
 }


### PR DESCRIPTION
This PR

* [x] Enables php_unit_strict fixer
* [x] Runs ```make cs```
* [x] Fixes tests

Follows #766 

:tipping_hand_man: For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.3#usage:
>* **php_unit_strict**
>
>  PHPUnit methods like ``assertSame`` should be used instead of
  ``assertEquals``.
>
>  *Risky rule: risky when any of the functions are overridden.*
>
>  Configuration options:
>
>  - ``assertions`` (``array``): list of assertion methods to fix; defaults to
    ``['assertAttributeEquals', 'assertAttributeNotEquals', 'assertEquals',
    'assertNotEquals']``