### PR TITLE
Fixed spelling mistake

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -74,7 +74,7 @@ class Application extends SilexApplication
         $this->register(new MonologServiceProvider(), [
             'monolog.logfile' => $this->config('log.path') ?: "{$basePath}/log/app.log",
             'monolog.name'    => 'opencfp',
-            'monlog.level'    => \strtoupper(
+            'monolog.level'    => \strtoupper(
                 $this->config('log.level') ?: 'debug'
             ),
         ]);

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -72,8 +72,8 @@ class Application extends SilexApplication
         $this->register(new LocaleServiceProvider());
         $this->register(new TranslationServiceProvider());
         $this->register(new MonologServiceProvider(), [
-            'monolog.logfile' => $this->config('log.path') ?: "{$basePath}/log/app.log",
-            'monolog.name'    => 'opencfp',
+            'monolog.logfile'  => $this->config('log.path') ?: "{$basePath}/log/app.log",
+            'monolog.name'     => 'opencfp',
             'monolog.level'    => \strtoupper(
                 $this->config('log.level') ?: 'debug'
             ),


### PR DESCRIPTION
This PR

* [x] Fixes an option spelling mistake in the section where we register the Monolog provider
