### PR TITLE
Fix: Mark test classes abstract or final

### DIFF
--- a/tests/Integration/Domain/Model/AirportTest.php
+++ b/tests/Integration/Domain/Model/AirportTest.php
@@ -22,7 +22,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
  * @group db
  * @coversNothing
  */
-class AirportTest extends BaseTestCase
+final class AirportTest extends BaseTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Domain/Model/Interaction/TalkTest.php
+++ b/tests/Integration/Domain/Model/Interaction/TalkTest.php
@@ -23,7 +23,7 @@ use OpenCFP\Test\Helper\DataBaseInteraction;
 /**
  * @coversNothing
  */
-class TalkTest extends BaseTestCase
+final class TalkTest extends BaseTestCase
 {
     use DataBaseInteraction;
 

--- a/tests/Integration/Domain/Model/Interaction/UserTest.php
+++ b/tests/Integration/Domain/Model/Interaction/UserTest.php
@@ -21,7 +21,7 @@ use OpenCFP\Test\Helper\DataBaseInteraction;
 /**
  * @coversNothing
  */
-class UserTest extends BaseTestCase
+final class UserTest extends BaseTestCase
 {
     use DataBaseInteraction;
 

--- a/tests/Integration/Domain/Model/TalkMetaTest.php
+++ b/tests/Integration/Domain/Model/TalkMetaTest.php
@@ -23,7 +23,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
 /**
  * @coversNothing
  */
-class TalkMetaTest extends BaseTestCase
+final class TalkMetaTest extends BaseTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Domain/Model/TalkTest.php
+++ b/tests/Integration/Domain/Model/TalkTest.php
@@ -23,7 +23,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
  * @group db
  * @coversNothing
  */
-class TalkTest extends BaseTestCase
+final class TalkTest extends BaseTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Domain/Model/UserTest.php
+++ b/tests/Integration/Domain/Model/UserTest.php
@@ -25,7 +25,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
  * @group db
  * @coversNothing
  */
-class UserTest extends BaseTestCase
+final class UserTest extends BaseTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Domain/Services/TalkFormatterTest.php
+++ b/tests/Integration/Domain/Services/TalkFormatterTest.php
@@ -24,7 +24,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
  * @group db
  * @coversNothing
  */
-class TalkFormatterTest extends BaseTestCase
+final class TalkFormatterTest extends BaseTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Integration/Domain/Talk/TalkHandlerTest.php
@@ -27,7 +27,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
 /**
  * @coversNothing
  */
-class TalkHandlerTest extends BaseTestCase
+final class TalkHandlerTest extends BaseTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
@@ -20,7 +20,7 @@ use OpenCFP\Test\WebTestCase;
 /**
  * @coversNothing
  */
-class DashboardControllerTest extends WebTestCase
+final class DashboardControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
@@ -21,7 +21,7 @@ use OpenCFP\Test\WebTestCase;
  * @covers \OpenCFP\Http\Controller\Admin\ExportsController
  * @covers \OpenCFP\Http\Controller\BaseController
  */
-class ExportsControllerTest extends WebTestCase
+final class ExportsControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
@@ -24,7 +24,7 @@ use OpenCFP\Test\WebTestCase;
  * @group db
  * @coversNothing
  */
-class SpeakersControllerTest extends WebTestCase
+final class SpeakersControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
@@ -21,7 +21,7 @@ use OpenCFP\Test\WebTestCase;
 /**
  * @coversNothing
  */
-class TalksControllerTest extends WebTestCase
+final class TalksControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/DashboardControllerTest.php
@@ -23,7 +23,7 @@ use OpenCFP\Test\WebTestCase;
  * @group db
  * @coversNothing
  */
-class DashboardControllerTest extends WebTestCase
+final class DashboardControllerTest extends WebTestCase
 {
     /**
      * Test that the index page returns a list of talks associated

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -23,7 +23,7 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
  * @group db
  * @coversNothing
  */
-class ForgotControllerTest extends \PHPUnit\Framework\TestCase
+final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
 {
     protected $app;
 

--- a/tests/Integration/Http/Controller/PagesControllerTest.php
+++ b/tests/Integration/Http/Controller/PagesControllerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation;
 /**
  * @covers \OpenCFP\Http\Controller\PagesController
  */
-class PagesControllerTest extends WebTestCase
+final class PagesControllerTest extends WebTestCase
 {
     /**
      * @test

--- a/tests/Integration/Http/Controller/ProfileControllerTest.php
+++ b/tests/Integration/Http/Controller/ProfileControllerTest.php
@@ -21,7 +21,7 @@ use OpenCFP\Test\WebTestCase;
  * @group db
  * @coversNothing
  */
-class ProfileControllerTest extends WebTestCase
+final class ProfileControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
@@ -20,7 +20,7 @@ use OpenCFP\Test\WebTestCase;
 /**
  * @coversNothing
  */
-class DashboardControllerTest extends WebTestCase
+final class DashboardControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/Reviewer/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/SpeakersControllerTest.php
@@ -20,7 +20,7 @@ use OpenCFP\Test\WebTestCase;
 /**
  * @coversNothing
  */
-class SpeakersControllerTest extends WebTestCase
+final class SpeakersControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
@@ -20,7 +20,7 @@ use OpenCFP\Test\WebTestCase;
 /**
  * @coversNothing
  */
-class TalksControllerTest extends WebTestCase
+final class TalksControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/SignupControllerTest.php
+++ b/tests/Integration/Http/Controller/SignupControllerTest.php
@@ -20,7 +20,7 @@ use OpenCFP\Test\WebTestCase;
  * @group db
  * @coversNothing
  */
-class SignupControllerTest extends WebTestCase
+final class SignupControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -25,7 +25,7 @@ use OpenCFP\Test\WebTestCase;
  * @group db
  * @coversNothing
  */
-class TalkControllerTest extends WebTestCase
+final class TalkControllerTest extends WebTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -23,7 +23,7 @@ use OpenCFP\Test\Helper\DataBaseInteraction;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentinelAccountManagement
  */
-class SentinelAccountManagementTest extends BaseTestCase
+final class SentinelAccountManagementTest extends BaseTestCase
 {
     use DataBaseInteraction;
 

--- a/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -23,7 +23,7 @@ use OpenCFP\Test\Helper\DataBaseInteraction;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentinelAuthentication
  */
-class SentinelAuthenticationTest extends BaseTestCase
+final class SentinelAuthenticationTest extends BaseTestCase
 {
     use DataBaseInteraction;
     /**

--- a/tests/Integration/Infrastructure/Auth/SentinelUserTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelUserTest.php
@@ -23,7 +23,7 @@ use OpenCFP\Test\Helper\RefreshDatabase;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentinelUser
  */
-class SentinelUserTest extends BaseTestCase
+final class SentinelUserTest extends BaseTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Integration/MigrationsTest.php
+++ b/tests/Integration/MigrationsTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
  *
  * @coversNothing
  */
-class MigrationsTest extends BaseTestCase
+final class MigrationsTest extends BaseTestCase
 {
     /**
      * @test

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * @mixin Response
  */
-class TestResponse
+final class TestResponse
 {
     /**
      * @var Application

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -24,7 +24,7 @@ use OpenCFP\Domain\Services\IdentityProvider;
 /**
  * @covers \OpenCFP\Application\Speakers
  */
-class SpeakersTest extends \PHPUnit\Framework\TestCase
+final class SpeakersTest extends \PHPUnit\Framework\TestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -20,7 +20,7 @@ use OpenCFP\Environment;
  * @covers \OpenCFP\Application
  * @group db
  */
-class ApplicationTest extends \PHPUnit\Framework\TestCase
+final class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
     /** @var Application */
     private $sut;

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console;
  * @group db
  * @covers \OpenCFP\Console\Application
  */
-class ApplicationTest extends \PHPUnit\Framework\TestCase
+final class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
     use MockeryPHPUnitIntegration;

--- a/tests/Unit/ContainerAwareFake.php
+++ b/tests/Unit/ContainerAwareFake.php
@@ -15,7 +15,7 @@ namespace OpenCFP\Test\Unit;
 
 use OpenCFP\ContainerAware;
 
-class ContainerAwareFake
+final class ContainerAwareFake
 {
     use ContainerAware;
 

--- a/tests/Unit/ContainerAwareTest.php
+++ b/tests/Unit/ContainerAwareTest.php
@@ -19,7 +19,7 @@ use OpenCFP\Application;
 /**
  * @covers \OpenCFP\ContainerAware
  */
-class ContainerAwareTest extends \PHPUnit\Framework\TestCase
+final class ContainerAwareTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllowsToRetrieveService()
     {

--- a/tests/Unit/Domain/CallForPapersTest.php
+++ b/tests/Unit/Domain/CallForPapersTest.php
@@ -18,7 +18,7 @@ use OpenCFP\Domain\CallForPapers;
 /**
  * @covers \OpenCFP\Domain\CallForPapers
  */
-class CallForPapersTest extends \PHPUnit\Framework\TestCase
+final class CallForPapersTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/tests/Unit/Domain/Services/PaginationTest.php
+++ b/tests/Unit/Domain/Services/PaginationTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework;
 /**
  * @covers \OpenCFP\Domain\Services\Pagination
  */
-class PaginationTest extends Framework\TestCase
+final class PaginationTest extends Framework\TestCase
 {
     /**
      * @var Pagination

--- a/tests/Unit/Domain/Services/ResetEmailerTest.php
+++ b/tests/Unit/Domain/Services/ResetEmailerTest.php
@@ -23,7 +23,7 @@ use Twig_Template;
 /**
  * @covers \OpenCFP\Domain\Services\ResetEmailer
  */
-class ResetEmailerTest extends \PHPUnit\Framework\TestCase
+final class ResetEmailerTest extends \PHPUnit\Framework\TestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
@@ -22,7 +22,7 @@ use OpenCFP\Domain\Services\TalkRating\YesNoRating;
 /**
  * @covers \OpenCFP\Domain\Services\TalkRating\TalkRatingContext
  */
-class TalkRatingContextTest extends \PHPUnit\Framework\TestCase
+final class TalkRatingContextTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
@@ -24,7 +24,7 @@ use OpenCFP\Domain\Services\TalkRating\YesNoRating;
  *
  * @covers \OpenCFP\Domain\Services\TalkRating\TalkRating
  */
-class TalkRatingTest extends \PHPUnit\Framework\TestCase
+final class TalkRatingTest extends \PHPUnit\Framework\TestCase
 {
     public function testRateThrowsExceptionOnInvalidRating()
     {

--- a/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -22,7 +22,7 @@ use OpenCFP\Domain\Services\TalkRating\YesNoRating;
 /**
  * @covers \OpenCFP\Domain\Services\TalkRating\YesNoRating
  */
-class YesNoRatingTest extends \PHPUnit\Framework\TestCase
+final class YesNoRatingTest extends \PHPUnit\Framework\TestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Unit/Domain/Talk/TalkFilterTest.php
+++ b/tests/Unit/Domain/Talk/TalkFilterTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework;
 /**
  * @covers \OpenCFP\Domain\Talk\TalkFilter
  */
-class TalkFilterTest extends Framework\TestCase
+final class TalkFilterTest extends Framework\TestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/tests/Unit/Domain/Talk/TalkProfileTest.php
+++ b/tests/Unit/Domain/Talk/TalkProfileTest.php
@@ -24,7 +24,7 @@ use OpenCFP\Domain\Talk\TalkProfile;
 /**
  * @covers \OpenCFP\Domain\Talk\TalkProfile
  */
-class TalkProfileTest extends \PHPUnit\Framework\TestCase
+final class TalkProfileTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -18,7 +18,7 @@ use OpenCFP\Environment;
 /**
  * @covers \OpenCFP\Environment
  */
-class EnvironmentTest extends \PHPUnit\Framework\TestCase
+final class EnvironmentTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstants()
     {

--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -19,7 +19,7 @@ use OpenCFP\Http\Form\SignupForm;
 /**
  * @covers \OpenCFP\Http\Form\SignupForm
  */
-class SignupFormTest extends \PHPUnit\Framework\TestCase
+final class SignupFormTest extends \PHPUnit\Framework\TestCase
 {
     private $purifier;
 

--- a/tests/Unit/Http/Form/TalkFormTest.php
+++ b/tests/Unit/Http/Form/TalkFormTest.php
@@ -18,7 +18,7 @@ use Localheinz\Test\Util\Helper;
 /**
  * @covers \OpenCFP\Http\Form\TalkForm
  */
-class TalkFormTest extends \PHPUnit\Framework\TestCase
+final class TalkFormTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 

--- a/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
+++ b/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManager;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\CsrfValidator
  */
-class CsrfValidatorTest extends \PHPUnit\Framework\TestCase
+final class CsrfValidatorTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
     use MockeryPHPUnitIntegration;

--- a/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -30,7 +30,7 @@ use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentinelAccountManagement
  */
-class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
+final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
     use MockeryPHPUnitIntegration;

--- a/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -30,7 +30,7 @@ use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentinelAuthentication
  */
-class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
+final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
     use MockeryPHPUnitIntegration;

--- a/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
@@ -24,7 +24,7 @@ use OpenCFP\Test\BaseTestCase;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentinelIdentityProvider
  */
-class SentinelIdentityProviderTest extends BaseTestCase
+final class SentinelIdentityProviderTest extends BaseTestCase
 {
     public function testIsFinal()
     {

--- a/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
@@ -21,7 +21,7 @@ use OpenCFP\Infrastructure\Auth\SentinelUser;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\SentinelUser
  */
-class SentinelUserTest extends \PHPUnit\Framework\TestCase
+final class SentinelUserTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 

--- a/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
@@ -19,7 +19,7 @@ use OpenCFP\Infrastructure\Auth\UserExistsException;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\UserExistsException
  */
-class UserExistsExceptionTest extends \PHPUnit\Framework\TestCase
+final class UserExistsExceptionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 

--- a/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
@@ -19,7 +19,7 @@ use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 /**
  * @covers \OpenCFP\Infrastructure\Auth\UserNotFoundException
  */
-class UserNotFoundExceptionTest extends \PHPUnit\Framework\TestCase
+final class UserNotFoundExceptionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 

--- a/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -18,7 +18,7 @@ use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
 /**
  * @covers \OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator
  */
-class PseudoRandomStringGeneratorTest extends \PHPUnit\Framework\TestCase
+final class PseudoRandomStringGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var PseudoRandomStringGenerator

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Unit;
+
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @coversNothing
+ */
+final class ProjectCodeTest extends Framework\TestCase
+{
+    use Helper;
+    
+    public function testTestClassesAreAbstractOrFinal()
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..');
+    }
+}

--- a/tests/Unit/Provider/SentinelServiceProviderTest.php
+++ b/tests/Unit/Provider/SentinelServiceProviderTest.php
@@ -20,7 +20,7 @@ use OpenCFP\Environment;
 /**
  * @covers \OpenCFP\Provider\SentinelServiceProvider
  */
-class SentinelServiceProviderTest extends \PHPUnit\Framework\TestCase
+final class SentinelServiceProviderTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllRepositoriesAreSet()
     {

--- a/tests/Unit/Provider/SymfonySentinelSessionTest.php
+++ b/tests/Unit/Provider/SymfonySentinelSessionTest.php
@@ -20,7 +20,7 @@ use OpenCFP\Provider\SymfonySentinelSession;
 /**
  * @covers \OpenCFP\Provider\SymfonySentinelSession
  */
-class SymfonySentinelSessionTest extends \PHPUnit\Framework\TestCase
+final class SymfonySentinelSessionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
     use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;


### PR DESCRIPTION
This PR

* [x] asserts that test classes are `abstract` or `final`
* [x] marks test classes as `final`

Follows #841.