### PR TITLE
Fix: Rename method

### DIFF
--- a/classes/Domain/Services/Authentication.php
+++ b/classes/Domain/Services/Authentication.php
@@ -50,7 +50,7 @@ interface Authentication
      *
      * @return bool
      */
-    public function check(): bool;
+    public function isAuthenticated(): bool;
 
     /**
      * Determine whether the user is a non-authenticated guest.

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -25,7 +25,7 @@ class SignupController extends BaseController
     {
         $auth = $this->service(Authentication::class);
 
-        if ($auth->check()) {
+        if ($auth->isAuthenticated()) {
             return $this->redirectTo('dashboard');
         }
 

--- a/classes/Infrastructure/Auth/RoleAccess.php
+++ b/classes/Infrastructure/Auth/RoleAccess.php
@@ -29,7 +29,7 @@ class RoleAccess implements UserAccess
      */
     public static function userHasAccess(Authentication $auth, string $role = 'admin')
     {
-        if (!$auth->check()) {
+        if (!$auth->isAuthenticated()) {
             return new RedirectResponse('/dashboard');
         }
 

--- a/classes/Infrastructure/Auth/SentinelAuthentication.php
+++ b/classes/Infrastructure/Auth/SentinelAuthentication.php
@@ -90,7 +90,7 @@ final class SentinelAuthentication implements Authentication
     /**
      * Determines whether or not the user is logged in.
      */
-    public function check(): bool
+    public function isAuthenticated(): bool
     {
         return $this->sentinel->check() !== false;
     }

--- a/classes/Infrastructure/Auth/SpeakerAccess.php
+++ b/classes/Infrastructure/Auth/SpeakerAccess.php
@@ -29,7 +29,7 @@ class SpeakerAccess implements UserAccess
      */
     public static function userHasAccess(Authentication $auth, string $role = '')
     {
-        if (!$auth->check()) {
+        if (!$auth->isAuthenticated()) {
             return new RedirectResponse('/dashboard');
         }
     }

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -53,7 +53,7 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
             }));
 
             // Authentication
-            if ($app[Authentication::class]->check()) {
+            if ($app[Authentication::class]->isAuthenticated()) {
                 $twig->addGlobal('user', $app[Authentication::class]->user());
                 $twig->addGlobal('user_is_admin', $app[Authentication::class]->user()->hasAccess('admin'));
                 $twig->addGlobal('user_is_reviewer', $app[Authentication::class]->user()->hasAccess('reviewer'));

--- a/tests/Integration/Http/Controller/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/DashboardControllerTest.php
@@ -43,7 +43,7 @@ class DashboardControllerTest extends WebTestCase
         $user->shouldReceive('hasAccess')->with('reviewer')->andReturn(false);
 
         $auth = m::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
         $auth->shouldReceive('user')->andReturn($user);
         $this->swap(Authentication::class, $auth);
 
@@ -86,7 +86,7 @@ class DashboardControllerTest extends WebTestCase
         $user->shouldReceive('id')->andReturn(1);
         $user->shouldReceive('hasAccess')->with('admin')->andReturn(false);
         $auth = m::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
         $auth->shouldReceive('user')->andReturn($user);
         $this->swap(Authentication::class, $auth);
         $this->swap('user', $user);

--- a/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -47,7 +47,7 @@ class SentinelAuthenticationTest extends BaseTestCase
     public function existing_user_can_authenticate()
     {
         $this->sut->authenticate('test@example.com', 'secret');
-        $this->assertTrue($this->sut->check());
+        $this->assertTrue($this->sut->isAuthenticated());
 
         $user = $this->sut->user();
 
@@ -86,9 +86,9 @@ class SentinelAuthenticationTest extends BaseTestCase
      */
     public function checkWorks()
     {
-        $this->assertFalse($this->sut->check());
+        $this->assertFalse($this->sut->isAuthenticated());
         $this->sut->authenticate('test@example.com', 'secret');
-        $this->assertTrue($this->sut->check());
+        $this->assertTrue($this->sut->isAuthenticated());
     }
 
     /**

--- a/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
@@ -34,7 +34,7 @@ final class RoleAccessTest extends \PHPUnit\Framework\TestCase
         $role = $this->getFaker()->word;
 
         $auth = Mockery::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(false);
+        $auth->shouldReceive('isAuthenticated')->andReturn(false);
 
         $this->assertInstanceOf(RedirectResponse::class, RoleAccess::userHasAccess($auth, $role));
     }
@@ -47,7 +47,7 @@ final class RoleAccessTest extends \PHPUnit\Framework\TestCase
         $user->shouldReceive('hasAccess')->with($role)->andReturn(false);
 
         $auth = Mockery::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
         $auth->shouldReceive('user')->andReturn($user);
 
         $this->assertInstanceOf(RedirectResponse::class, RoleAccess::userHasAccess($auth, $role));
@@ -61,7 +61,7 @@ final class RoleAccessTest extends \PHPUnit\Framework\TestCase
         $user->shouldReceive('hasAccess')->with($role)->andReturn(true);
 
         $auth = Mockery::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
         $auth->shouldReceive('user')->andReturn($user);
 
         $this->assertNull(RoleAccess::userHasAccess($auth, $role));

--- a/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -134,7 +134,7 @@ class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
         $account  = Mockery::mock(AccountManagement::class);
         $sentinel->shouldReceive('check')->andReturn($user);
         $auth    = new SentinelAuthentication($sentinel, $account);
-        $this->assertTrue($auth->check());
+        $this->assertTrue($auth->isAuthenticated());
     }
 
     public function testCheckReturnsFalseWhenNotLoggedIn()
@@ -143,7 +143,7 @@ class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
         $account  = Mockery::mock(AccountManagement::class);
         $sentinel->shouldReceive('check')->andReturn(false);
         $auth    = new SentinelAuthentication($sentinel, $account);
-        $this->assertFalse($auth->check());
+        $this->assertFalse($auth->isAuthenticated());
     }
 
     public function testGuestReturnsTheOppositeOfCheck()

--- a/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
@@ -26,7 +26,7 @@ final class SpeakerAccessTest extends \PHPUnit\Framework\TestCase
     public function testReturnsRedirectResponseIfCheckFailed()
     {
         $auth = Mockery::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(false);
+        $auth->shouldReceive('isAuthenticated')->andReturn(false);
 
         $this->assertInstanceOf(RedirectResponse::class, SpeakerAccess::userHasAccess($auth));
     }
@@ -34,7 +34,7 @@ final class SpeakerAccessTest extends \PHPUnit\Framework\TestCase
     public function testReturnsNothingIfCheckSucceeded()
     {
         $auth = Mockery::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
 
         $this->assertNull(SpeakerAccess::userHasAccess($auth));
     }

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -175,7 +175,7 @@ abstract class WebTestCase extends BaseTestCase
         $user->shouldReceive('getLogin')->andReturn('my@email.com');
 
         $auth = Mockery::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
         $auth->shouldReceive('user')->andReturn($user);
         $auth->shouldReceive('userId')->andReturn($id);
         $this->swap(Authentication::class, $auth);
@@ -194,7 +194,7 @@ abstract class WebTestCase extends BaseTestCase
         $user->shouldReceive('hasPermission')->with('reviewer')->andReturn(false);
         $auth = Mockery::mock(Authentication::class);
 
-        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
         $auth->shouldReceive('user')->andReturn($user);
         $auth->shouldReceive('userId')->andReturn($id);
         $this->swap(Authentication::class, $auth);
@@ -213,7 +213,7 @@ abstract class WebTestCase extends BaseTestCase
         $user->shouldReceive('hasPermission')->with('reviewer')->andReturn(true);
 
         $auth = Mockery::mock(Authentication::class);
-        $auth->shouldReceive('check')->andReturn(true);
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
         $auth->shouldReceive('user')->andReturn($user);
         $auth->shouldReceive('userId')->andReturn($id);
         $this->swap(Authentication::class, $auth);


### PR DESCRIPTION
This PR

* [x] renames `Authentication::check()` to `Authentication::isAuthenticated()`

💁‍♂️ I believe something like `isAuthenticated()` or `isSignedIn()` or `isLoggedIn()` reveals the intent better than something as generic as `check()`. It also aligns nicely with the [`Authentication::authenticate()`](https://github.com/opencfp/opencfp/blob/d872d646e9b561e9cb8ed41fc3e1a4abdbaddfeb/classes/Domain/Services/Authentication.php#L20-L28).