### PR TITLE
Enhancement: Catch generic exception

### DIFF
--- a/classes/Console/Command/UserDemoteCommand.php
+++ b/classes/Console/Command/UserDemoteCommand.php
@@ -90,6 +90,13 @@ EOF
             ));
 
             return 1;
+        } catch (\Exception $exception) {
+            $io->error(\sprintf(
+                'Could not demote account with email "%s".',
+                $email
+            ));
+
+            return 1;
         }
 
         $io->success(\sprintf(

--- a/classes/Console/Command/UserPromoteCommand.php
+++ b/classes/Console/Command/UserPromoteCommand.php
@@ -90,6 +90,13 @@ EOF
             ));
 
             return 1;
+        } catch (\Exception $exception) {
+            $io->error(\sprintf(
+                'Could not promote account with email "%s".',
+                $email
+            ));
+
+            return 1;
         }
 
         $io->success(\sprintf(


### PR DESCRIPTION
This PR

* [x] catches generic exceptions thrown during `AccountManagemenht::demoteFrom()` and `AccountManagement::promoteTo()`

Follows https://github.com/opencfp/opencfp/pull/824#issuecomment-348823711.