### PR TITLE
Fix: Rename test methods

### DIFF
--- a/tests/Unit/Console/Command/UserDemoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserDemoteCommandTest.php
@@ -81,7 +81,7 @@ final class UserDemoteCommandTest extends Framework\TestCase
         $this->assertFalse($argument->isArray());
     }
 
-    public function testExecuteFailsIfUserDoesNotExist()
+    public function testExecuteFailsIfUserWasNotFound()
     {
         $faker = $this->getFaker();
 
@@ -126,7 +126,7 @@ final class UserDemoteCommandTest extends Framework\TestCase
         $this->assertContains($failureMessage, $commandTester->getDisplay());
     }
 
-    public function testExecuteSucceedsIfUserExists()
+    public function testExecuteSucceedsIfUserWasFound()
     {
         $faker = $this->getFaker();
 

--- a/tests/Unit/Console/Command/UserPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserPromoteCommandTest.php
@@ -81,7 +81,7 @@ final class UserPromoteCommandTest extends Framework\TestCase
         $this->assertFalse($argument->isArray());
     }
 
-    public function testExecuteFailsIfUserDoesNotExist()
+    public function testExecuteFailsIfUserWasNotFound()
     {
         $faker = $this->getFaker();
 
@@ -126,7 +126,7 @@ final class UserPromoteCommandTest extends Framework\TestCase
         $this->assertContains($failureMessage, $commandTester->getDisplay());
     }
 
-    public function testExecuteSucceedsIfUserExists()
+    public function testExecuteSucceedsIfUserWasFound()
     {
         $faker = $this->getFaker();
 


### PR DESCRIPTION
This PR

* [x] renames test methods

💁‍♂️ This brings them more in line with those added in #838 and #839.