### PR TITLE
Fix: Use type declaration

### DIFF
--- a/classes/Domain/Services/UserAccess.php
+++ b/classes/Domain/Services/UserAccess.php
@@ -26,5 +26,5 @@ interface UserAccess
      *
      * @return RedirectResponse|void
      */
-    public static function userHasAccess(Application $app, $role = '');
+    public static function userHasAccess(Application $app, string $role = '');
 }

--- a/classes/Infrastructure/Auth/RoleAccess.php
+++ b/classes/Infrastructure/Auth/RoleAccess.php
@@ -28,7 +28,7 @@ class RoleAccess implements UserAccess
      *
      * @return RedirectResponse|void
      */
-    public static function userHasAccess(Application $app, $role = 'admin')
+    public static function userHasAccess(Application $app, string $role = 'admin')
     {
         /** @var Authentication $auth */
         $auth = $app[Authentication::class];

--- a/classes/Infrastructure/Auth/SpeakerAccess.php
+++ b/classes/Infrastructure/Auth/SpeakerAccess.php
@@ -28,7 +28,7 @@ class SpeakerAccess implements UserAccess
      *
      * @return RedirectResponse|void
      */
-    public static function userHasAccess(Application $app, $role = '')
+    public static function userHasAccess(Application $app, string $role = '')
     {
         /** @var Authentication $auth */
         $auth = $app[Authentication::class];


### PR DESCRIPTION
This PR

* [x] uses a type declaration for the `$role` argument

Spotted in #808.