### PR TITLE
Fix: Set background-size to cover

### DIFF
--- a/resources/views/home.twig
+++ b/resources/views/home.twig
@@ -1,7 +1,7 @@
 {% extends "layouts/default.twig" %}
 
 {% block header %}
-    <header id="hero" class="bg-cover p-24" style="background:linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url({{ app.config.application.venue_image_path }}) no-repeat center -300px fixed;">
+    <header id="hero" class="bg-cover p-24" style="background:linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url({{ app.config.application.venue_image_path }}) no-repeat center -300px / cover fixed;">
         <div class="container mx-auto flex">
             <div class="p-8 bg-brand text-white">
                 {% if cfp_open %}

--- a/resources/views/layouts/splash.twig
+++ b/resources/views/layouts/splash.twig
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="/assets/css/app.css" rel="stylesheet" media="screen">
     </head>
-    <body class="h-full border-t-4 border-brand bg-cover flex items-center justify-center" style="background:linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url({{ app.config.application.venue_image_path }}) no-repeat center center fixed;">
+    <body class="h-full border-t-4 border-brand bg-cover flex items-center justify-center" style="background:linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url({{ app.config.application.venue_image_path }}) no-repeat center center / cover fixed;">
 
         {% block content %}
         {% endblock %}


### PR DESCRIPTION
This PR

* [x] sets the `background-size` for hero images to `cover`

💁‍♂️ This mostly affects larger displays, but I think it wasn't intended to look as it does.

### Before

![screen shot 2017-12-03 at 15 23 21](https://user-images.githubusercontent.com/605483/33526212-1338c396-d83e-11e7-8b58-754a3523075e.png)
![screen shot 2017-12-03 at 15 23 26](https://user-images.githubusercontent.com/605483/33526213-13541380-d83e-11e7-958e-3d3c34019b25.png)
![screen shot 2017-12-03 at 15 23 31](https://user-images.githubusercontent.com/605483/33526214-136de7b0-d83e-11e7-9356-61dadf13243e.png)

### After

![screen shot 2017-12-03 at 15 23 44](https://user-images.githubusercontent.com/605483/33526219-1ecf40fe-d83e-11e7-81a6-d8bbb18e7d39.png)
![screen shot 2017-12-03 at 15 23 47](https://user-images.githubusercontent.com/605483/33526220-1ee8027e-d83e-11e7-8239-2aa982f39d35.png)
![screen shot 2017-12-03 at 15 23 51](https://user-images.githubusercontent.com/605483/33526221-1f0150d0-d83e-11e7-849a-a1e0574bb53b.png)
