### PR TITLE
Fix: Use more specific assertions for responses

### DIFF
--- a/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
@@ -193,10 +193,13 @@ final class TalksControllerTest extends WebTestCase
     {
         $talk = self::$talks->first();
 
-        $this->asAdmin()
-            ->post('/admin/talks/' . $talk->id . '/rate', ['rating' => $rating])
-            ->assertSee('1')
-            ->assertSuccessful();
+        $response = $this->asAdmin()->post('/admin/talks/' . $talk->id . '/rate', [
+            'rating' => $rating,
+        ]);
+
+        $response->assertSuccessful();
+
+        $this->assertSame('1', $response->getContent());
     }
 
     public function providerValidRating(): array
@@ -221,10 +224,13 @@ final class TalksControllerTest extends WebTestCase
     {
         $talk = self::$talks->first();
 
-        $this->asAdmin()
-            ->post('/admin/talks/' . $talk->id . '/rate', ['rating' => $rating])
-            ->assertNotSee('1')
-            ->assertSuccessful();
+        $response = $this->asAdmin()->post('/admin/talks/' . $talk->id . '/rate', [
+            'rating' => $rating,
+        ]);
+
+        $response->assertSuccessful();
+
+        $this->assertSame('', $response->getContent());
     }
 
     public function providerInvalidRating(): array

--- a/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
@@ -79,10 +79,13 @@ final class TalksControllerTest extends WebTestCase
     {
         $talk = self::$talks->first();
 
-        $this->asReviewer()
-            ->post('/reviewer/talks/' . $talk->id . '/rate', ['rating' => $rating])
-            ->assertSee('1')
-            ->assertSuccessful();
+        $response = $this->asReviewer()->post('/reviewer/talks/' . $talk->id . '/rate', [
+            'rating' => $rating,
+        ]);
+
+        $response->assertSuccessful();
+        
+        $this->assertSame('1', $response->getContent());
     }
 
     public function providerValidRating(): array
@@ -107,10 +110,13 @@ final class TalksControllerTest extends WebTestCase
     {
         $talk = self::$talks->first();
 
-        $this->asReviewer()
-            ->post('/reviewer/talks/' . $talk->id . '/rate', ['rating' => $rating])
-            ->assertNotSee('1')
-            ->assertSuccessful();
+        $response = $this->asReviewer()->post('/reviewer/talks/' . $talk->id . '/rate', [
+            'rating' => $rating,
+        ]);
+
+        $response->assertSuccessful();
+
+        $this->assertSame('', $response->getContent());
     }
 
     public function providerInvalidRating(): array


### PR DESCRIPTION
This PR

* [x] uses more specific assertions when testing the rating system

Follows #853.
Follows https://github.com/opencfp/opencfp/pull/852#issuecomment-349339120.
