### PR TITLE
Fix: Do not return string

### DIFF
--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -117,8 +117,6 @@ class TalksController extends BaseController
             $content = (string) $this->talkHandler
                 ->grabTalk((int) $request->get('id'))
                 ->rate((int) $request->get('rating'));
-
-            return $content;
         } catch (ValidationException $e) {
             $content = '';
         }


### PR DESCRIPTION
This PR

* [x] removes a `return` statement 

Follows #874.
Blocks #852.