### PR TITLE
Enhancement: Catch RoleNotFoundException

### DIFF
--- a/classes/Console/Command/UserDemoteCommand.php
+++ b/classes/Console/Command/UserDemoteCommand.php
@@ -83,6 +83,13 @@ EOF
             ));
 
             return 1;
+        } catch (Auth\RoleNotFoundException $exception) {
+            $io->error(\sprintf(
+                'Could not find role with name "%s".',
+                $roleName
+            ));
+
+            return 1;
         }
 
         $io->success(\sprintf(

--- a/classes/Console/Command/UserPromoteCommand.php
+++ b/classes/Console/Command/UserPromoteCommand.php
@@ -83,6 +83,13 @@ EOF
             ));
 
             return 1;
+        } catch (Auth\RoleNotFoundException $exception) {
+            $io->error(\sprintf(
+                'Could not find role with name "%s".',
+                $roleName
+            ));
+
+            return 1;
         }
 
         $io->success(\sprintf(

--- a/tests/Unit/Console/Command/UserPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserPromoteCommandTest.php
@@ -126,7 +126,52 @@ final class UserPromoteCommandTest extends Framework\TestCase
         $this->assertContains($failureMessage, $commandTester->getDisplay());
     }
 
-    public function testExecuteSucceedsIfUserWasFound()
+    public function testExecuteFailsIfRoleWasNotFound()
+    {
+        $faker = $this->getFaker();
+
+        $email    = $faker->email;
+        $roleName = $faker->word;
+
+        $accountManagement = $this->createAccountManagementMock();
+
+        $accountManagement
+            ->expects($this->once())
+            ->method('promoteTo')
+            ->with(
+                $this->identicalTo($email),
+                $this->identicalTo($roleName)
+            )
+            ->willThrowException(new Auth\RoleNotFoundException());
+
+        $command = new UserPromoteCommand($accountManagement);
+
+        $commandTester = new Console\Tester\CommandTester($command);
+
+        $commandTester->execute([
+            'email'     => $email,
+            'role-name' => $roleName,
+        ]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+
+        $sectionMessage = \sprintf(
+            'Promoting account with email "%s" to "%s"',
+            $email,
+            $roleName
+        );
+
+        $this->assertContains($sectionMessage, $commandTester->getDisplay());
+
+        $failureMessage = \sprintf(
+            'Could not find role with name "%s".',
+            $roleName
+        );
+
+        $this->assertContains($failureMessage, $commandTester->getDisplay());
+    }
+
+    public function testExecuteSucceedsIfUserAndRoleWereFound()
     {
         $faker = $this->getFaker();
 


### PR DESCRIPTION
This PR

* [x] catches `RoleNotFoundExceptions` thrown during `AccountManagemenht::demoteFrom()` and `AccountManagement::promoteTo()`

Follows #818.