### PR TITLE
Fix: Extract variable for role name

### DIFF
--- a/classes/Console/Command/AdminDemoteCommand.php
+++ b/classes/Console/Command/AdminDemoteCommand.php
@@ -56,6 +56,8 @@ EOF
     {
         $email = $input->getArgument('email');
 
+        $roleName = 'Admin';
+
         $io = new SymfonyStyle(
             $input,
             $output
@@ -64,8 +66,9 @@ EOF
         $io->title('OpenCFP');
 
         $io->section(\sprintf(
-            'Demoting account with email "%s" from "Admin"',
-            $email
+            'Demoting account with email "%s" from "%s"',
+            $email,
+            $roleName
         ));
 
         try {
@@ -81,12 +84,13 @@ EOF
 
         $this->accountManagement->demoteFrom(
             $email,
-            'Admin'
+            $roleName
         );
 
         $io->success(\sprintf(
-            'Removed account with email "%s" from the "Admin" group',
-            $email
+            'Removed account with email "%s" from the "%s" group',
+            $email,
+            $roleName
         ));
     }
 }

--- a/classes/Console/Command/AdminPromoteCommand.php
+++ b/classes/Console/Command/AdminPromoteCommand.php
@@ -56,6 +56,8 @@ EOF
     {
         $email = $input->getArgument('email');
 
+        $roleName = 'Admin';
+
         $io = new SymfonyStyle(
             $input,
             $output
@@ -64,8 +66,9 @@ EOF
         $io->title('OpenCFP');
 
         $io->section(\sprintf(
-            'Promoting account with email "%s" to "Admin"',
-            $email
+            'Promoting account with email "%s" to "%s"',
+            $email,
+            $roleName
         ));
 
         try {
@@ -81,12 +84,13 @@ EOF
 
         $this->accountManagement->promoteTo(
             $email,
-            'Admin'
+            $roleName
         );
 
         $io->success(\sprintf(
-            'Added account with email "%s" to the "Admin" group',
-            $email
+            'Added account with email "%s" to the "%s" group',
+            $email,
+            $roleName
         ));
     }
 }

--- a/classes/Console/Command/ReviewerDemoteCommand.php
+++ b/classes/Console/Command/ReviewerDemoteCommand.php
@@ -56,6 +56,8 @@ EOF
     {
         $email = $input->getArgument('email');
 
+        $roleName = 'Reviewer';
+
         $io = new SymfonyStyle(
             $input,
             $output
@@ -64,8 +66,9 @@ EOF
         $io->title('OpenCFP');
 
         $io->section(\sprintf(
-            'Demoting account with email "%s" from "Reviewer"',
-            $email
+            'Demoting account with email "%s" from "%s"',
+            $email,
+            $roleName
         ));
 
         try {
@@ -81,12 +84,13 @@ EOF
 
         $this->accountManagement->demoteFrom(
             $email,
-            'Reviewer'
+            $roleName
         );
 
         $io->success(\sprintf(
-            'Removed account with email "%s" from the "Reviewer" group',
-            $email
+            'Removed account with email "%s" from the "%s" group',
+            $email,
+            $roleName
         ));
     }
 }

--- a/classes/Console/Command/ReviewerPromoteCommand.php
+++ b/classes/Console/Command/ReviewerPromoteCommand.php
@@ -56,6 +56,8 @@ EOF
     {
         $email = $input->getArgument('email');
 
+        $roleName = 'Reviewer';
+
         $io = new SymfonyStyle(
             $input,
             $output
@@ -64,8 +66,9 @@ EOF
         $io->title('OpenCFP');
 
         $io->section(\sprintf(
-            'Promoting account with email "%s" to "Reviewer"',
-            $email
+            'Promoting account with email "%s" to "%s"',
+            $email,
+            $roleName
         ));
 
         try {
@@ -81,12 +84,13 @@ EOF
 
         $this->accountManagement->promoteTo(
             $email,
-            'Reviewer'
+            $roleName
         );
 
         $io->success(\sprintf(
-            'Added account with email "%s" to the "Reviewer" group',
-            $email
+            'Added account with email "%s" to the "%s" group',
+            $email,
+            $roleName
         ));
     }
 }

--- a/tests/Unit/Console/Command/AdminDemoteCommandTest.php
+++ b/tests/Unit/Console/Command/AdminDemoteCommandTest.php
@@ -67,7 +67,9 @@ final class AdminDemoteCommandTest extends Framework\TestCase
 
     public function testExecuteFailsIfUserDoesNotExist()
     {
-        $email= $this->getFaker()->email;
+        $email = $this->getFaker()->email;
+
+        $roleName = 'Admin';
 
         $accountManagement = $this->createAccountManagementMock();
 
@@ -88,8 +90,9 @@ final class AdminDemoteCommandTest extends Framework\TestCase
         $this->assertSame(1, $commandTester->getStatusCode());
 
         $sectionMessage = \sprintf(
-            'Demoting account with email "%s" from "Admin"',
-            $email
+            'Demoting account with email "%s" from "%s"',
+            $email,
+            $roleName
         );
 
         $this->assertContains($sectionMessage, $commandTester->getDisplay());
@@ -106,6 +109,8 @@ final class AdminDemoteCommandTest extends Framework\TestCase
     {
         $email = $this->getFaker()->email;
 
+        $roleName = 'Admin';
+
         $user = $this->createUserMock();
 
         $accountManagement = $this->createAccountManagementMock();
@@ -121,7 +126,7 @@ final class AdminDemoteCommandTest extends Framework\TestCase
             ->method('demoteFrom')
             ->with(
                 $this->identicalTo($email),
-                $this->identicalTo('Admin')
+                $this->identicalTo($roleName)
             );
 
         $command = new AdminDemoteCommand($accountManagement);
@@ -135,15 +140,17 @@ final class AdminDemoteCommandTest extends Framework\TestCase
         $this->assertSame(0, $commandTester->getStatusCode());
 
         $sectionMessage = \sprintf(
-            'Demoting account with email "%s" from "Admin"',
-            $email
+            'Demoting account with email "%s" from "%s"',
+            $email,
+            $roleName
         );
 
         $this->assertContains($sectionMessage, $commandTester->getDisplay());
 
         $successMessage = \sprintf(
-            'Removed account with email "%s" from the "Admin" group',
-            $email
+            'Removed account with email "%s" from the "%s" group',
+            $email,
+            $roleName
         );
 
         $this->assertContains($successMessage, $commandTester->getDisplay());

--- a/tests/Unit/Console/Command/AdminPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/AdminPromoteCommandTest.php
@@ -67,7 +67,9 @@ final class AdminPromoteCommandTest extends Framework\TestCase
 
     public function testExecuteFailsIfUserDoesNotExist()
     {
-        $email= $this->getFaker()->email;
+        $email = $this->getFaker()->email;
+
+        $roleName = 'Admin';
 
         $accountManagement = $this->createAccountManagementMock();
 
@@ -88,8 +90,9 @@ final class AdminPromoteCommandTest extends Framework\TestCase
         $this->assertSame(1, $commandTester->getStatusCode());
 
         $sectionMessage = \sprintf(
-            'Promoting account with email "%s" to "Admin"',
-            $email
+            'Promoting account with email "%s" to "%s"',
+            $email,
+            $roleName
         );
 
         $this->assertContains($sectionMessage, $commandTester->getDisplay());
@@ -106,6 +109,8 @@ final class AdminPromoteCommandTest extends Framework\TestCase
     {
         $email = $this->getFaker()->email;
 
+        $roleName = 'Admin';
+
         $user = $this->createUserMock();
 
         $accountManagement = $this->createAccountManagementMock();
@@ -121,7 +126,7 @@ final class AdminPromoteCommandTest extends Framework\TestCase
             ->method('promoteTo')
             ->with(
                 $this->identicalTo($email),
-                $this->identicalTo('Admin')
+                $this->identicalTo($roleName)
             );
 
         $command = new AdminPromoteCommand($accountManagement);
@@ -135,15 +140,17 @@ final class AdminPromoteCommandTest extends Framework\TestCase
         $this->assertSame(0, $commandTester->getStatusCode());
 
         $sectionMessage = \sprintf(
-            'Promoting account with email "%s" to "Admin"',
-            $email
+            'Promoting account with email "%s" to "%s"',
+            $email,
+            $roleName
         );
 
         $this->assertContains($sectionMessage, $commandTester->getDisplay());
 
         $successMessage = \sprintf(
-            'Added account with email "%s" to the "Admin" group',
-            $email
+            'Added account with email "%s" to the "%s" group',
+            $email,
+            $roleName
         );
 
         $this->assertContains($successMessage, $commandTester->getDisplay());

--- a/tests/Unit/Console/Command/ReviewerDemoteCommandTest.php
+++ b/tests/Unit/Console/Command/ReviewerDemoteCommandTest.php
@@ -67,7 +67,9 @@ final class ReviewerDemoteCommandTest extends Framework\TestCase
 
     public function testExecuteFailsIfUserDoesNotExist()
     {
-        $email= $this->getFaker()->email;
+        $email = $this->getFaker()->email;
+
+        $roleName = 'Reviewer';
 
         $accountManagement = $this->createAccountManagementMock();
 
@@ -88,8 +90,9 @@ final class ReviewerDemoteCommandTest extends Framework\TestCase
         $this->assertSame(1, $commandTester->getStatusCode());
 
         $sectionMessage = \sprintf(
-            'Demoting account with email "%s" from "Reviewer"',
-            $email
+            'Demoting account with email "%s" from "%s"',
+            $email,
+            $roleName
         );
 
         $this->assertContains($sectionMessage, $commandTester->getDisplay());
@@ -106,6 +109,8 @@ final class ReviewerDemoteCommandTest extends Framework\TestCase
     {
         $email = $this->getFaker()->email;
 
+        $roleName = 'Reviewer';
+
         $user = $this->createUserMock();
 
         $accountManagement = $this->createAccountManagementMock();
@@ -121,7 +126,7 @@ final class ReviewerDemoteCommandTest extends Framework\TestCase
             ->method('demoteFrom')
             ->with(
                 $this->identicalTo($email),
-                $this->identicalTo('Reviewer')
+                $this->identicalTo($roleName)
             );
 
         $command = new ReviewerDemoteCommand($accountManagement);
@@ -135,15 +140,17 @@ final class ReviewerDemoteCommandTest extends Framework\TestCase
         $this->assertSame(0, $commandTester->getStatusCode());
 
         $sectionMessage = \sprintf(
-            'Demoting account with email "%s" from "Reviewer"',
-            $email
+            'Demoting account with email "%s" from "%s"',
+            $email,
+            $roleName
         );
 
         $this->assertContains($sectionMessage, $commandTester->getDisplay());
 
         $successMessage = \sprintf(
-            'Removed account with email "%s" from the "Reviewer" group',
-            $email
+            'Removed account with email "%s" from the "%s" group',
+            $email,
+            $roleName
         );
 
         $this->assertContains($successMessage, $commandTester->getDisplay());

--- a/tests/Unit/Console/Command/ReviewerPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/ReviewerPromoteCommandTest.php
@@ -67,7 +67,9 @@ final class ReviewerPromoteCommandTest extends Framework\TestCase
 
     public function testExecuteFailsIfUserDoesNotExist()
     {
-        $email= $this->getFaker()->email;
+        $email = $this->getFaker()->email;
+
+        $roleName = 'Reviewer';
 
         $accountManagement = $this->createAccountManagementMock();
 
@@ -88,8 +90,9 @@ final class ReviewerPromoteCommandTest extends Framework\TestCase
         $this->assertSame(1, $commandTester->getStatusCode());
 
         $sectionMessage = \sprintf(
-            'Promoting account with email "%s" to "Reviewer"',
-            $email
+            'Promoting account with email "%s" to "%s"',
+            $email,
+            $roleName
         );
 
         $this->assertContains($sectionMessage, $commandTester->getDisplay());
@@ -105,6 +108,8 @@ final class ReviewerPromoteCommandTest extends Framework\TestCase
     public function testExecuteSucceedsIfUserExists()
     {
         $email = $this->getFaker()->email;
+
+        $roleName = 'Reviewer';
 
         $user = $this->createUserMock();
 
@@ -135,15 +140,17 @@ final class ReviewerPromoteCommandTest extends Framework\TestCase
         $this->assertSame(0, $commandTester->getStatusCode());
 
         $sectionMessage = \sprintf(
-            'Promoting account with email "%s" to "Reviewer"',
-            $email
+            'Promoting account with email "%s" to "%s"',
+            $email,
+            $roleName
         );
 
         $this->assertContains($sectionMessage, $commandTester->getDisplay());
 
         $successMessage = \sprintf(
-            'Added account with email "%s" to the "Reviewer" group',
-            $email
+            'Added account with email "%s" to the "%s" group',
+            $email,
+            $roleName
         );
 
         $this->assertContains($successMessage, $commandTester->getDisplay());


### PR DESCRIPTION
This PR

* [x] extracts a variable for the role name