### PR TITLE
Moved Eloquent setup into a very early event listener

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace OpenCFP;
 
-use Illuminate\Database\Capsule\Manager as Capsule;
 use OpenCFP\Infrastructure\Event\ExceptionListener;
 use OpenCFP\Provider\ApplicationServiceProvider;
 use OpenCFP\Provider\CallForPapersProvider;
@@ -102,7 +101,6 @@ class Application extends SilexApplication
         // Application Services...
         $this->register(new ApplicationServiceProvider());
 
-        $this->setUpDataBaseConnection();
         $this->registerGlobalErrorHandler();
     }
 
@@ -185,12 +183,6 @@ class Application extends SilexApplication
         }
 
         return $cursor;
-    }
-
-    private function setUpDataBaseConnection()
-    {
-        $this[Capsule::class]->setAsGlobal();
-        $this[Capsule::class]->bootEloquent();
     }
 
     private function registerGlobalErrorHandler()

--- a/classes/Infrastructure/Event/DatabaseSetupListener.php
+++ b/classes/Infrastructure/Event/DatabaseSetupListener.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Infrastructure\Event;
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class DatabaseSetupListener implements EventSubscriberInterface
+{
+    /**
+     * @var Capsule
+     */
+    private $capsule;
+
+    public function __construct(Capsule $capsule)
+    {
+        $this->capsule = $capsule;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST  => ['setup', 512],
+            ConsoleEvents::COMMAND => ['setup', 512],
+        ];
+    }
+
+    public function setup()
+    {
+        $this->capsule->setAsGlobal();
+        $this->capsule->bootEloquent();
+    }
+}

--- a/classes/Provider/ApplicationServiceProvider.php
+++ b/classes/Provider/ApplicationServiceProvider.php
@@ -29,11 +29,14 @@ use OpenCFP\Infrastructure\Auth\SentinelAccountManagement;
 use OpenCFP\Infrastructure\Auth\SentinelAuthentication;
 use OpenCFP\Infrastructure\Auth\SentinelIdentityProvider;
 use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
+use OpenCFP\Infrastructure\Event\DatabaseSetupListener;
 use OpenCFP\Infrastructure\Persistence\IlluminateSpeakerRepository;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use Silex\Api\EventListenerProviderInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-final class ApplicationServiceProvider implements ServiceProviderInterface
+final class ApplicationServiceProvider implements ServiceProviderInterface, EventListenerProviderInterface
 {
     /**s
      * {@inheritdoc}
@@ -90,5 +93,10 @@ final class ApplicationServiceProvider implements ServiceProviderInterface
         $app['security.random'] = function () {
             return new PseudoRandomStringGenerator();
         };
+    }
+
+    public function subscribe(Container $app, EventDispatcherInterface $dispatcher)
+    {
+        $dispatcher->addSubscriber(new DatabaseSetupListener($app[Capsule::class]));
     }
 }

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -65,6 +65,7 @@ final class ProjectCodeTest extends Framework\TestCase
                 Http\View\TalkHelper::class,
                 Infrastructure\Event\AuthenticationListener::class,
                 Infrastructure\Event\CsrfValidationListener::class,
+                Infrastructure\Event\DatabaseSetupListener::class,
                 Infrastructure\Event\ExceptionListener::class,
                 Infrastructure\Event\TwigGlobalsListener::class,
                 Infrastructure\Templating\TwigExtension::class,


### PR DESCRIPTION
The setup logic for Eloquent was moved out of the application class.

Related to #618.
