### PR TITLE
Fix: Add return type declarations to controller actions

### DIFF
--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -20,6 +20,7 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Http\Controller\BaseController;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
@@ -37,7 +38,7 @@ class DashboardController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction()
+    public function indexAction(): Response
     {
         $userId        = $this->authentication->user()->getId();
         $talkFormatter = new TalkFormatter();

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -15,6 +15,7 @@ namespace OpenCFP\Http\Controller\Admin;
 
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Http\Controller\BaseController;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
@@ -33,22 +34,22 @@ class ExportsController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function anonymousTalksExportAction()
+    public function anonymousTalksExportAction(): Response
     {
         return $this->talksExportAction(false);
     }
 
-    public function attributedTalksExportAction()
+    public function attributedTalksExportAction(): Response
     {
         return $this->talksExportAction(true);
     }
 
-    public function selectedTalksExportAction()
+    public function selectedTalksExportAction(): Response
     {
         return $this->talksExportAction(true, ['selected' => 1]);
     }
 
-    public function emailExportAction()
+    public function emailExportAction(): Response
     {
         $talks     = Talk::all();
         $formatted = [];
@@ -66,7 +67,7 @@ class ExportsController extends BaseController
         return $this->csvReturn($formatted, 'emailExports');
     }
 
-    private function talksExportAction(bool $attributed, $where = null)
+    private function talksExportAction(bool $attributed, $where = null): Response
     {
         $talks = Talk::orderBy('created_at', 'DESC');
         $talks = $where == null ? $talks : $talks->where($where);

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -23,6 +23,7 @@ use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
@@ -85,7 +86,7 @@ class SpeakersController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         $search = $request->get('search');
 
@@ -131,7 +132,7 @@ class SpeakersController extends BaseController
         ]);
     }
 
-    public function viewAction(Request $request)
+    public function viewAction(Request $request): Response
     {
         $speakerDetails = User::find($request->get('id'));
 
@@ -171,7 +172,7 @@ class SpeakersController extends BaseController
         ]);
     }
 
-    public function deleteAction(Request $request)
+    public function deleteAction(Request $request): Response
     {
         $this->capsule->getConnection()->beginTransaction();
 
@@ -199,7 +200,7 @@ class SpeakersController extends BaseController
         return $this->redirectTo('admin_speakers');
     }
 
-    public function demoteAction(Request $request)
+    public function demoteAction(Request $request): Response
     {
         $role = $request->get('role');
         $id   = (int) $request->get('id');
@@ -234,7 +235,7 @@ class SpeakersController extends BaseController
         return $this->redirectTo('admin_speakers');
     }
 
-    public function promoteAction(Request $request)
+    public function promoteAction(Request $request): Response
     {
         $role = $request->get('role');
         $id   = (int) $request->get('id');

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -56,7 +56,7 @@ class TalksController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         $adminUserId = $this->authentication->user()->getId();
         $options     = [
@@ -90,7 +90,7 @@ class TalksController extends BaseController
         ]);
     }
 
-    public function viewAction(Request $request)
+    public function viewAction(Request $request): Response
     {
         $handler = $this->talkHandler
             ->grabTalk((int) $request->get('id'));
@@ -110,7 +110,7 @@ class TalksController extends BaseController
         ]);
     }
 
-    public function rateAction(Request $request)
+    public function rateAction(Request $request): Response
     {
         try {
             $this->validate($request, [
@@ -134,7 +134,7 @@ class TalksController extends BaseController
      *
      * @return Response
      */
-    public function favoriteAction(Request $request)
+    public function favoriteAction(Request $request): Response
     {
         $content = (string) $this->talkHandler
             ->grabTalk((int) $request->get('id'))
@@ -150,7 +150,7 @@ class TalksController extends BaseController
      *
      * @return Response
      */
-    public function selectAction(Request $request)
+    public function selectAction(Request $request): Response
     {
         $content = (string) $this->talkHandler
             ->grabTalk((int) $request->get('id'))
@@ -159,7 +159,7 @@ class TalksController extends BaseController
         return new Response($content);
     }
 
-    public function commentCreateAction(Request $request)
+    public function commentCreateAction(Request $request): Response
     {
         $talkId = (int) $request->get('id');
 

--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -15,6 +15,7 @@ namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Application\Speakers;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
@@ -35,7 +36,7 @@ class DashboardController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function showSpeakerProfile()
+    public function showSpeakerProfile(): Response
     {
         try {
             return $this->render('dashboard.twig', [

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -19,6 +19,7 @@ use OpenCFP\Http\Form\ForgotForm;
 use OpenCFP\Http\Form\ResetForm;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
@@ -53,7 +54,7 @@ class ForgotController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction()
+    public function indexAction(): Response
     {
         $form = $this->formFactory->createBuilder(ForgotForm::class)->getForm();
 
@@ -63,7 +64,7 @@ class ForgotController extends BaseController
         ]);
     }
 
-    public function sendResetAction(Request $request)
+    public function sendResetAction(Request $request): Response
     {
         $form = $this->formFactory
             ->createBuilder(ForgotForm::class)
@@ -110,7 +111,7 @@ class ForgotController extends BaseController
         return $this->redirectTo('login');
     }
 
-    public function resetAction(Request $request)
+    public function resetAction(Request $request): Response
     {
         if (empty($request->get('reset_code'))) {
             throw new \Exception();
@@ -150,7 +151,7 @@ class ForgotController extends BaseController
         ]);
     }
 
-    public function processResetAction(Request $request)
+    public function processResetAction(Request $request): Response
     {
         $userId    = $request->get('user_id');
         $resetCode = $request->get('reset_code');
@@ -195,7 +196,7 @@ class ForgotController extends BaseController
         return $this->redirectTo('forgot_password');
     }
 
-    public function updatePasswordAction(Request $request)
+    public function updatePasswordAction(Request $request): Response
     {
         $form = $this->formFactory->createBuilder(ResetForm::class)->getForm();
         $form->handleRequest($request);

--- a/classes/Http/Controller/PagesController.php
+++ b/classes/Http/Controller/PagesController.php
@@ -14,20 +14,21 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Domain\Model\Talk;
+use Symfony\Component\HttpFoundation\Response;
 
 class PagesController extends BaseController
 {
-    public function showHomepage()
+    public function showHomepage(): Response
     {
         return $this->render('home.twig', $this->getContextWithTalksCount());
     }
 
-    public function showSpeakerPackage()
+    public function showSpeakerPackage(): Response
     {
         return $this->render('package.twig', $this->getContextWithTalksCount());
     }
 
-    public function showTalkIdeas()
+    public function showTalkIdeas(): Response
     {
         return $this->render('ideas.twig', $this->getContextWithTalksCount());
     }

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -19,6 +19,7 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\ProfileImageProcessor;
 use OpenCFP\Http\Form\SignupForm;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
@@ -53,7 +54,7 @@ class ProfileController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function editAction(Request $request)
+    public function editAction(Request $request): Response
     {
         $user = $this->authentication->user();
 
@@ -89,7 +90,7 @@ class ProfileController extends BaseController
         ]);
     }
 
-    public function processAction(Request $request)
+    public function processAction(Request $request): Response
     {
         $userId = $this->authentication->user()->getId();
 
@@ -137,12 +138,12 @@ class ProfileController extends BaseController
         ]));
     }
 
-    public function passwordAction()
+    public function passwordAction(): Response
     {
         return $this->render('user/change_password.twig');
     }
 
-    public function passwordProcessAction(Request $request)
+    public function passwordProcessAction(Request $request): Response
     {
         $user = $this->authentication->user();
 

--- a/classes/Http/Controller/Reviewer/DashboardController.php
+++ b/classes/Http/Controller/Reviewer/DashboardController.php
@@ -20,6 +20,7 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Talk\TalkFormatter;
 use OpenCFP\Http\Controller\BaseController;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
@@ -37,7 +38,7 @@ class DashboardController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction()
+    public function indexAction(): Response
     {
         $userId        = $this->authentication->user()->getId();
         $talkFormatter = new TalkFormatter();

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -18,6 +18,7 @@ use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
@@ -35,7 +36,7 @@ class SpeakersController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         $search   = $request->get('search');
         $speakers = User::search($search)->get()->toArray();
@@ -52,7 +53,7 @@ class SpeakersController extends BaseController
         ]);
     }
 
-    public function viewAction(Request $request)
+    public function viewAction(Request $request): Response
     {
         $speakerDetails = User::where('id', $request->get('id'))->first();
 

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -55,7 +55,7 @@ class TalksController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         $reviewerId = $this->authentication->user()->getId();
 
@@ -88,7 +88,7 @@ class TalksController extends BaseController
         ]);
     }
 
-    public function viewAction(Request $request)
+    public function viewAction(Request $request): Response
     {
         $this->talkHandler->grabTalk((int) $request->get('id'));
 
@@ -107,7 +107,7 @@ class TalksController extends BaseController
         ]);
     }
 
-    public function rateAction(Request $request)
+    public function rateAction(Request $request): Response
     {
         try {
             $this->validate($request, [

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -36,14 +36,14 @@ class SecurityController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction()
+    public function indexAction(): Response
     {
         return $this->render('security/login.twig', [
             'email' => null,
         ]);
     }
 
-    public function processAction(Request $request)
+    public function processAction(Request $request): Response
     {
         try {
             $this->authentication->authenticate($request->get('email'), $request->get('password'));
@@ -67,7 +67,7 @@ class SecurityController extends BaseController
         }
     }
 
-    public function outAction()
+    public function outAction(): Response
     {
         $this->authentication->logout();
 

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -18,6 +18,7 @@ use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\ValidationException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
@@ -52,7 +53,7 @@ class SignupController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         if ($this->authentication->isAuthenticated()) {
             return $this->redirectTo('dashboard');
@@ -71,7 +72,7 @@ class SignupController extends BaseController
         return $this->render('security/signup.twig');
     }
 
-    public function processAction(Request $request)
+    public function processAction(Request $request): Response
     {
         try {
             $this->validate($request, [

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -26,6 +26,7 @@ use Swift_Message;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
@@ -123,7 +124,7 @@ class TalkController extends BaseController
      *
      * @return mixed
      */
-    public function viewAction(Request $request)
+    public function viewAction(Request $request): Response
     {
         try {
             $talkId = (int) $request->get('id');
@@ -138,7 +139,7 @@ class TalkController extends BaseController
         ]);
     }
 
-    public function editAction(Request $request)
+    public function editAction(Request $request): Response
     {
         $talkId = (int) $request->get('id');
 
@@ -185,7 +186,7 @@ class TalkController extends BaseController
         ]);
     }
 
-    public function createAction(Request $request)
+    public function createAction(Request $request): Response
     {
         // You can only create talks while the CfP is open
         if (!$this->callForPapers->isOpen()) {
@@ -216,7 +217,7 @@ class TalkController extends BaseController
         ]);
     }
 
-    public function processCreateAction(Request $request)
+    public function processCreateAction(Request $request): Response
     {
         // You can only create talks while the CfP is open
         if (!$this->callForPapers->isOpen()) {
@@ -287,7 +288,7 @@ class TalkController extends BaseController
         ]);
     }
 
-    public function updateAction(Request $request)
+    public function updateAction(Request $request): Response
     {
         if (!$this->callForPapers->isOpen()) {
             $request->getSession()->set('flash', [
@@ -362,7 +363,7 @@ class TalkController extends BaseController
         ]);
     }
 
-    public function deleteAction(Request $request)
+    public function deleteAction(Request $request): Response
     {
         // You can only delete talks while the CfP is open
         if (!$this->callForPapers->isOpen()) {


### PR DESCRIPTION
This PR

* [x] asserts that `public` methods in controllers use `Symfony\Component\HttpFoundation\Response` as return type declaration
* [x] adds return type declarations to controller actions

Somewhat related to #850.

💁‍♂️ There are a few controller actions that actually also return `false`, not sure what's kicking in there later to actually return a response.