### PR TITLE
Decoupled direct container access in tests via PSR-11

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -19,6 +19,8 @@ use OpenCFP\Application;
 use OpenCFP\Environment;
 use OpenCFP\Test\Helper\DataBaseInteraction;
 use OpenCFP\Test\Helper\RefreshDatabase;
+use Pimple\Psr11\Container;
+use Psr\Container\ContainerInterface;
 
 abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 {
@@ -29,6 +31,11 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      * @var Application
      */
     protected $app;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
 
     public static function setUpBeforeClass()
     {
@@ -47,7 +54,8 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
     {
         if ($this->app) {
             $this->app->flush();
-            $this->app = null;
+            $this->app       = null;
+            $this->container = null;
         }
     }
 
@@ -61,7 +69,8 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 
     public function refreshApplication()
     {
-        $this->app = $this->createApplication();
+        $this->app       = $this->createApplication();
+        $this->container = new Container($this->app);
     }
 
     /**

--- a/tests/Helper/DataBaseInteraction.php
+++ b/tests/Helper/DataBaseInteraction.php
@@ -24,6 +24,6 @@ trait DataBaseInteraction
 
     protected function getCapsule(): Manager
     {
-        return $this->app[Manager::class];
+        return $this->container->get(Manager::class);
     }
 }

--- a/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
@@ -99,7 +99,7 @@ final class SpeakersControllerTest extends WebTestCase
         $accounts = Mockery::mock(AccountManagement::class);
         $accounts->shouldReceive('findById')->andReturn($user);
         $this->swap(AccountManagement::class, $accounts);
-        $csrfToken = $this->app['csrf.token_manager']
+        $csrfToken = $this->container->get('csrf.token_manager')
             ->getToken('admin_speaker_promote')
             ->getValue();
         $this->asAdmin()
@@ -114,7 +114,7 @@ final class SpeakersControllerTest extends WebTestCase
      */
     public function promoteActionWorksCorrectly()
     {
-        $csrfToken = $this->app['csrf.token_manager']
+        $csrfToken = $this->container->get('csrf.token_manager')
             ->getToken('admin_speaker_promote')
             ->getValue();
         $this->asAdmin()
@@ -140,7 +140,7 @@ final class SpeakersControllerTest extends WebTestCase
      */
     public function demoteActionFailsIfUserNotFound()
     {
-        $csrfToken = $this->app['csrf.token_manager']
+        $csrfToken = $this->container->get('csrf.token_manager')
             ->getToken('admin_speaker_demote')
             ->getValue();
         $this->asAdmin()
@@ -156,7 +156,7 @@ final class SpeakersControllerTest extends WebTestCase
     public function demoteActionFailsIfDemotingSelf()
     {
         $user      = self::$users->last();
-        $csrfToken = $this->app['csrf.token_manager']
+        $csrfToken = $this->container->get('csrf.token_manager')
             ->getToken('admin_speaker_demote')
             ->getValue();
         $this->asAdmin($user->id)
@@ -180,7 +180,7 @@ final class SpeakersControllerTest extends WebTestCase
         $accounts->shouldReceive('findById')->andReturn($user);
         $accounts->shouldReceive('demoteFrom');
         $this->swap(AccountManagement::class, $accounts);
-        $csrfToken = $this->app['csrf.token_manager']
+        $csrfToken = $this->container->get('csrf.token_manager')
             ->getToken('admin_speaker_demote')
             ->getValue();
         $this->asAdmin(self::$users->first()->id)

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -14,29 +14,16 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Integration\Http\Controller;
 
 use Mockery as m;
-use OpenCFP\Application;
 use OpenCFP\Domain\Services\AccountManagement;
-use OpenCFP\Environment;
 use OpenCFP\Infrastructure\Auth\UserInterface;
-use Symfony\Component\HttpFoundation\Request;
+use OpenCFP\Test\WebTestCase;
 
 /**
  * @group db
- * @coversNothing
+ * @covers \OpenCFP\Http\Controller\ForgotController
  */
-final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
+final class ForgotControllerTest extends WebTestCase
 {
-    protected $app;
-
-    protected function setUp()
-    {
-        $this->app                 = new Application(__DIR__ . '/../../../..', Environment::testing());
-        $this->app['session.test'] = true;
-        \ob_start();
-        $this->app->run();
-        \ob_end_clean();
-    }
-
     /**
      * Test that index action displays a form that allows the user to reset
      * their password
@@ -45,21 +32,20 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function indexDisplaysCorrectForm()
     {
-        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
-        $response   = $controller->indexAction();
+        $response = $this->get('/forgot');
 
         // Get the form object and verify things look correct
         $this->assertContains(
             '<form id="forgot"',
-            (string) $response
+            $response->getContent()
         );
         $this->assertContains(
             '<input type="hidden" id="forgot_form__token"',
-            (string) $response
+            $response->getContent()
         );
         $this->assertContains(
             '<input type="email" id="forgot_form_email"',
-            (string) $response
+            $response->getContent()
         );
     }
 
@@ -70,26 +56,22 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
     {
         $accounts = m::mock(AccountManagement::class);
         $accounts->shouldReceive('findByLogin')->andReturn($this->createUser());
-        unset($this->app[AccountManagement::class]);
-        $this->app[AccountManagement::class] = $accounts;
+        $this->swap(AccountManagement::class, $accounts);
 
         // Override our reset_emailer service
         $resetEmailer = m::mock(\OpenCFP\Domain\Services\ResetEmailer::class);
         $resetEmailer->shouldReceive('send')->andReturn(true);
-        $this->app['reset_emailer'] = $resetEmailer;
+        $this->swap('reset_emailer', $resetEmailer);
 
         // We need to create a replacement form.factory to return a form we control
         $formFactory = m::mock(\Symfony\Component\Form\FormFactoryInterface::class);
         $formFactory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('valid'));
-        $this->app['form.factory'] = $formFactory;
+        $this->swap('form.factory', $formFactory);
 
-        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
-        $request    = new Request();
-        $request->setSession($this->app['session']);
-        $controller->sendResetAction($request);
+        $this->post('/forgot');
 
         // As long as the email validates as being a potential email, the flash message should indicate success
-        $flashMessage = $this->app['session']->get('flash');
+        $flashMessage = $this->container->get('session')->get('flash');
         $this->assertContains(
             'If your email was valid, we sent a link to reset your password to',
             $flashMessage['ext']
@@ -103,14 +85,11 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
     {
         $formFactory = m::mock(\Symfony\Component\Form\FormFactoryInterface::class);
         $formFactory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('not valid'));
-        $this->app['form.factory'] = $formFactory;
+        $this->swap('form.factory', $formFactory);
 
-        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
-        $request    = new Request();
-        $request->setSession($this->app['session']);
-        $controller->sendResetAction($request);
+        $this->post('/forgot');
 
-        $flashMessage = $this->app['session']->get('flash');
+        $flashMessage = $this->container->get('session')->get('flash');
         $this->assertContains(
             'Please enter a properly formatted email address',
             $flashMessage['ext']
@@ -124,14 +103,11 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
     {
         $formFactory = m::mock(\Symfony\Component\Form\FormFactoryInterface::class);
         $formFactory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('valid'));
-        $this->app['form.factory'] = $formFactory;
+        $this->swap('form.factory', $formFactory);
 
-        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
-        $request    = new Request();
-        $request->setSession($this->app['session']);
-        $controller->sendResetAction($request);
+        $this->post('/forgot');
 
-        $flashMessage = $this->app['session']->get('flash');
+        $flashMessage = $this->container->get('session')->get('flash');
         $this->assertContains(
             'If your email was valid, we sent a link to reset your password to',
             $flashMessage['ext']
@@ -145,26 +121,22 @@ final class ForgotControllerTest extends \PHPUnit\Framework\TestCase
     {
         $accounts = m::mock(AccountManagement::class);
         $accounts->shouldReceive('findByLogin')->andReturn($this->createUser());
-        unset($this->app[AccountManagement::class]);
-        $this->app[AccountManagement::class] = $accounts;
+        $this->swap(AccountManagement::class, $accounts);
 
         // Override our reset_emailer service
         $resetEmailer = m::mock(\OpenCFP\Domain\Services\ResetEmailer::class);
         $resetEmailer->shouldReceive('send')->andReturn(false);
-        $this->app['reset_emailer'] = $resetEmailer;
+        $this->swap('reset_emailer', $resetEmailer);
 
         // We need to create a replacement form.factory to return a form we control
         $formFactory = m::mock(\Symfony\Component\Form\FormFactoryInterface::class);
         $formFactory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('valid'));
-        $this->app['form.factory'] = $formFactory;
+        $this->swap('form.factory', $formFactory);
 
-        $controller = $this->app[\OpenCFP\Http\Controller\ForgotController::class];
-        $request    = new Request();
-        $request->setSession($this->app['session']);
-        $controller->sendResetAction($request);
+        $this->post('/forgot');
 
         // As long as the email validates as being a potential email, the flash message should indicate success
-        $flashMessage = $this->app['session']->get('flash');
+        $flashMessage = $this->container->get('session')->get('flash');
         $this->assertContains(
             'We were unable to send your password reset request. Please try again',
             $flashMessage['ext']

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -156,7 +156,7 @@ final class TalkControllerTest extends WebTestCase
      */
     public function seeEditPageWhenAllowed()
     {
-        $csrfToken = $this->app['csrf.token_manager']
+        $csrfToken = $this->container->get('csrf.token_manager')
             ->getToken('edit_talk')
             ->getValue();
         $this->asLoggedInSpeaker(self::$user->id)
@@ -236,7 +236,7 @@ final class TalkControllerTest extends WebTestCase
      */
     public function cantProcessCreateTalkWithMissingData()
     {
-        $csrfToken = $this->app['csrf.token_manager']
+        $csrfToken = $this->container->get('csrf.token_manager')
             ->getToken('speaker_talk')
             ->getValue();
         $postData = [
@@ -288,7 +288,7 @@ final class TalkControllerTest extends WebTestCase
      */
     public function cantUpdateActionWithInvalidData()
     {
-        $csrfToken = $this->app['csrf.token_manager']
+        $csrfToken = $this->container->get('csrf.token_manager')
             ->getToken('speaker_talk')
             ->getValue();
         $postData = [

--- a/tests/Integration/Infrastructure/Auth/SentinelUserTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelUserTest.php
@@ -86,7 +86,7 @@ final class SentinelUserTest extends BaseTestCase
     public function checkResetPasswordCodeWorks()
     {
         /** @var Capsule $capsule */
-        $capsule = $this->app[Capsule::class];
+        $capsule = $this->container->get(Capsule::class);
         $capsule->getConnection()->query()->from('reminders')->insert([
             'user_id' => self::$user->getId(),
             'code'    => 'secret.reset.code',
@@ -103,7 +103,7 @@ final class SentinelUserTest extends BaseTestCase
     public function getResetPassWordCodeWorks()
     {
         /** @var Capsule $capsule */
-        $capsule = $this->app[Capsule::class];
+        $capsule = $this->container->get(Capsule::class);
         $capsule->getConnection()->query()->from('reminders')->insert([
             'user_id' => self::$user->getId(),
             'code'    => 'secret.reset.code',
@@ -128,7 +128,7 @@ final class SentinelUserTest extends BaseTestCase
     public function attemptResetPasswordWorks()
     {
         /** @var Capsule $capsule */
-        $capsule = $this->app[Capsule::class];
+        $capsule = $this->container->get(Capsule::class);
         $capsule->getConnection()->query()->from('reminders')->insert([
             'user_id' => self::$user->getId(),
             'code'    => 'secret.reset.code',

--- a/tests/Integration/MigrationsTest.php
+++ b/tests/Integration/MigrationsTest.php
@@ -71,6 +71,6 @@ final class MigrationsTest extends BaseTestCase
 
     private function getCapsule(): Capsule
     {
-        return $this->app[Capsule::class];
+        return $this->container->get(Capsule::class);
     }
 }

--- a/tests/TestResponse.php
+++ b/tests/TestResponse.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace OpenCFP\Test;
 
-use OpenCFP\Application;
 use PHPUnit\Framework\Assert;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,9 +27,9 @@ use Symfony\Component\HttpFoundation\Response;
 final class TestResponse
 {
     /**
-     * @var Application
+     * @var ContainerInterface
      */
-    private $app;
+    private $container;
 
     /**
      * The response we're decorating.
@@ -38,10 +38,10 @@ final class TestResponse
      */
     public $baseResponse;
 
-    public function __construct(Application $app, Response $response)
+    public function __construct(ContainerInterface $container, Response $response)
     {
         $this->baseResponse = $response;
-        $this->app          = $app;
+        $this->container    = $container;
     }
 
     public function assertSuccessful(): self
@@ -75,7 +75,7 @@ final class TestResponse
         );
 
         if ($route !== null) {
-            $expected = $this->app['url_generator']->generate($route, $parameters);
+            $expected = $this->container->get('url_generator')->generate($route, $parameters);
             Assert::assertEquals($expected, $this->headers->get('Location'));
         }
 
@@ -98,7 +98,7 @@ final class TestResponse
 
     public function assertFlashContains(string $flash): self
     {
-        $fullFlash = $this->app['session']->get('flash');
+        $fullFlash = $this->container->get('session')->get('flash');
         $fullFlash = \is_array($fullFlash) ? $fullFlash : [];
         Assert::assertContains($flash, $fullFlash);
 
@@ -107,7 +107,7 @@ final class TestResponse
 
     public function assertNoFlashSet(): self
     {
-        Assert::assertNull($this->app['session']->get('flash'));
+        Assert::assertNull($this->container->get('session')->get('flash'));
 
         return $this;
     }

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -110,7 +110,7 @@ abstract class WebTestCase extends BaseTestCase
         $response = $this->app->handle($request);
         $this->app->terminate($request, $response);
 
-        return new TestResponse($this->app, $response);
+        return new TestResponse($this->container, $response);
     }
 
     public function get(string $uri, array $parameters = [], array $cookies = [], array $files = [], array $server = [], string $content = null): TestResponse
@@ -138,7 +138,7 @@ abstract class WebTestCase extends BaseTestCase
         $cfp = Mockery::mock(CallForPapers::class);
         $cfp->shouldReceive('isOpen')->andReturn(true);
         $this->swap(CallForPapers::class, $cfp);
-        $this->app['twig']->addGlobal('cfp_open', true);
+        $this->container->get('twig')->addGlobal('cfp_open', true);
 
         return $this;
     }
@@ -148,17 +148,17 @@ abstract class WebTestCase extends BaseTestCase
         $cfp = Mockery::mock(CallForPapers::class);
         $cfp->shouldReceive('isOpen')->andReturn(false);
         $this->swap(CallForPapers::class, $cfp);
-        $this->app['twig']->addGlobal('cfp_open', false);
+        $this->container->get('twig')->addGlobal('cfp_open', false);
 
         return $this;
     }
 
     public function isOnlineConference(): self
     {
-        $config                                     = $this->app['config'];
+        $config                                     = $this->container->get('config');
         $config['application']['online_conference'] = true;
-        $this->app['config']                        = $config;
-        $this->app['twig']->addGlobal('site', $this->app->config('application'));
+        $this->swap('config', $config);
+        $this->container->get('twig')->addGlobal('site', $config['application']);
 
         return $this;
     }


### PR DESCRIPTION
This PR decouples most tests from the Pimple container by making them access services through the PSR-11 interface. This way, it should not matter to them whether the container is Pimple or Symfony DI.

Related to #618.

TODO in a follow-up: The service swapping is going to be interesting with a compiled container. 😱 