### PR TITLE
Fix php internal server

### DIFF
--- a/script/server
+++ b/script/server
@@ -9,4 +9,9 @@ cd "$(dirname "$0")/.."
 # ensure everything in the app is up to date.
 script/update
 
-CFP_ENV=development php -S localhost:8000 -t web server.php
+export PHPVER=$(php -r "echo PHP_VERSION;")
+if [ "$PHPVER" = "7.1.12" ]; then
+    CFP_ENV=development php -S localhost:8000 -t web ../server.php
+else
+    CFP_ENV=development php -S localhost:8000 -t web server.php
+fi


### PR DESCRIPTION
This PR

* [x] Fixes an issue with the PHP internal server for php version 7.1.12

I'm not 100% sure why, but since upgrading to PHP 7.1.12 i had an issue with the internal php server, for some reason it was looking for the server.php in the web folder, rather then the root of the project. 

So this add a check to see if the user is on php 7.1.12, and if so, it points it to the correct place