### PR TITLE
Fix: Do not return anything from activate()

### DIFF
--- a/classes/Infrastructure/Auth/SentinelAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentinelAccountManagement.php
@@ -88,19 +88,12 @@ final class SentinelAccountManagement implements AccountManagement
         throw new UserExistsException();
     }
 
-    /**
-     * @param string $email
-     *
-     * @throws UserNotFoundException
-     *
-     * @return bool
-     */
-    public function activate(string $email): bool
+    public function activate(string $email)
     {
         $user           = $this->findByLogin($email)->getUser();
         $activationCode = $this->sentinel->getActivationRepository()->create($user)->getCode();
 
-        return $this->sentinel->getActivationRepository()->complete($user, $activationCode);
+        $this->sentinel->getActivationRepository()->complete($user, $activationCode);
     }
 
     public function promoteTo(string $email, string $role)

--- a/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -127,7 +127,9 @@ class SentinelAccountManagementTest extends BaseTestCase
         $user = $this->sut->findByLogin('test@example.com')->getUser();
         //Check there are no records of activation for the user;
         $this->assertFalse($this->sentinel->getActivationRepository()->exists($user));
-        $this->assertTrue($this->sut->activate('test@example.com'));
+
+        $this->sut->activate('test@example.com');
+        
         //Check we completed activation
         $this->assertTrue($this->sentinel->getActivationRepository()->completed($user)->completed);
     }

--- a/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -118,7 +118,7 @@ class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $account->create('mail@mail.mail', 'pass');
     }
 
-    public function testActivateReturnsBool()
+    public function testActivateActivatesUser()
     {
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel = Mockery::mock(Sentinel::class);
@@ -126,7 +126,8 @@ class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $sentinel->shouldReceive('getActivationRepository->create->getCode');
         $sentinel->shouldReceive('getActivationRepository->complete')->andReturn(true);
         $account = new SentinelAccountManagement($sentinel);
-        $this->assertTrue($account->activate('mail@mail'));
+
+        $account->activate('mail@mail');
     }
 
     public function testPromoteToIsVoid()


### PR DESCRIPTION
This PR

* [x] stops returning a `bool` from `SentinelAccountManagement::activate()`

Follows https://github.com/opencfp/opencfp/pull/809#discussion_r154369159.