### PR TITLE
Fix: Limit airport to 3 characters

### DIFF
--- a/migrations/20171203144758_limit_airport_to_three_characters.php
+++ b/migrations/20171203144758_limit_airport_to_three_characters.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+final class LimitAirportToThreeCharacters extends AbstractMigration
+{
+    public function change()
+    {
+        $table = $this->table('users');
+
+        $table->changeColumn('airport', 'string', [
+            'length' => 3,
+            'null'   => true,
+        ]);
+    }
+}

--- a/resources/views/forms/_user.twig
+++ b/resources/views/forms/_user.twig
@@ -43,7 +43,7 @@
 
             {% if site.online_conference == false %}
                 <label for="form-user-airport">Departing Airport Code</label>
-                <input id="form-user-airport" type="text" name="airport" placeholder="3 Characters" value="{{ airport | default('') }}">
+                <input id="form-user-airport" type="text" name="airport" maxlength="3" placeholder="3 Characters" value="{{ airport | default('') }}">
             {% endif %}
 
             <label for="form-user-notes">Additional Notes</label>


### PR DESCRIPTION
This PR

* [x] limits the length of the `airport` field to `3` characters

💁‍♂️ We should probably also update validation, but I couldn't find any.