### PR TITLE
Fix: UserAccess to use Auth object

### DIFF
--- a/classes/Domain/Services/UserAccess.php
+++ b/classes/Domain/Services/UserAccess.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace OpenCFP\Domain\Services;
 
-use Silex\Application;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 interface UserAccess
@@ -21,10 +20,10 @@ interface UserAccess
     /**
      * If a user doesn't have access to a page they get redirected, otherwise nothing happens
      *
-     * @param Application $app
-     * @param string      $role Role to check against
+     * @param Authentication $auth
+     * @param string         $role Role to check against
      *
      * @return RedirectResponse|void
      */
-    public static function userHasAccess(Application $app, string $role = '');
+    public static function userHasAccess(Authentication $auth, string $role = '');
 }

--- a/classes/Infrastructure/Auth/RoleAccess.php
+++ b/classes/Infrastructure/Auth/RoleAccess.php
@@ -15,7 +15,6 @@ namespace OpenCFP\Infrastructure\Auth;
 
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\UserAccess;
-use Silex\Application;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class RoleAccess implements UserAccess
@@ -23,22 +22,20 @@ class RoleAccess implements UserAccess
     /**
      * If a user doesn't have access to a page they get redirected, otherwise nothing happens
      *
-     * @param Application $app
-     * @param string      $role Role to check against Defaults to admin for security reasons
+     * @param Authentication $auth
+     * @param string         $role Role to check against Defaults to admin for security reasons
      *
      * @return RedirectResponse|void
      */
-    public static function userHasAccess(Application $app, string $role = 'admin')
+    public static function userHasAccess(Authentication $auth, string $role = 'admin')
     {
-        /** @var Authentication $auth */
-        $auth = $app[Authentication::class];
         if (!$auth->check()) {
-            return $app->redirect('/dashboard');
+            return new RedirectResponse('/dashboard');
         }
 
         $user = $auth->user();
         if (!$user->hasAccess($role)) {
-            return $app->redirect('/dashboard');
+            return new RedirectResponse('/dashboard');
         }
     }
 }

--- a/classes/Infrastructure/Auth/SpeakerAccess.php
+++ b/classes/Infrastructure/Auth/SpeakerAccess.php
@@ -15,7 +15,6 @@ namespace OpenCFP\Infrastructure\Auth;
 
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\UserAccess;
-use Silex\Application;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class SpeakerAccess implements UserAccess
@@ -23,18 +22,15 @@ class SpeakerAccess implements UserAccess
     /**
      * If a user doesn't have access to a page they get redirected, otherwise nothing happens
      *
-     * @param Application $app
-     * @param string      $role Role to check against
+     * @param Authentication $auth
+     * @param string         $role Role to check against
      *
      * @return RedirectResponse|void
      */
-    public static function userHasAccess(Application $app, string $role = '')
+    public static function userHasAccess(Authentication $auth, string $role = '')
     {
-        /** @var Authentication $auth */
-        $auth = $app[Authentication::class];
-
         if (!$auth->check()) {
-            return $app->redirect('/login');
+            return new RedirectResponse('/dashboard');
         }
     }
 }

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -70,7 +70,7 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         }
 
         $asSpeaker = function () use ($app) {
-            return SpeakerAccess::userHasAccess($app);
+            return SpeakerAccess::userHasAccess($app[Authentication::class]);
         };
 
         $csrfChecker = function (Request $request) use ($app) {
@@ -149,7 +149,7 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         /** @var ControllerCollection $admin */
         $admin = $app['controllers_factory'];
         $admin->before(function () use ($app) {
-            return RoleAccess::userHasAccess($app, 'admin');
+            return RoleAccess::userHasAccess($app[Authentication::class], 'admin');
         });
 
         // Admin Routes
@@ -196,7 +196,7 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         /** @var ControllerCollection $reviewer */
         $reviewer = $app['controllers_factory'];
         $reviewer->before(function () use ($app) {
-            return RoleAccess::userHasAccess($app, 'reviewer');
+            return RoleAccess::userHasAccess($app[Authentication::class], 'reviewer');
         });
 
         //Reviewer Routes

--- a/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
@@ -16,33 +16,26 @@ namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 use Mockery;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Infrastructure\Auth\SpeakerAccess;
-use OpenCFP\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SpeakerAccess
  */
-class SpeakerAccessTest extends WebTestCase
+class SpeakerAccessTest extends \PHPUnit\Framework\TestCase
 {
     public function testReturnsRedirectIfCheckFailed()
     {
         $auth = Mockery::mock(Authentication::class);
         $auth->shouldReceive('check')->andReturn(false);
-        $this->swap(Authentication::class, $auth);
-        $this->assertInstanceOf(RedirectResponse::class, SpeakerAccess::userHasAccess($this->app));
+
+        $this->assertInstanceOf(RedirectResponse::class, SpeakerAccess::userHasAccess($auth));
     }
 
     public function testReturnsNothingIfUserIsLoggedIn()
     {
         $auth = Mockery::mock(Authentication::class);
         $auth->shouldReceive('check')->andReturn(true);
-        $this->swap(Authentication::class, $auth);
-        $this->assertNull(SpeakerAccess::userHasAccess($this->app));
-    }
 
-    public function testAnAdminHasAccessToSpeakerPages()
-    {
-        $this->asAdmin();
-        $this->assertNull(SpeakerAccess::userHasAccess($this->app));
+        $this->assertNull(SpeakerAccess::userHasAccess($auth));
     }
 }

--- a/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
@@ -21,9 +21,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SpeakerAccess
  */
-class SpeakerAccessTest extends \PHPUnit\Framework\TestCase
+final class SpeakerAccessTest extends \PHPUnit\Framework\TestCase
 {
-    public function testReturnsRedirectIfCheckFailed()
+    public function testReturnsRedirectResponseIfCheckFailed()
     {
         $auth = Mockery::mock(Authentication::class);
         $auth->shouldReceive('check')->andReturn(false);
@@ -31,7 +31,7 @@ class SpeakerAccessTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(RedirectResponse::class, SpeakerAccess::userHasAccess($auth));
     }
 
-    public function testReturnsNothingIfUserIsLoggedIn()
+    public function testReturnsNothingIfCheckSucceeded()
     {
         $auth = Mockery::mock(Authentication::class);
         $auth->shouldReceive('check')->andReturn(true);


### PR DESCRIPTION
This PR

* [x] lets the UserAccess classes use the Auth object, rather than the Application object.
 
There really is no reason to pass it the entire application object, when all it needs is the Authentication object.

A future PR idea would be to rename this to something like ``RoleValidator``` and have it implement a validator interface. That way the naming would make more sense