### PR TITLE
Fix: Increase visibility of services shared by container

### DIFF
--- a/bin/opencfp
+++ b/bin/opencfp
@@ -10,6 +10,7 @@ use OpenCFP\Console\Application;
 use OpenCFP\Console\Command;
 use OpenCFP\Domain\Services;
 use OpenCFP\Environment;
+use OpenCFP\PathInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 
 $basePath    = \realpath(\dirname(__DIR__));
@@ -18,8 +19,11 @@ $environment = $input->getParameterOption(['--env'], \getenv('CFP_ENV') ?: 'deve
 
 $container = new ApplicationContainer($basePath, Environment::fromString($environment));
 
+/** @var Services\AccountManagement $accountManagement */
 $accountManagement = $container[Services\AccountManagement::class];
-$path              = $container['path'];
+
+/** @var PathInterface $path */
+$path = $container['path'];
 
 $app = new Application($container);
 

--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -25,7 +25,11 @@ class DashboardController extends BaseController
 {
     public function indexAction()
     {
-        $userId        = $this->service(Authentication::class)->userId();
+        /** @var Authentication $authentication */
+        $authentication = $this->service(Authentication::class);
+
+        $userId = $authentication->userId();
+
         $talkFormatter = new TalkFormatter();
 
         /** @var Collection $recentTalks */

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -15,6 +15,7 @@ namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Http\Controller\BaseController;
+use Symfony\Component\HttpFoundation\Session;
 
 class ExportsController extends BaseController
 {
@@ -105,7 +106,10 @@ class ExportsController extends BaseController
     private function csvReturn(array $contents, string $filename = 'data')
     {
         if (\count($contents) === 0) {
-            $this->service('session')->set('flash', [
+            /** @var Session\Session $session */
+            $session = $this->service('session');
+
+            $session->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
                 'ext'   => 'There were no talks that matched selected criteria.',

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -20,6 +20,7 @@ use OpenCFP\Domain\Talk\TalkHandler;
 use OpenCFP\Domain\ValidationException;
 use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session;
 
 class TalksController extends BaseController
 {
@@ -34,7 +35,10 @@ class TalksController extends BaseController
             'sort'     => $request->get('sort'),
         ];
 
-        $formattedTalks = $this->service(TalkFilter::class)->getTalks(
+        /** @var TalkFilter $talkFilter */
+        $talkFilter = $this->service(TalkFilter::class);
+
+        $formattedTalks = $talkFilter->getTalks(
             $adminUserId,
             $request->get('filter'),
             $options
@@ -65,11 +69,15 @@ class TalksController extends BaseController
     public function viewAction(Request $request)
     {
         /** @var TalkHandler $handler */
-        $handler = $this->service(TalkHandler::class)
-            ->grabTalk((int) $request->get('id'));
+        $handler = $this->service(TalkHandler::class);
+
+        $handler->grabTalk((int) $request->get('id'));
 
         if (!$handler->view()) {
-            $this->service('session')->set('flash', [
+            /** @var Session\Session $session */
+            $session = $this->service('session');
+
+            $session->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
                 'ext'   => 'Could not find requested talk',
@@ -88,7 +96,10 @@ class TalksController extends BaseController
                 'rating' => 'required|integer',
             ]);
 
-            return $this->service(TalkHandler::class)
+            /** @var TalkHandler $talkHandler */
+            $talkHandler = $this->service(TalkHandler::class);
+
+            return $talkHandler
                 ->grabTalk((int) $request->get('id'))
                 ->rate((int) $request->get('rating'));
         } catch (ValidationException $e) {
@@ -105,7 +116,10 @@ class TalksController extends BaseController
      */
     public function favoriteAction(Request $request)
     {
-        return $this->service(TalkHandler::class)
+        /** @var TalkHandler $talkHandler */
+        $talkHandler = $this->service(TalkHandler::class);
+
+        return $talkHandler
             ->grabTalk((int) $request->get('id'))
             ->setFavorite($request->get('delete') == null);
     }
@@ -119,7 +133,10 @@ class TalksController extends BaseController
      */
     public function selectAction(Request $request)
     {
-        return $this->service(TalkHandler::class)
+        /** @var TalkHandler $talkHandler */
+        $talkHandler = $this->service(TalkHandler::class);
+
+        return $talkHandler
             ->grabTalk((int) $request->get('id'))
             ->select($request->get('delete') != true);
     }
@@ -128,15 +145,21 @@ class TalksController extends BaseController
     {
         $talkId = (int) $request->get('id');
 
-        $this->service(TalkHandler::class)
+        /** @var TalkHandler $talkHandler */
+        $talkHandler = $this->service(TalkHandler::class);
+
+        $talkHandler
             ->grabTalk($talkId)
             ->commentOn($request->get('comment'));
 
-        $this->service('session')->set('flash', [
-                'type'  => 'success',
-                'short' => 'Success',
-                'ext'   => 'Comment Added!',
-            ]);
+        /** @var Session\Session $session */
+        $session = $this->service('session');
+
+        $session->set('flash', [
+            'type'  => 'success',
+            'short' => 'Success',
+            'ext'   => 'Comment Added!',
+        ]);
 
         return $this->app->redirect($this->url('admin_talk_view', ['id' => $talkId]));
     }

--- a/classes/Http/Controller/BaseController.php
+++ b/classes/Http/Controller/BaseController.php
@@ -22,6 +22,7 @@ use OpenCFP\ContainerAware;
 use OpenCFP\Domain\ValidationException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -61,7 +62,10 @@ abstract class BaseController
      */
     protected function url($route, $parameters = [])
     {
-        return $this->service('url_generator')->generate($route, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
+        /** @var UrlGeneratorInterface $urlGenerator */
+        $urlGenerator = $this->service('url_generator');
+
+        return $urlGenerator->generate($route, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**
@@ -105,8 +109,10 @@ abstract class BaseController
 
     protected function validate($rules = [], $messages = [], $customAttributes = [])
     {
-        /** @var Request $request */
-        $request = $this->service('request_stack')->getCurrentRequest();
+        /** @var RequestStack $requestStack */
+        $requestStack = $this->service('request_stack');
+
+        $request = $requestStack->getCurrentRequest();
         $data    = $request->query->all() + $request->request->all() + $request->files->all();
 
         $validation = new Factory(

--- a/classes/Http/Controller/Reviewer/DashboardController.php
+++ b/classes/Http/Controller/Reviewer/DashboardController.php
@@ -25,7 +25,11 @@ class DashboardController extends BaseController
 {
     public function indexAction()
     {
-        $userId        = $this->service(Authentication::class)->userId();
+        /** @var Authentication $authentication */
+        $authentication = $this->service(Authentication::class);
+
+        $userId = $authentication->userId();
+
         $talkFormatter = new TalkFormatter();
 
         /** @var Collection $recentTalks */

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -18,6 +18,7 @@ use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session;
 
 class SpeakersController extends BaseController
 {
@@ -45,7 +46,10 @@ class SpeakersController extends BaseController
         $speakerDetails = User::where('id', $request->get('id'))->first();
 
         if (!$speakerDetails instanceof User) {
-            $this->service('session')->set('flash', [
+            /** @var Session\Session $session */
+            $session = $this->service('session');
+
+            $session->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
                 'ext'   => 'Could not find requested speaker',

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -16,6 +16,7 @@ namespace OpenCFP\Http\Controller;
 use OpenCFP\Domain\Services\Authentication;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session;
 
 class SecurityController extends BaseController
 {
@@ -36,7 +37,10 @@ class SecurityController extends BaseController
 
             return $this->redirectTo('dashboard');
         } catch (\Exception $e) {
-            $this->service('session')->set('flash', [
+            /** @var Session\Session $session */
+            $session = $this->service('session');
+
+            $session->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
                 'ext'   => $e->getMessage(),
@@ -53,7 +57,10 @@ class SecurityController extends BaseController
 
     public function outAction()
     {
-        $this->service(Authentication::class)->logout();
+        /** @var Authentication $authentication */
+        $authentication = $this->service(Authentication::class);
+
+        $authentication->logout();
 
         return $this->redirectTo('homepage');
     }

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -18,21 +18,27 @@ use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\ValidationException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session;
 
 class SignupController extends BaseController
 {
     public function indexAction()
     {
+        /** @var Authentication $auth */
         $auth = $this->service(Authentication::class);
 
         if ($auth->isAuthenticated()) {
             return $this->redirectTo('dashboard');
         }
 
+        /** @var CallForPapers $cfp */
         $cfp = $this->service(CallForPapers::class);
 
         if (!$cfp->isOpen()) {
-            $this->service('session')->set('flash', [
+            /** @var Session\Session $session */
+            $session = $this->service('session');
+
+            $session->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
                 'ext'   => 'Sorry, the call for papers has ended.',
@@ -67,8 +73,11 @@ class SignupController extends BaseController
                 'ext'   => "You've successfully created your account!",
             ]);
 
+            /** @var Authentication $authentication */
+            $authentication = $this->service(Authentication::class);
+
             // Automatically authenticate the newly created user.
-            $this->service(Authentication::class)->authenticate($request->get('email'), $request->get('password'));
+            $authentication->authenticate($request->get('email'), $request->get('password'));
 
             return $this->redirectTo('dashboard');
         } catch (ValidationException $e) {


### PR DESCRIPTION
This PR

* [x] increases the visibility of services shared by the application container

💁‍♂️ Introducing temporary variables for services fetched from the application container allows to annotate them with the type to which they resolve, and thus increases visibility - making it easier to see which services are actually used, as well as navigating the code.