### PR TITLE
Enhancement: Throw RoleNotFoundException if role was not found

### DIFF
--- a/classes/Domain/Services/AccountManagement.php
+++ b/classes/Domain/Services/AccountManagement.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Domain\Services;
 
+use OpenCFP\Infrastructure\Auth\RoleNotFoundException;
 use OpenCFP\Infrastructure\Auth\UserExistsException;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Infrastructure\Auth\UserNotFoundException;
@@ -38,11 +39,13 @@ interface AccountManagement
     public function findByLogin(string $email): UserInterface;
 
     /**
-     * @param string $role
+     * @param string $name
+     *
+     * @throws RoleNotFoundException
      *
      * @return UserInterface[]
      */
-    public function findByRole(string $role): array;
+    public function findByRole(string $name): array;
 
     /**
      * @param string $email
@@ -64,17 +67,19 @@ interface AccountManagement
 
     /**
      * @param string $email
-     * @param string $role
+     * @param string $roleName
      *
+     * @throws RoleNotFoundException
      * @throws UserNotFoundException
      */
-    public function promoteTo(string $email, string $role);
+    public function promoteTo(string $email, string $roleName);
 
     /**
      * @param string $email
-     * @param string $role
+     * @param string $roleName
      *
+     * @throws RoleNotFoundException
      * @throws UserNotFoundException
      */
-    public function demoteFrom(string $email, string $role);
+    public function demoteFrom(string $email, string $roleName);
 }

--- a/classes/Infrastructure/Auth/RoleNotFoundException.php
+++ b/classes/Infrastructure/Auth/RoleNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Infrastructure\Auth;
+
+final class RoleNotFoundException extends \RuntimeException
+{
+    public static function fromName(string $name): self
+    {
+        return new self(\sprintf(
+            'Unable to find a role with name "%s".',
+            $name
+        ));
+    }
+}

--- a/classes/Infrastructure/Auth/SentinelAccountManagement.php
+++ b/classes/Infrastructure/Auth/SentinelAccountManagement.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Infrastructure\Auth;
 
+use Cartalyst\Sentinel\Roles;
 use Cartalyst\Sentinel\Sentinel;
 use Cartalyst\Sentinel\Users\UserInterface as SentinelUserInterface;
 use OpenCFP\Domain\Services\AccountManagement;
@@ -50,9 +51,15 @@ final class SentinelAccountManagement implements AccountManagement
         throw UserNotFoundException::fromEmail($email);
     }
 
-    public function findByRole(string $role): array
+    public function findByRole(string $name): array
     {
-        return $this->sentinel->getRoleRepository()->findByName($role)->getUsers()->toArray();
+        $role = $this->sentinel->getRoleRepository()->findByName($name);
+
+        if (!$role instanceof Roles\RoleInterface) {
+            throw RoleNotFoundException::fromName($name);
+        }
+
+        return $role->getUsers()->toArray();
     }
 
     public function create(string $email, string $password, array $data = []): UserInterface
@@ -89,20 +96,28 @@ final class SentinelAccountManagement implements AccountManagement
         return $this->sentinel->getActivationRepository()->complete($user, $activationCode);
     }
 
-    public function promoteTo(string $email, string $role)
+    public function promoteTo(string $email, string $roleName)
     {
-        $this->sentinel
-            ->getRoleRepository()
-            ->findByName(\strtolower($role))
+        $role = $this->sentinel->getRoleRepository()->findByName(\strtolower($roleName));
+
+        if (!$role instanceof Roles\RoleInterface) {
+            throw RoleNotFoundException::fromName($roleName);
+        }
+
+        $role
             ->users()
             ->attach($this->findByLogin($email)->getId());
     }
 
-    public function demoteFrom(string $email, string $role)
+    public function demoteFrom(string $email, string $roleName)
     {
-        $this->sentinel
-            ->getRoleRepository()
-            ->findByName(\strtolower($role))
+        $role = $this->sentinel->getRoleRepository()->findByName(\strtolower($roleName));
+
+        if (!$role instanceof Roles\RoleInterface) {
+            throw RoleNotFoundException::fromName($roleName);
+        }
+
+        $role
             ->users()
             ->detach($this->findByLogin($email)->getId());
     }

--- a/tests/Unit/Infrastructure/Auth/RoleNotFoundExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleNotFoundExceptionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Unit\Infrastructure\Auth;
+
+use OpenCFP\Infrastructure\Auth\RoleNotFoundException;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
+
+/**
+ * @covers \OpenCFP\Infrastructure\Auth\RoleNotFoundException
+ */
+final class RoleNotFoundExceptionTest extends \PHPUnit\Framework\TestCase
+{
+    use GeneratorTrait;
+
+    public function testIsFinal()
+    {
+        $reflection = new \ReflectionClass(RoleNotFoundException::class);
+
+        $this->assertTrue($reflection->isFinal());
+    }
+
+    public function testIsRuntimeException()
+    {
+        $exception = new RoleNotFoundException();
+
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
+    }
+
+    public function testFromNameReturnsException()
+    {
+        $name = $this->getFaker()->word;
+
+        $exception = RoleNotFoundException::fromName($name);
+
+        $this->assertInstanceOf(RoleNotFoundException::class, $exception);
+
+        $message = \sprintf(
+            'Unable to find a role with name "%s".',
+            $name
+        );
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a `RoleNotFoundException`
* [x] throws a `RoleNotFoundException` if a role was not found