### PR TITLE
Refactored twig middleware into an event subscriber and a twig extension

### DIFF
--- a/classes/Infrastructure/Event/TwigGlobalsListener.php
+++ b/classes/Infrastructure/Event/TwigGlobalsListener.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Infrastructure\Event;
+
+use OpenCFP\Domain\CallForPapers;
+use OpenCFP\Domain\Services\Authentication;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Twig_Environment;
+
+class TwigGlobalsListener implements EventSubscriberInterface
+{
+    /**
+     * @var Authentication
+     */
+    private $authentication;
+
+    /**
+     * @var CallForPapers
+     */
+    private $callForPapers;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var Twig_Environment
+     */
+    private $twig;
+
+    public function __construct(
+        Authentication $authentication,
+        CallForPapers $callForPapers,
+        SessionInterface $session,
+        Twig_Environment $twig
+    ) {
+        $this->authentication = $authentication;
+        $this->callForPapers  = $callForPapers;
+        $this->twig           = $twig;
+        $this->session        = $session;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 512],
+        ];
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        $this->twig->addGlobal('current_page', $request->getRequestUri());
+        $this->twig->addGlobal('cfp_open', $this->callForPapers->isOpen());
+
+        // Authentication
+        if ($this->authentication->isAuthenticated()) {
+            $this->twig->addGlobal('user', $this->authentication->user());
+            $this->twig->addGlobal('user_is_admin', $this->authentication->user()->hasAccess('admin'));
+            $this->twig->addGlobal('user_is_reviewer', $this->authentication->user()->hasAccess('reviewer'));
+        }
+
+        // Flash
+        if ($this->session->has('flash')) {
+            $this->twig->addGlobal('flash', $this->session->get('flash'));
+            $this->session->set('flash', null);
+        }
+    }
+}

--- a/classes/Infrastructure/Templating/TwigExtension.php
+++ b/classes/Infrastructure/Templating/TwigExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Infrastructure\Templating;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+class TwigExtension extends Twig_Extension
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    public function __construct(RequestStack $requestStack, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->requestStack = $requestStack;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new Twig_SimpleFunction('uploads', function ($path) {
+                return '/uploads/' . $path;
+            }),
+            new Twig_SimpleFunction('assets', function ($path) {
+                return '/assets/' . $path;
+            }),
+
+            new Twig_SimpleFunction('active', function ($route) {
+                return $this->urlGenerator->generate($route)
+                    === $this->requestStack->getCurrentRequest()->getRequestUri();
+            }),
+        ];
+    }
+}

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -40,8 +40,6 @@ use Silex\Application;
 use Silex\ControllerCollection;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Twig_Environment;
-use Twig_SimpleFunction;
 
 class WebGatewayProvider implements BootableProviderInterface, ServiceProviderInterface
 {
@@ -185,29 +183,6 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         $web = $app['controllers_factory'];
 
         $app->before(new RequestCleaner($app['purifier']));
-        $app->before(function (Request $request, Container $app) {
-            /* @var Twig_Environment $twig */
-            $twig = $app['twig'];
-
-            $twig->addGlobal('current_page', $request->getRequestUri());
-            $twig->addGlobal('cfp_open', $app[CallForPapers::class]->isOpen());
-
-            $twig->addFunction(new Twig_SimpleFunction('active', function ($route) use ($app, $request) {
-                return $app['url_generator']->generate($route) == $request->getRequestUri();
-            }));
-
-            // Authentication
-            if ($app[Authentication::class]->isAuthenticated()) {
-                $twig->addGlobal('user', $app[Authentication::class]->user());
-                $twig->addGlobal('user_is_admin', $app[Authentication::class]->user()->hasAccess('admin'));
-                $twig->addGlobal('user_is_reviewer', $app[Authentication::class]->user()->hasAccess('reviewer'));
-            }
-
-            if ($app['session']->has('flash')) {
-                $twig->addGlobal('flash', $app['session']->get('flash'));
-                $app['session']->set('flash', null);
-            }
-        }, Application::EARLY_EVENT);
 
         if ($app->config('application.secure_ssl')) {
             $app->requireHttps();

--- a/tests/Unit/Infrastructure/Event/Fixtures/global_with_admin.txt
+++ b/tests/Unit/Infrastructure/Event/Fixtures/global_with_admin.txt
@@ -1,0 +1,5 @@
+current_page: /foo
+cfp_open: Yes
+user: 42
+user_is_admin: Yes
+user_is_reviewer: No

--- a/tests/Unit/Infrastructure/Event/Fixtures/global_with_anonymous_user.txt
+++ b/tests/Unit/Infrastructure/Event/Fixtures/global_with_anonymous_user.txt
@@ -1,0 +1,2 @@
+current_page: /bar
+cfp_open: No

--- a/tests/Unit/Infrastructure/Event/Fixtures/global_with_reviewer.txt
+++ b/tests/Unit/Infrastructure/Event/Fixtures/global_with_reviewer.txt
@@ -1,0 +1,6 @@
+current_page: /foo
+cfp_open: Yes
+user: 43
+user_is_admin: No
+user_is_reviewer: Yes
+flash: You've got mail.

--- a/tests/Unit/Infrastructure/Event/Fixtures/globals.txt.twig
+++ b/tests/Unit/Infrastructure/Event/Fixtures/globals.txt.twig
@@ -1,0 +1,19 @@
+{% autoescape false %}
+current_page: {{ current_page }}
+cfp_open: {% if cfp_open %}Yes{% else %}No{% endif %}
+
+{% if user is defined %}
+user: {{ user.id }}
+{% endif %}
+{% if user_is_admin is defined %}
+user_is_admin: {% if user_is_admin %}Yes{% else %}No{% endif %}
+
+{% endif %}
+{% if user_is_reviewer is defined %}
+user_is_reviewer: {% if user_is_reviewer %}Yes{% else %}No{% endif %}
+
+{% endif %}
+{% if flash is defined %}
+flash: {{ flash }}
+{% endif %}
+{% endautoescape %}

--- a/tests/Unit/Infrastructure/Event/TwigGlobalsListenerTest.php
+++ b/tests/Unit/Infrastructure/Event/TwigGlobalsListenerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Unit\Infrastructure\Event;
+
+use Mockery;
+use OpenCFP\Domain\CallForPapers;
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Infrastructure\Auth\UserInterface;
+use OpenCFP\Infrastructure\Event\TwigGlobalsListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Twig_Environment;
+
+/**
+ * @covers \OpenCFP\Infrastructure\Event\TwigGlobalsListener
+ */
+final class TwigGlobalsListenerTest extends TestCase
+{
+    /**
+     * @dataProvider provideTestSetup
+     */
+    public function testGlobals(Authentication $authentication, bool $isOpen, string $uri, string $flash = null, string $fixture)
+    {
+        $twig    = new Twig_Environment(new \Twig_Loader_Filesystem(__DIR__ . '/Fixtures'));
+        $session = new Session(new MockArraySessionStorage());
+
+        if ($flash !== null) {
+            $session->set('flash', $flash);
+        }
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber(new TwigGlobalsListener(
+            $authentication,
+            $this->mockCallForPapers($isOpen),
+            $session,
+            $twig
+        ));
+
+        $eventDispatcher->dispatch(KernelEvents::REQUEST, new GetResponseEvent(
+            Mockery::mock(HttpKernelInterface::class),
+            Request::create($uri),
+            HttpKernelInterface::MASTER_REQUEST
+        ));
+
+        $output = $twig->render('globals.txt.twig');
+
+        $this->assertStringEqualsFile(__DIR__ . '/Fixtures/' . $fixture, $output);
+    }
+
+    public function provideTestSetup(): array
+    {
+        return [
+            [$this->mockAdmin(), true, '/foo', null, 'global_with_admin.txt'],
+            [$this->mockReviewer(), true, '/foo', 'You\'ve got mail.', 'global_with_reviewer.txt'],
+            [$this->mockAnonymous(), false, '/bar', null, 'global_with_anonymous_user.txt'],
+        ];
+    }
+
+    private function mockAdmin(): Authentication
+    {
+        $user = Mockery::mock(UserInterface::class);
+        $user->shouldReceive('getId')->andReturn(42);
+        $user->shouldReceive('hasAccess')->with('admin')->andReturn(true);
+        $user->shouldReceive('hasAccess')->with('reviewer')->andReturn(false);
+        $auth = Mockery::mock(Authentication::class);
+
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
+        $auth->shouldReceive('user')->andReturn($user);
+
+        return $auth;
+    }
+
+    private function mockReviewer(): Authentication
+    {
+        $user = Mockery::mock(UserInterface::class);
+        $user->shouldReceive('getId')->andReturn(43);
+        $user->shouldReceive('hasAccess')->with('admin')->andReturn(false);
+        $user->shouldReceive('hasAccess')->with('reviewer')->andReturn(true);
+        $auth = Mockery::mock(Authentication::class);
+
+        $auth->shouldReceive('isAuthenticated')->andReturn(true);
+        $auth->shouldReceive('user')->andReturn($user);
+
+        return $auth;
+    }
+
+    private function mockAnonymous(): Authentication
+    {
+        $auth = Mockery::mock(Authentication::class);
+
+        $auth->shouldReceive('isAuthenticated')->andReturn(false);
+        $auth->shouldReceive('user')->andReturn(null);
+
+        return $auth;
+    }
+
+    private function mockCallForPapers(bool $isOpen): CallForPapers
+    {
+        $cfp = Mockery::mock(CallForPapers::class);
+        $cfp->shouldReceive('isOpen')->andReturn($isOpen);
+
+        return $cfp;
+    }
+}

--- a/tests/Unit/Infrastructure/Templating/Fixtures/functions.txt
+++ b/tests/Unit/Infrastructure/Templating/Fixtures/functions.txt
@@ -1,0 +1,3 @@
+/uploads/picture.png
+/assets/picture.png
+dashboard

--- a/tests/Unit/Infrastructure/Templating/Fixtures/functions.txt.twig
+++ b/tests/Unit/Infrastructure/Templating/Fixtures/functions.txt.twig
@@ -1,0 +1,5 @@
+{{ uploads('picture.png') }}
+{{ assets('picture.png') }}
+{% if active('admin') %}admin{% endif %}
+{% if active('dashboard') %}dashboard{% endif %}
+

--- a/tests/Unit/Infrastructure/Templating/TwigExtensionTest.php
+++ b/tests/Unit/Infrastructure/Templating/TwigExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Unit\Infrastructure\Templating;
+
+use OpenCFP\Infrastructure\Templating\TwigExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @covers \OpenCFP\Infrastructure\Templating\TwigExtension
+ */
+final class TwigExtensionTest extends TestCase
+{
+    public function testExtension()
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('/dashboard'));
+
+        $routes = new RouteCollection();
+        $routes->add('admin', new Route('/admin'));
+        $routes->add('dashboard', new Route('/dashboard'));
+        $urlGenerator = new UrlGenerator($routes, new RequestContext());
+
+        $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__ . '/Fixtures'));
+        $twig->addExtension(new TwigExtension(
+            $requestStack,
+            $urlGenerator
+        ));
+
+        $this->assertStringEqualsFile(__DIR__ . '/Fixtures/functions.txt', $twig->render('functions.txt.twig'));
+    }
+}


### PR DESCRIPTION
Preparation for #618:
* The middleware that sets global Twig variables based on the current request has been refactored to an event subscriber.
* All custom Twig functions have been bundled in a single Twig extension.
* Some tests have been added to cover that functionality.

It should be possible to reuse both classes when switching to Symfony.
