### PR TITLE
Fix: Use faker() instead of unavailable getFaker()

### DIFF
--- a/tests/Unit/Console/Command/UserDemoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserDemoteCommandTest.php
@@ -169,7 +169,7 @@ final class UserDemoteCommandTest extends Framework\TestCase
 
     public function testExecuteFailsIfDemoteFromThrowsGenericException()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $email    = $faker->email;
         $roleName = $faker->word;

--- a/tests/Unit/Console/Command/UserPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserPromoteCommandTest.php
@@ -169,7 +169,7 @@ final class UserPromoteCommandTest extends Framework\TestCase
 
     public function testExecuteFailsIfPromoteToThrowsGenericException()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $email    = $faker->email;
         $roleName = $faker->word;


### PR DESCRIPTION
This PR

* [x] uses `Helper::faker()` instead of the unavailable `GeneratorTrait::getFaker()`

Follows #841.

🤦‍♂️ Sorry!