### PR TITLE
Converted authentication middleware into an event subscriber

### DIFF
--- a/classes/Infrastructure/Event/AuthenticationListener.php
+++ b/classes/Infrastructure/Event/AuthenticationListener.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Infrastructure\Event;
+
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Infrastructure\Auth\RoleAccess;
+use OpenCFP\Infrastructure\Auth\SpeakerAccess;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class AuthenticationListener implements EventSubscriberInterface
+{
+    /**
+     * @var Authentication
+     */
+    private $authentication;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    public function __construct(Authentication $authentication, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->authentication = $authentication;
+        $this->urlGenerator   = $urlGenerator;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', -1024],
+        ];
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $uri = $event->getRequest()->getRequestUri();
+
+        if (\preg_match('/^\/(talk|profile)/', $uri)) {
+            if ($response = SpeakerAccess::userHasAccess($this->authentication)) {
+                $event->setResponse($response);
+            }
+
+            return;
+        }
+
+        if (\preg_match('/^\/admin/', $uri)) {
+            if ($response = RoleAccess::userHasAccess($this->authentication, 'admin')) {
+                $event->setResponse($response);
+            }
+
+            return;
+        }
+
+        if (\preg_match('/^\/reviewer/', $uri)) {
+            if ($response = RoleAccess::userHasAccess($this->authentication, 'reviewer')) {
+                $event->setResponse($response);
+            }
+
+            return;
+        }
+    }
+}

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -17,7 +17,6 @@ use OpenCFP\Application;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Decorates a Symfony Response object and provides several
@@ -76,7 +75,7 @@ final class TestResponse
         );
 
         if ($route !== null) {
-            $expected = $this->app['url_generator']->generate($route, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
+            $expected = $this->app['url_generator']->generate($route, $parameters);
             Assert::assertEquals($expected, $this->headers->get('Location'));
         }
 
@@ -129,5 +128,10 @@ final class TestResponse
     public function __call($method, $args)
     {
         return $this->baseResponse->{$method}(...$args);
+    }
+
+    public function __get($name)
+    {
+        return $this->baseResponse->{$name};
     }
 }

--- a/tests/Unit/Infrastructure/Event/AuthenticationListenerTest.php
+++ b/tests/Unit/Infrastructure/Event/AuthenticationListenerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Unit\Infrastructure\Event;
+
+use OpenCFP\Test\WebTestCase;
+
+/**
+ * @covers \OpenCFP\Infrastructure\Event\AuthenticationListener
+ */
+final class AuthenticationListenerTest extends WebTestCase
+{
+    public function testNoLoginRequired()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+
+    public function testTalksRouteRequireLogin()
+    {
+        $response = $this->get('/talk/create');
+
+        $response->assertRedirect('dashboard');
+    }
+
+    public function testTalksRouteWithLogin()
+    {
+        $response = $this->asLoggedInSpeaker()->get('/talk/create');
+
+        $response->assertStatus(200);
+    }
+
+    public function testReviewerDashboardRequiresLogin()
+    {
+        $response = $this->get('/reviewer/');
+
+        $response->assertRedirect('dashboard');
+    }
+
+    public function testReviewerDashboardRequiresReviewer()
+    {
+        $response = $this->asLoggedInSpeaker()->get('/reviewer/');
+
+        $response->assertRedirect('dashboard');
+    }
+
+    public function testReviewerDashboardAsReviewer()
+    {
+        $response = $this->asReviewer()->get('/reviewer/');
+
+        $response->assertStatus(200);
+    }
+
+    public function testAdminDashboardRequiresLogin()
+    {
+        $response = $this->get('/admin/');
+
+        $response->assertRedirect('dashboard');
+    }
+
+    public function testAdminDashboardRequiresAdmin()
+    {
+        $response = $this->asLoggedInSpeaker()->get('/admin/');
+
+        $response->assertRedirect('dashboard');
+    }
+
+    public function testAdminDashboardAsAdmin()
+    {
+        $response = $this->asAdmin()->get('/admin/');
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Preparation for #618: All middlewares that check for an authenticated user have been replaced by a single event subscriber that can be reused in Symfony.