### PR TITLE
Make ResetEmailer depend on Twig instead of a Twig template

### DIFF
--- a/classes/Domain/Services/ResetEmailer.php
+++ b/classes/Domain/Services/ResetEmailer.php
@@ -21,9 +21,9 @@ class ResetEmailer
     private $swiftMailer;
 
     /**
-     * @var \Twig_Template
+     * @var \Twig_Environment
      */
-    private $template;
+    private $twig;
 
     /**
      * @var string
@@ -36,15 +36,15 @@ class ResetEmailer
     private $configTitle;
 
     /**
-     * @param \Swift_Mailer  $swiftMailer
-     * @param \Twig_Template $template
-     * @param string         $configEmail
-     * @param string         $configTitle
+     * @param \Swift_Mailer     $swiftMailer
+     * @param \Twig_Environment $twig
+     * @param string            $configEmail
+     * @param string            $configTitle
      */
-    public function __construct(\Swift_Mailer $swiftMailer, \Twig_Template $template, $configEmail, $configTitle)
+    public function __construct(\Swift_Mailer $swiftMailer, \Twig_Environment $twig, $configEmail, $configTitle)
     {
         $this->swiftMailer = $swiftMailer;
-        $this->template    = $template;
+        $this->twig        = $twig;
         $this->configEmail = $configEmail;
         $this->configTitle = $configTitle;
     }
@@ -99,16 +99,19 @@ class ResetEmailer
     {
         $message = new \Swift_Message();
 
+        /** @var \Twig_Template $template */
+        $template = $this->twig->loadTemplate('emails/reset_password.twig');
+
         $message->setTo($email);
         $message->setFrom(
-            $this->template->renderBlock('from', $parameters),
-            $this->template->renderBlock('from_name', $parameters)
+            $template->renderBlock('from', $parameters),
+            $template->renderBlock('from_name', $parameters)
         );
 
-        $message->setSubject($this->template->renderBlock('subject', $parameters));
-        $message->setBody($this->template->renderBlock('body_text', $parameters));
+        $message->setSubject($template->renderBlock('subject', $parameters));
+        $message->setBody($template->renderBlock('body_text', $parameters));
         $message->addPart(
-            $this->template->renderBlock('body_html', $parameters),
+            $template->renderBlock('body_html', $parameters),
             'text/html'
         );
 

--- a/classes/Provider/ResetEmailerServiceProvider.php
+++ b/classes/Provider/ResetEmailerServiceProvider.php
@@ -16,7 +16,6 @@ namespace OpenCFP\Provider;
 use OpenCFP\Domain\Services\ResetEmailer;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use Twig_Environment;
 
 class ResetEmailerServiceProvider implements ServiceProviderInterface
 {
@@ -26,12 +25,9 @@ class ResetEmailerServiceProvider implements ServiceProviderInterface
     public function register(Container $app)
     {
         $app['reset_emailer'] = function ($app) {
-            /* @var Twig_Environment $twig */
-            $twig = $app['twig'];
-
             return new ResetEmailer(
                 $app['mailer'],
-                $twig->loadTemplate('emails/reset_password.twig'),
+                $app['twig'],
                 $app->config('application.email'),
                 $app->config('application.title')
             );

--- a/tests/Unit/Domain/Services/ResetEmailerTest.php
+++ b/tests/Unit/Domain/Services/ResetEmailerTest.php
@@ -46,9 +46,14 @@ final class ResetEmailerTest extends \PHPUnit\Framework\TestCase
         /* @var Twig_Template $template */
         $template = Mockery::mock(Twig_Template::class)->shouldIgnoreMissing();
 
+        $twig = Mockery::mock(\Twig_Environment::class);
+        $twig->shouldReceive('loadTemplate')
+            ->withArgs(['emails/reset_password.twig'])
+            ->andReturn($template);
+
         $resetEmailer = new ResetEmailer(
             $swiftMailer,
-            $template,
+            $twig,
             'admin@example.com',
             'Reset'
         );


### PR DESCRIPTION
This PR makes `ResetEmailer` use the Twig environment directly instead of depending on a template object. This will make it easier to wire that class as a service.

This make the class aware of the actual template it needs to use, but I don't see this as a big problem.

Related to #618.
