### PR TITLE
Load all controllers as services

### DIFF
--- a/classes/Http/Controller/Admin/DashboardController.php
+++ b/classes/Http/Controller/Admin/DashboardController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Controller\Admin;
 
 use Illuminate\Database\Eloquent\Collection;
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
@@ -23,6 +24,8 @@ use OpenCFP\Http\Controller\BaseController;
 
 class DashboardController extends BaseController
 {
+    use ContainerAware;
+
     public function indexAction()
     {
         /** @var Authentication $authentication */

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Session;
 
 class ExportsController extends BaseController
 {
+    use ContainerAware;
+
     public function anonymousTalksExportAction()
     {
         return $this->talksExportAction(false);

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Controller\Admin;
 
 use Illuminate\Database\Capsule\Manager as Capsule;
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\EntityNotFoundException;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\AccountManagement;
@@ -27,6 +28,8 @@ use Symfony\Component\HttpFoundation\Session;
 
 class SpeakersController extends BaseController
 {
+    use ContainerAware;
+
     public function indexAction(Request $request)
     {
         $search = $request->get('search');

--- a/classes/Http/Controller/Admin/TalksController.php
+++ b/classes/Http/Controller/Admin/TalksController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Controller\Admin;
 
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Talk\TalkFilter;
@@ -24,6 +25,8 @@ use Symfony\Component\HttpFoundation\Session;
 
 class TalksController extends BaseController
 {
+    use ContainerAware;
+
     public function indexAction(Request $request)
     {
         /* @var Authentication $auth */
@@ -92,7 +95,7 @@ class TalksController extends BaseController
     public function rateAction(Request $request)
     {
         try {
-            $this->validate([
+            $this->validate($request, [
                 'rating' => 'required|integer',
             ]);
 

--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -14,11 +14,14 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Application\Speakers;
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
 
 class DashboardController extends BaseController
 {
+    use ContainerAware;
+
     public function showSpeakerProfile()
     {
         /**

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Controller;
 
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Domain\Services\ResetEmailer;
 use OpenCFP\Http\Form\ForgotForm;
@@ -23,6 +24,8 @@ use Symfony\Component\HttpFoundation\Session;
 
 class ForgotController extends BaseController
 {
+    use ContainerAware;
+
     public function indexAction()
     {
         /** @var FormFactory $formFactory */

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Controller;
 
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\ProfileImageProcessor;
@@ -22,6 +23,8 @@ use Symfony\Component\HttpFoundation\Session;
 
 class ProfileController extends BaseController
 {
+    use ContainerAware;
+
     public function editAction(Request $request)
     {
         /** @var Authentication $authentication */

--- a/classes/Http/Controller/Reviewer/DashboardController.php
+++ b/classes/Http/Controller/Reviewer/DashboardController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Controller\Reviewer;
 
 use Illuminate\Support\Collection;
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
@@ -23,6 +24,8 @@ use OpenCFP\Http\Controller\BaseController;
 
 class DashboardController extends BaseController
 {
+    use ContainerAware;
+
     public function indexAction()
     {
         /** @var Authentication $authentication */

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Controller\Reviewer;
 
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
@@ -22,6 +23,8 @@ use Symfony\Component\HttpFoundation\Session;
 
 class SpeakersController extends BaseController
 {
+    use ContainerAware;
+
     public function indexAction(Request $request)
     {
         $search   = $request->get('search');

--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Controller\Reviewer;
 
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Talk\TalkFilter;
@@ -24,6 +25,8 @@ use Symfony\Component\HttpFoundation\Session;
 
 class TalksController extends BaseController
 {
+    use ContainerAware;
+
     public function indexAction(Request $request)
     {
         /** @var Authentication $authentication */
@@ -91,7 +94,7 @@ class TalksController extends BaseController
     public function rateAction(Request $request)
     {
         try {
-            $this->validate([
+            $this->validate($request, [
                 'rating' => 'required|integer',
             ]);
 

--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Controller;
 
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\Services\Authentication;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpFoundation\Session;
 
 class SecurityController extends BaseController
 {
+    use ContainerAware;
+
     public function indexAction()
     {
         return $this->render('security/login.twig', [

--- a/classes/Http/Controller/SignupController.php
+++ b/classes/Http/Controller/SignupController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Controller;
 
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Services\AccountManagement;
 use OpenCFP\Domain\Services\Authentication;
@@ -22,6 +23,8 @@ use Symfony\Component\HttpFoundation\Session;
 
 class SignupController extends BaseController
 {
+    use ContainerAware;
+
     public function indexAction()
     {
         /** @var Authentication $auth */
@@ -53,7 +56,7 @@ class SignupController extends BaseController
     public function processAction(Request $request)
     {
         try {
-            $this->validate([
+            $this->validate($request, [
                 'email'    => 'required|email',
                 'password' => 'required',
                 'coc'      => 'accepted',
@@ -87,7 +90,7 @@ class SignupController extends BaseController
                 'ext'   => $e->errors(),
             ]);
 
-            return $this->redirectBack();
+            return $this->redirectBack($request);
         } catch (\RuntimeException $e) {
             $this->app['session']->set('flash', [
                 'type'  => 'error',
@@ -95,7 +98,7 @@ class SignupController extends BaseController
                 'ext'   => 'A user already exists with that email address',
             ]);
 
-            return $this->redirectBack();
+            return $this->redirectBack($request);
         }
     }
 }

--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -15,6 +15,7 @@ namespace OpenCFP\Http\Controller;
 
 use OpenCFP\Application\NotAuthorizedException;
 use OpenCFP\Application\Speakers;
+use OpenCFP\ContainerAware;
 use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Services\Authentication;
@@ -27,6 +28,8 @@ use Twig_Environment;
 
 class TalkController extends BaseController
 {
+    use ContainerAware;
+
     /**
      * @param $requestData
      *

--- a/classes/Provider/ControllerResolver.php
+++ b/classes/Provider/ControllerResolver.php
@@ -13,18 +13,14 @@ declare(strict_types=1);
 
 namespace OpenCFP\Provider;
 
-use OpenCFP\Http\Controller\BaseController;
-
 class ControllerResolver extends \Silex\ControllerResolver
 {
     protected function instantiateController($class)
     {
-        $controller = parent::instantiateController($class);
-
-        if ($controller instanceof BaseController) {
-            $controller->setApplication($this->app);
+        if (isset($this->app[$class])) {
+            return $this->app[$class];
         }
 
-        return $controller;
+        return parent::instantiateController($class);
     }
 }

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -15,6 +15,15 @@ namespace OpenCFP\Provider\Gateways;
 
 use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Http\Controller\Admin;
+use OpenCFP\Http\Controller\DashboardController;
+use OpenCFP\Http\Controller\ForgotController;
+use OpenCFP\Http\Controller\PagesController;
+use OpenCFP\Http\Controller\ProfileController;
+use OpenCFP\Http\Controller\Reviewer;
+use OpenCFP\Http\Controller\SecurityController;
+use OpenCFP\Http\Controller\SignupController;
+use OpenCFP\Http\Controller\TalkController;
 use OpenCFP\Infrastructure\Auth\CsrfValidator;
 use OpenCFP\Infrastructure\Auth\RoleAccess;
 use OpenCFP\Infrastructure\Auth\SpeakerAccess;
@@ -32,6 +41,102 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
 {
     public function register(Container $app)
     {
+        $app[DashboardController::class] = function ($app) {
+            $controller = new DashboardController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[ForgotController::class] = function ($app) {
+            $controller = new ForgotController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[PagesController::class] = function ($app) {
+            return new PagesController($app['twig'], $app['url_generator']);
+        };
+
+        $app[ProfileController::class] = function ($app) {
+            $controller = new ProfileController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[SecurityController::class] = function ($app) {
+            $controller = new SecurityController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[SignupController::class] = function ($app) {
+            $controller = new SignupController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[TalkController::class] = function ($app) {
+            $controller = new TalkController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        // Admin controllers
+        $app[Admin\DashboardController::class] = function ($app) {
+            $controller = new Admin\DashboardController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[Admin\ExportsController::class] = function ($app) {
+            $controller = new Admin\ExportsController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[Admin\SpeakersController::class] = function ($app) {
+            $controller = new Admin\SpeakersController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[Admin\TalksController::class] = function ($app) {
+            $controller = new Admin\TalksController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        // Reviewer controllers
+        $app[Reviewer\DashboardController::class] = function ($app) {
+            $controller = new Reviewer\DashboardController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[Reviewer\SpeakersController::class] = function ($app) {
+            $controller = new Reviewer\SpeakersController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
+
+        $app[Reviewer\TalksController::class] = function ($app) {
+            $controller = new Reviewer\TalksController($app['twig'], $app['url_generator']);
+            $controller->setApplication($app);
+
+            return $controller;
+        };
     }
 
     public function boot(Application $app)

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -44,9 +44,8 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function indexDisplaysCorrectForm()
     {
-        $controller = new \OpenCFP\Http\Controller\ForgotController();
-        $controller->setApplication($this->app);
-        $response = $controller->indexAction();
+        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
+        $response   = $controller->indexAction();
 
         // Get the form object and verify things look correct
         $this->assertContains(
@@ -84,8 +83,7 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         $this->app['form.factory'] = $formFactory;
 
         $request    = m::mock(\Symfony\Component\HttpFoundation\Request::class);
-        $controller = new \OpenCFP\Http\Controller\ForgotController();
-        $controller->setApplication($this->app);
+        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
         $controller->sendResetAction($request);
 
         // As long as the email validates as being a potential email, the flash message should indicate success
@@ -106,8 +104,7 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         $this->app['form.factory'] = $formFactory;
 
         $request    = m::mock(\Symfony\Component\HttpFoundation\Request::class);
-        $controller = new \OpenCFP\Http\Controller\ForgotController();
-        $controller->setApplication($this->app);
+        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
         $controller->sendResetAction($request);
 
         $flashMessage = $this->app['session']->get('flash');
@@ -127,8 +124,7 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         $this->app['form.factory'] = $formFactory;
 
         $request    = m::mock(\Symfony\Component\HttpFoundation\Request::class);
-        $controller = new \OpenCFP\Http\Controller\ForgotController();
-        $controller->setApplication($this->app);
+        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
         $controller->sendResetAction($request);
 
         $flashMessage = $this->app['session']->get('flash');
@@ -159,8 +155,7 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
         $this->app['form.factory'] = $formFactory;
 
         $request    = m::mock(\Symfony\Component\HttpFoundation\Request::class);
-        $controller = new \OpenCFP\Http\Controller\ForgotController();
-        $controller->setApplication($this->app);
+        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
         $controller->sendResetAction($request);
 
         // As long as the email validates as being a potential email, the flash message should indicate success


### PR DESCRIPTION
This PR is basically a light version of #850.

All controllers a being load from the container. While the `BaseController` class receives its dependencies via DI, most child controllers still use the `ContainerAware` trait.

Merging this PR to master would allow me to split #850 into smaller PRs that are easier to review and maintain. Also, the diff of #850 itself would become smaller.