### PR TITLE
Fix: Pull up import of GeneratorTrait

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -17,10 +17,12 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenCFP\Application;
 use OpenCFP\Environment;
 use OpenCFP\Test\Helper\DataBaseInteraction;
+use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 use OpenCFP\Test\Helper\RefreshDatabase;
 
 abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 {
+    use GeneratorTrait;
     use MockeryPHPUnitIntegration;
 
     /**

--- a/tests/Integration/Http/Controller/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/DashboardControllerTest.php
@@ -17,7 +17,6 @@ use Mockery as m;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Infrastructure\Auth\UserInterface;
-use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 use OpenCFP\Test\WebTestCase;
 
 /**
@@ -26,8 +25,6 @@ use OpenCFP\Test\WebTestCase;
  */
 class DashboardControllerTest extends WebTestCase
 {
-    use GeneratorTrait;
-
     /**
      * Test that the index page returns a list of talks associated
      * with a specific user and information about that user as well

--- a/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
@@ -20,15 +20,12 @@ use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Domain\Speaker\SpeakerRepository;
 use OpenCFP\Infrastructure\Auth\SentinelIdentityProvider;
 use OpenCFP\Test\BaseTestCase;
-use OpenCFP\Test\Helper\Faker\GeneratorTrait;
 
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentinelIdentityProvider
  */
 class SentinelIdentityProviderTest extends BaseTestCase
 {
-    use GeneratorTrait;
-
     public function testIsFinal()
     {
         $reflection = new \ReflectionClass(SentinelIdentityProvider::class);


### PR DESCRIPTION
This PR

* [x] pulls up the import of the `GeneratorTrait`

Follows #836.