### PR TITLE
Fix: Add @covers annotation to EventListenerTest

### DIFF
--- a/tests/Unit/Infrastructure/Event/ExceptionListenerTest.php
+++ b/tests/Unit/Infrastructure/Event/ExceptionListenerTest.php
@@ -17,7 +17,7 @@ use OpenCFP\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Infrastructure\Event\ExceptionListener
  */
 final class ExceptionListenerTest extends WebTestCase
 {


### PR DESCRIPTION
This PR

* [x] Adds an ```@covers``` annotation to the ```ExceptionListenerTest```

Follows: #866 
