### PR TITLE
Remove application object from function call

### DIFF
--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Domain\Services\Authentication;
-use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -29,7 +28,7 @@ class SecurityController extends BaseController
         ]);
     }
 
-    public function processAction(Request $req, Application $app)
+    public function processAction(Request $req)
     {
         /** @var Authentication $auth */
         $auth = $this->service(Authentication::class);
@@ -47,7 +46,7 @@ class SecurityController extends BaseController
 
             $templateData = [
                 'email' => $req->get('email'),
-                'flash' => $this->getFlash($app),
+                'flash' => $this->getFlash($this->app),
             ];
 
             return $this->render('security/login.twig', $templateData, Response::HTTP_BAD_REQUEST);

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -45,7 +45,7 @@ class SignupController extends BaseController
         return $this->render('security/signup.twig');
     }
 
-    public function processAction(Request $req, \OpenCFP\Application $app)
+    public function processAction(Request $req)
     {
         try {
             $this->validate([
@@ -62,7 +62,7 @@ class SignupController extends BaseController
             ]);
             $accounts->activate($req->get('email'));
 
-            $app['session']->set('flash', [
+            $this->app['session']->set('flash', [
                 'type'  => 'success',
                 'short' => 'Success',
                 'ext'   => "You've successfully created your account!",
@@ -73,7 +73,7 @@ class SignupController extends BaseController
 
             return $this->redirectTo('dashboard');
         } catch (ValidationException $e) {
-            $app['session']->set('flash', [
+            $this->app['session']->set('flash', [
                 'type'  => 'error',
                 'short' => $e->getMessage(),
                 'ext'   => $e->errors(),
@@ -81,7 +81,7 @@ class SignupController extends BaseController
 
             return $this->redirectBack();
         } catch (\RuntimeException $e) {
-            $app['session']->set('flash', [
+            $this->app['session']->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
                 'ext'   => 'A user already exists with that email address',


### PR DESCRIPTION
This PR

* [x] Removes the application object from 2 controller function calls

There was no real reason why it had to be passed to the function directly