### PR TITLE
Fix: Reduce visibility

### DIFF
--- a/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -37,7 +37,7 @@ class SentinelAccountManagementTest extends BaseTestCase
      */
     private $sentinel;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->sentinel = (new Sentinel())->getSentinel();

--- a/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -31,7 +31,7 @@ class SentinelAuthenticationTest extends BaseTestCase
      */
     private $sut;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $sentinel = (new Sentinel())->getSentinel();


### PR DESCRIPTION
This PR

* [x] reduces visibility of `setUp()` from `public` to `protected`

💁‍♂️ This is the visibility as declared on the parent; there's no need to increase it.