### PR TITLE
Removed ContainerAware from TalkController

### DIFF
--- a/classes/Http/Controller/TalkController.php
+++ b/classes/Http/Controller/TalkController.php
@@ -13,22 +13,94 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Controller;
 
+use HTMLPurifier;
 use OpenCFP\Application\NotAuthorizedException;
 use OpenCFP\Application\Speakers;
-use OpenCFP\ContainerAware;
 use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Http\Form\TalkForm;
 use OpenCFP\Http\View\TalkHelper;
+use Swift_Mailer;
 use Swift_Message;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Environment;
 
 class TalkController extends BaseController
 {
-    use ContainerAware;
+    /**
+     * @var Authentication
+     */
+    private $authentication;
+
+    /**
+     * @var Speakers
+     */
+    private $speakers;
+
+    /**
+     * @var TalkHelper
+     */
+    private $talkHelper;
+
+    /**
+     * @var CallForPapers
+     */
+    private $callForPapers;
+
+    /**
+     * @var HTMLPurifier
+     */
+    private $purifier;
+
+    /**
+     * @var Swift_Mailer
+     */
+    private $mailer;
+
+    /**
+     * @var string
+     */
+    private $applicationEmail;
+
+    /**
+     * @var string
+     */
+    private $applicationTitle;
+
+    /**
+     * @var string
+     */
+    private $applicationEndDate;
+
+    public function __construct(
+        Authentication $authentication,
+        Speakers $speakers,
+        TalkHelper $talkHelper,
+        CallForPapers $callForPapers,
+        HTMLPurifier $purifier,
+        Swift_Mailer $mailer,
+        Twig_Environment $twig,
+        UrlGeneratorInterface $urlGenerator,
+        string $applicationEmail,
+        string $applicationTitle,
+        string $applicationEndDate
+    ) {
+        $this->authentication     = $authentication;
+        $this->speakers           = $speakers;
+        $this->talkHelper         = $talkHelper;
+        $this->callForPapers      = $callForPapers;
+        $this->purifier           = $purifier;
+        $this->mailer             = $mailer;
+        $this->applicationEmail   = $applicationEmail;
+        $this->applicationTitle   = $applicationTitle;
+        $this->applicationEndDate = $applicationEndDate;
+
+        parent::__construct($twig, $urlGenerator);
+    }
 
     /**
      * @param $requestData
@@ -37,19 +109,11 @@ class TalkController extends BaseController
      */
     private function getTalkForm($requestData): TalkForm
     {
-        /** @var TalkHelper $helper */
-        $helper = $this->service(TalkHelper::class);
-
-        $options = [
-            'categories' => $helper->getTalkCategories(),
-            'levels'     => $helper->getTalkLevels(),
-            'types'      => $helper->getTalkTypes(),
-        ];
-
-        /** @var \HTMLPurifier $htmlPurifier */
-        $htmlPurifier = $this->service('purifier');
-
-        return new TalkForm($requestData, $htmlPurifier, $options);
+        return new TalkForm($requestData, $this->purifier, [
+            'categories' => $this->talkHelper->getTalkCategories(),
+            'levels'     => $this->talkHelper->getTalkLevels(),
+            'types'      => $this->talkHelper->getTalkTypes(),
+        ]);
     }
 
     /**
@@ -61,12 +125,9 @@ class TalkController extends BaseController
      */
     public function viewAction(Request $request)
     {
-        /* @var Speakers $speakers */
-        $speakers = $this->service('application.speakers');
-
         try {
             $talkId = (int) $request->get('id');
-            $talk   = $speakers->getTalk($talkId);
+            $talk   = $this->speakers->getTalk($talkId);
         } catch (NotAuthorizedException $e) {
             return $this->redirectTo('dashboard');
         }
@@ -78,32 +139,23 @@ class TalkController extends BaseController
     {
         $talkId = (int) $request->get('id');
 
-        /** @var CallForPapers $callForPapers */
-        $callForPapers = $this->service(CallForPapers::class);
-
         // You can only edit talks while the CfP is open
         // This will redirect to "view" the talk in a read-only template
-        if (!$callForPapers->isOpen()) {
-            /** @var Session\Session $session */
-            $session = $this->service('session');
-
-            $session->set('flash', [
+        if (!$this->callForPapers->isOpen()) {
+            $request->getSession()->set('flash', [
                 'type'  => 'error',
                 'short' => 'Read Only',
                 'ext'   => 'You cannot edit talks once the call for papers has ended',
             ]);
 
-            return $this->app->redirect($this->url('talk_view', ['id' => $talkId]));
+            return new RedirectResponse($this->url('talk_view', ['id' => $talkId]));
         }
 
         if (empty($talkId)) {
             return $this->redirectTo('dashboard');
         }
 
-        /** @var Authentication $authentication */
-        $authentication = $this->service(Authentication::class);
-
-        $userId = $authentication->user()->getId();
+        $userId = $this->authentication->user()->getId();
 
         $talk = Talk::find($talkId);
 
@@ -111,14 +163,11 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        /** @var TalkHelper $helper */
-        $helper = $this->service(TalkHelper::class);
-
-        $data = [
+        return $this->render('talk/edit.twig', [
             'formAction'     => $this->url('talk_update'),
-            'talkCategories' => $helper->getTalkCategories(),
-            'talkTypes'      => $helper->getTalkTypes(),
-            'talkLevels'     => $helper->getTalkLevels(),
+            'talkCategories' => $this->talkHelper->getTalkCategories(),
+            'talkTypes'      => $this->talkHelper->getTalkTypes(),
+            'talkLevels'     => $this->talkHelper->getTalkLevels(),
             'id'             => $talkId,
             'title'          => \html_entity_decode($talk['title']),
             'description'    => \html_entity_decode($talk['description']),
@@ -130,22 +179,14 @@ class TalkController extends BaseController
             'other'          => $talk['other'],
             'sponsor'        => $talk['sponsor'],
             'buttonInfo'     => 'Update my talk!',
-        ];
-
-        return $this->render('talk/edit.twig', $data);
+        ]);
     }
 
     public function createAction(Request $request)
     {
-        /** @var CallForPapers $callForPapers */
-        $callForPapers = $this->service(CallForPapers::class);
-
         // You can only create talks while the CfP is open
-        if (!$callForPapers->isOpen()) {
-            /** @var Session\Session $session */
-            $session = $this->service('session');
-
-            $session->set('flash', [
+        if (!$this->callForPapers->isOpen()) {
+            $request->getSession()->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
                 'ext'   => 'You cannot create talks once the call for papers has ended',
@@ -154,14 +195,11 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        /** @var TalkHelper $helper */
-        $helper = $this->service(TalkHelper::class);
-
-        $data = [
+        return $this->render('talk/create.twig', [
             'formAction'     => $this->url('talk_create'),
-            'talkCategories' => $helper->getTalkCategories(),
-            'talkTypes'      => $helper->getTalkTypes(),
-            'talkLevels'     => $helper->getTalkLevels(),
+            'talkCategories' => $this->talkHelper->getTalkCategories(),
+            'talkTypes'      => $this->talkHelper->getTalkTypes(),
+            'talkLevels'     => $this->talkHelper->getTalkLevels(),
             'title'          => $request->get('title'),
             'description'    => $request->get('description'),
             'type'           => $request->get('type'),
@@ -172,22 +210,14 @@ class TalkController extends BaseController
             'other'          => $request->get('other'),
             'sponsor'        => $request->get('sponsor'),
             'buttonInfo'     => 'Submit my talk!',
-        ];
-
-        return $this->render('talk/create.twig', $data);
+        ]);
     }
 
     public function processCreateAction(Request $request)
     {
-        /** @var CallForPapers $callForPapers */
-        $callForPapers = $this->service(CallForPapers::class);
-
-        /** @var Session\Session $session */
-        $session = $this->service('session');
-
         // You can only create talks while the CfP is open
-        if (!$callForPapers->isOpen()) {
-            $session->set('flash', [
+        if (!$this->callForPapers->isOpen()) {
+            $request->getSession()->set('flash', [
                 'type'  => 'error',
                 'short' => 'Error',
                 'ext'   => 'You cannot create talks once the call for papers has ended',
@@ -196,12 +226,9 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        /** @var Authentication $authentication */
-        $authentication = $this->service(Authentication::class);
+        $user = $this->authentication->user();
 
-        $user = $authentication->user();
-
-        $requestData = [
+        $form = $this->getTalkForm([
             'title'       => $request->get('title'),
             'description' => $request->get('description'),
             'type'        => $request->get('type'),
@@ -212,9 +239,7 @@ class TalkController extends BaseController
             'other'       => $request->get('other'),
             'sponsor'     => $request->get('sponsor'),
             'user_id'     => $request->get('user_id'),
-        ];
-
-        $form = $this->getTalkForm($requestData);
+        ]);
         $form->sanitize();
 
         if ($form->validateAll()) {
@@ -222,7 +247,7 @@ class TalkController extends BaseController
             $sanitizedData['user_id'] = (int) $user->getId();
             $talk                     = Talk::create($sanitizedData);
 
-            $session->set('flash', [
+            $request->getSession()->set('flash', [
                 'type'  => 'success',
                 'short' => 'Success',
                 'ext'   => 'Successfully saved talk.',
@@ -234,14 +259,17 @@ class TalkController extends BaseController
             return $this->redirectTo('dashboard');
         }
 
-        /** @var TalkHelper $helper */
-        $helper = $this->service(TalkHelper::class);
+        $request->getSession()->set('flash', [
+            'type'  => 'error',
+            'short' => 'Error',
+            'ext'   => \implode('<br>', $form->getErrorMessages()),
+        ]);
 
-        $data = [
+        return $this->render('talk/create.twig', [
             'formAction'     => $this->url('talk_create'),
-            'talkCategories' => $helper->getTalkCategories(),
-            'talkTypes'      => $helper->getTalkTypes(),
-            'talkLevels'     => $helper->getTalkLevels(),
+            'talkCategories' => $this->talkHelper->getTalkCategories(),
+            'talkTypes'      => $this->talkHelper->getTalkTypes(),
+            'talkLevels'     => $this->talkHelper->getTalkLevels(),
             'title'          => $request->get('title'),
             'description'    => $request->get('description'),
             'type'           => $request->get('type'),
@@ -252,41 +280,23 @@ class TalkController extends BaseController
             'other'          => $request->get('other'),
             'sponsor'        => $request->get('sponsor'),
             'buttonInfo'     => 'Submit my talk!',
-        ];
-
-        $session->set('flash', [
-            'type'  => 'error',
-            'short' => 'Error',
-            'ext'   => \implode('<br>', $form->getErrorMessages()),
+            'flash'          => $request->getSession()->get('flash'),
         ]);
-
-        $data['flash'] = $session->get('flash');
-
-        return $this->render('talk/create.twig', $data);
     }
 
     public function updateAction(Request $request)
     {
-        /** @var CallForPapers $callForPapers */
-        $callForPapers = $this->service(CallForPapers::class);
-
-        /** @var Session\Session $session */
-        $session = $this->service('session');
-
-        if (!$callForPapers->isOpen()) {
-            $session->set('flash', [
+        if (!$this->callForPapers->isOpen()) {
+            $request->getSession()->set('flash', [
                 'type'  => 'error',
                 'short' => 'Read Only',
                 'ext'   => 'You cannot edit talks once the call for papers has ended',
             ]);
 
-            return $this->app->redirect($this->url('talk_view', ['id' => $request->get('id')]));
+            return new RedirectResponse($this->url('talk_view', ['id' => $request->get('id')]));
         }
 
-        /** @var Authentication $authentication */
-        $authentication = $this->service(Authentication::class);
-
-        $user = $authentication->user();
+        $user = $this->authentication->user();
 
         $requestData = [
             'id'          => $request->get('id'),
@@ -310,7 +320,7 @@ class TalkController extends BaseController
             $sanitizedData['user_id'] = (int) $user->getId();
             
             if (Talk::find((int) $sanitizedData['id'])->update($sanitizedData)) {
-                $session->set('flash', [
+                $request->getSession()->set('flash', [
                     'type'  => 'success',
                     'short' => 'Success',
                     'ext'   => 'Successfully saved talk.',
@@ -323,14 +333,17 @@ class TalkController extends BaseController
             }
         }
 
-        /** @var TalkHelper $helper */
-        $helper = $this->service(TalkHelper::class);
+        $request->getSession()->set('flash', [
+            'type'  => 'error',
+            'short' => 'Error',
+            'ext'   => \implode('<br>', $form->getErrorMessages()),
+        ]);
 
-        $data = [
+        return $this->render('talk/edit.twig', [
             'formAction'     => $this->url('talk_update'),
-            'talkCategories' => $helper->getTalkCategories(),
-            'talkTypes'      => $helper->getTalkTypes(),
-            'talkLevels'     => $helper->getTalkLevels(),
+            'talkCategories' => $this->talkHelper->getTalkCategories(),
+            'talkTypes'      => $this->talkHelper->getTalkTypes(),
+            'talkLevels'     => $this->talkHelper->getTalkLevels(),
             'id'             => $request->get('id'),
             'title'          => $request->get('title'),
             'description'    => $request->get('description'),
@@ -342,42 +355,27 @@ class TalkController extends BaseController
             'other'          => $request->get('other'),
             'sponsor'        => $request->get('sponsor'),
             'buttonInfo'     => 'Update my talk!',
-        ];
-
-        $session->set('flash', [
-            'type'  => 'error',
-            'short' => 'Error',
-            'ext'   => \implode('<br>', $form->getErrorMessages()),
+            'flash'          => $request->getSession()->get('flash'),
         ]);
-
-        $data['flash'] = $session->get('flash');
-
-        return $this->render('talk/edit.twig', $data);
     }
 
     public function deleteAction(Request $request)
     {
-        /** @var CallForPapers $callForPapers */
-        $callForPapers = $this->service(CallForPapers::class);
-
         // You can only delete talks while the CfP is open
-        if (!$callForPapers->isOpen()) {
-            return $this->app->json(['delete' => 'no']);
+        if (!$this->callForPapers->isOpen()) {
+            return new JsonResponse(['delete' => 'no']);
         }
 
-        /** @var Authentication $authentication */
-        $authentication = $this->service(Authentication::class);
-
-        $userId = $authentication->user()->getId();
+        $userId = $this->authentication->user()->getId();
         $talk   = Talk::find($request->get('tid'), ['id', 'user_id']);
 
         if ((int) $talk->user_id !== $userId) {
-            return $this->app->json(['delete' => 'no']);
+            return new JsonResponse(['delete' => 'no']);
         }
 
         $talk->delete();
 
-        return $this->app->json(['delete' => 'ok']);
+        return new JsonResponse(['delete' => 'ok']);
     }
 
     /**
@@ -392,22 +390,16 @@ class TalkController extends BaseController
     {
         $talk = Talk::find($talkId, ['title']);
 
-        /* @var Twig_Environment $twig */
-        $twig = $this->service('twig');
-
         // Build our email that we will send
-        $template   = $twig->loadTemplate('emails/talk_submit.twig');
+        $template   = $this->twig->loadTemplate('emails/talk_submit.twig');
         $parameters = [
-            'email'   => $this->app->config('application.email'),
-            'title'   => $this->app->config('application.title'),
+            'email'   => $this->applicationEmail,
+            'title'   => $this->applicationTitle,
             'talk'    => $talk->title,
-            'enddate' => $this->app->config('application.enddate'),
+            'enddate' => $this->applicationEndDate,
         ];
 
         try {
-            /** @var \Swift_Mailer $mailer */
-            $mailer = $this->service('mailer');
-
             $message = new Swift_Message();
 
             $message->setTo($email);
@@ -423,7 +415,7 @@ class TalkController extends BaseController
                 'text/html'
             );
 
-            return $mailer->send($message);
+            return $this->mailer->send($message);
         } catch (\Exception $e) {
             echo $e;
             die();

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -27,6 +27,7 @@ use OpenCFP\Http\Controller\Reviewer;
 use OpenCFP\Http\Controller\SecurityController;
 use OpenCFP\Http\Controller\SignupController;
 use OpenCFP\Http\Controller\TalkController;
+use OpenCFP\Http\View\TalkHelper;
 use OpenCFP\Infrastructure\Auth\CsrfValidator;
 use OpenCFP\Infrastructure\Auth\RoleAccess;
 use OpenCFP\Infrastructure\Auth\SpeakerAccess;
@@ -95,10 +96,19 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         };
 
         $app[TalkController::class] = function ($app) {
-            $controller = new TalkController($app['twig'], $app['url_generator']);
-            $controller->setApplication($app);
-
-            return $controller;
+            return new TalkController(
+                $app[Authentication::class],
+                $app['application.speakers'],
+                $app[TalkHelper::class],
+                $app[CallForPapers::class],
+                $app['purifier'],
+                $app['mailer'],
+                $app['twig'],
+                $app['url_generator'],
+                $app->config('application.email'),
+                $app->config('application.title'),
+                $app->config('application.enddate')
+            );
         };
 
         // Admin controllers

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -56,7 +56,7 @@ final class TalkControllerTest extends WebTestCase
     public function ampersandsAcceptableCharacterForTalks()
     {
         // Create a test double for SwiftMailer
-        $swiftMailer = m::mock(\stdClass::class);
+        $swiftMailer = m::mock(\Swift_Mailer::class);
         $swiftMailer->shouldReceive('send')->andReturn(true);
         $this->swap('mailer', $swiftMailer);
 


### PR DESCRIPTION
The ProfileController is being constructed via DI.

This is a rather large controller with a lot of dependencies that are not used by all actions. It should definitely be split up in a later PR.

Follows #855.
Related to #618.