### PR TITLE
Fix: Exclude cached php files from php cs fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,7 +13,8 @@ TXT;
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
-    ->name('opencfp');
+    ->name('opencfp')
+    ->exclude('cache');
 
 return PhpCsFixer\Config::create()
     ->setUsingCache(true)


### PR DESCRIPTION
This PR

* [x] excludes the cache dir from php-cs fixer