### PR TITLE
Fix: Mark getFaker() as final

### DIFF
--- a/tests/Helper/Faker/GeneratorTrait.php
+++ b/tests/Helper/Faker/GeneratorTrait.php
@@ -18,7 +18,7 @@ use Faker\Generator;
 
 trait GeneratorTrait
 {
-    protected function getFaker(): Generator
+    final protected function getFaker(): Generator
     {
         static $faker;
 

--- a/tests/Unit/Faker/GeneratorTest.php
+++ b/tests/Unit/Faker/GeneratorTest.php
@@ -23,6 +23,15 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
 {
     use GeneratorTrait;
 
+    public function testGetFakerIsFinal()
+    {
+        $reflection = new \ReflectionClass(GeneratorTrait::class);
+
+        $method = $reflection->getMethod('getFaker');
+
+        $this->assertTrue($method->isFinal());
+    }
+
     public function testGetFakerReturnsFaker()
     {
         $faker = $this->getFaker();


### PR DESCRIPTION
This PR

* [x] marks the method `getFaker()` as `final`

💁‍♂️ This prevents needlessly importing the `GeneratorTrait` multiple times along an inheritance chain.