### PR TITLE
Fix: Move CONTRIBUTING.md into .github

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,6 +77,6 @@ to run both all the tests and to automatically fix code style issues.
 
 ## Credit
 
-This [CONTRIBUTING.md](CONTRIBUTING.md) format was graciously lifted from The PHP League's [example](https://github.com/thephpleague/skeleton/blob/master/CONTRIBUTING.md). Thanks!
+This `CONTRIBUTING.md` format was graciously lifted from The PHP League's [example](https://github.com/thephpleague/skeleton/blob/master/CONTRIBUTING.md). Thanks!
 
 **Happy coding**!

--- a/README.md
+++ b/README.md
@@ -50,12 +50,7 @@ You can find screenshots of the application in our [wiki](https://github.com/ope
 
 ## [Contributing](#contributing)
 
-We welcome and love contributions! To facilitate receiving updates to OpenCFP, we encourage you to create a new
-personal branch after you fork this repository. This branch should be used for content and changes that are specific
-to your event. However, anything you are willing to push back should be updated in your master branch. This will help
-keep the master branch generic for future event organizers that choose to use the system. You would then be able to
-merge master to your private branch and get updates when desired!
-
+See [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## [Requirements](#requirements)
 


### PR DESCRIPTION
This PR

* [x] moves `CONTRIBUTING.md` into `.github/`

Follows #365.