### PR TITLE
Enhancement: Assert that production classes have unit tests

### DIFF
--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Unit;
 
 use Localheinz\Test\Util\Helper;
+use OpenCFP\Domain;
+use OpenCFP\Http;
+use OpenCFP\Provider;
 use PHPUnit\Framework;
 
 /**
@@ -28,7 +31,51 @@ final class ProjectCodeTest extends Framework\TestCase
         $this->assertClassesHaveTests(
             __DIR__ . '/../../classes',
             'OpenCFP\\',
-            'OpenCFP\\Test\\Unit\\'
+            'OpenCFP\\Test\\Unit\\',
+            [
+                Domain\Model\Airport::class,
+                Domain\Model\Eloquent::class,
+                Domain\Model\Favorite::class,
+                Domain\Model\Talk::class,
+                Domain\Model\TalkComment::class,
+                Domain\Model\TalkMeta::class,
+                Domain\Model\User::class,
+                Domain\Services\ProfileImageProcessor::class,
+                Domain\Talk\TalkFormatter::class,
+                Domain\Talk\TalkHandler::class,
+                Http\Controller\Admin\DashboardController::class,
+                Http\Controller\Admin\ExportsController::class,
+                Http\Controller\Admin\SpeakersController::class,
+                Http\Controller\Admin\TalksController::class,
+                Http\Controller\DashboardController::class,
+                Http\Controller\ForgotController::class,
+                Http\Controller\PagesController::class,
+                Http\Controller\ProfileController::class,
+                Http\Controller\Reviewer\DashboardController::class,
+                Http\Controller\Reviewer\SpeakersController::class,
+                Http\Controller\Reviewer\TalksController::class,
+                Http\Controller\SecurityController::class,
+                Http\Controller\SignupController::class,
+                Http\Controller\TalkController::class,
+                Http\Form\ForgotForm::class,
+                Http\Form\ResetForm::class,
+                Http\View\TalkHelper::class,
+                Provider\ApplicationServiceProvider::class,
+                Provider\CallForPapersProvider::class,
+                Provider\ControllerResolver::class,
+                Provider\ControllerResolverServiceProvider::class,
+                Provider\Gateways\RequestCleaner::class,
+                Provider\Gateways\WebGatewayProvider::class,
+                Provider\HtmlPurifierServiceProvider::class,
+                Provider\ImageProcessorProvider::class,
+                Provider\ResetEmailerServiceProvider::class,
+                Provider\TalkFilterProvider::class,
+                Provider\TalkHandlerProvider::class,
+                Provider\TalkHelperProvider::class,
+                Provider\TalkRatingProvider::class,
+                Provider\TwigServiceProvider::class,
+                Provider\YamlConfigDriver::class,
+            ]
         );
     }
     

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -22,6 +22,15 @@ use PHPUnit\Framework;
 final class ProjectCodeTest extends Framework\TestCase
 {
     use Helper;
+
+    public function testProductionClassesHaveUnitTests()
+    {
+        $this->assertClassesHaveTests(
+            __DIR__ . '/../../classes',
+            'OpenCFP\\',
+            'OpenCFP\\Test\\Unit\\'
+        );
+    }
     
     public function testTestClassesAreAbstractOrFinal()
     {


### PR DESCRIPTION
This PR

* [x] asserts that production classes have unit tests
* [x] excludes production classes without unit tests

Follows #842.

