### PR TITLE
Turned CSRF checker into an event subscriber

### DIFF
--- a/classes/Infrastructure/Event/CsrfValidationListener.php
+++ b/classes/Infrastructure/Event/CsrfValidationListener.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Infrastructure\Event;
+
+use OpenCFP\Domain\Services\RequestValidator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class CsrfValidationListener implements EventSubscriberInterface
+{
+    /**
+     * @var RequestValidator
+     */
+    private $csrfValidator;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    public function __construct(RequestValidator $csrfValidator, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->csrfValidator = $csrfValidator;
+        $this->urlGenerator  = $urlGenerator;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            // The router runs on priority 32.
+            // We need to make sure, this subscriber runs after the router.
+            KernelEvents::REQUEST => ['onKernelRequest', 16],
+        ];
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (!$request->attributes->get('_require_csrf_token', false)) {
+            return;
+        }
+
+        if ($this->csrfValidator->isValid($request)) {
+            return;
+        }
+
+        $event->setResponse(new RedirectResponse(
+            $this->urlGenerator->generate('dashboard')
+        ));
+    }
+}

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -32,6 +32,7 @@ use OpenCFP\Http\Controller\TalkController;
 use OpenCFP\Http\View\TalkHelper;
 use OpenCFP\Infrastructure\Auth\CsrfValidator;
 use OpenCFP\Infrastructure\Event\AuthenticationListener;
+use OpenCFP\Infrastructure\Event\CsrfValidationListener;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Silex\Api\BootableProviderInterface;
@@ -39,8 +40,6 @@ use Silex\Api\EventListenerProviderInterface;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 class WebGatewayProvider implements BootableProviderInterface, ServiceProviderInterface, EventListenerProviderInterface
 {
@@ -189,14 +188,6 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
             $app->requireHttps();
         }
 
-        $csrfChecker = function (Request $request) use ($app) {
-            $checker = $app[CsrfValidator::class];
-
-            if (!$checker->isValid($request)) {
-                return new RedirectResponse('/dashboard');
-            }
-        };
-
         $web->get('/', 'OpenCFP\Http\Controller\PagesController::showHomepage')
             ->bind('homepage');
         $web->get('/package', 'OpenCFP\Http\Controller\PagesController::showSpeakerPackage')
@@ -210,15 +201,15 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
 
         // Talks
         $web->get('/talk/edit/{id}', 'OpenCFP\Http\Controller\TalkController::editAction')
-            ->bind('talk_edit')->before($csrfChecker);
+            ->bind('talk_edit')->value('_require_csrf_token', true);
         $web->get('/talk/create', 'OpenCFP\Http\Controller\TalkController::createAction')
             ->bind('talk_new');
         $web->post('/talk/create', 'OpenCFP\Http\Controller\TalkController::processCreateAction')
-            ->bind('talk_create')->before($csrfChecker);
+            ->bind('talk_create')->value('_require_csrf_token', true);
         $web->post('/talk/update', 'OpenCFP\Http\Controller\TalkController::updateAction')
-            ->bind('talk_update')->before($csrfChecker);
+            ->bind('talk_update')->value('_require_csrf_token', true);
         $web->post('/talk/delete', 'OpenCFP\Http\Controller\TalkController::deleteAction')
-            ->bind('talk_delete')->before($csrfChecker);
+            ->bind('talk_delete')->value('_require_csrf_token', true);
         $web->get('/talk/{id}', 'OpenCFP\Http\Controller\TalkController::viewAction')
             ->bind('talk_view');
 
@@ -289,11 +280,11 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
         $admin->get('/speakers/{id}', 'OpenCFP\Http\Controller\Admin\SpeakersController::viewAction')
             ->bind('admin_speaker_view');
         $admin->get('/speakers/{id}/promote', 'OpenCFP\Http\Controller\Admin\SpeakersController::promoteAction')
-            ->bind('admin_speaker_promote')->before($csrfChecker);
+            ->bind('admin_speaker_promote')->value('_require_csrf_token', true);
         $admin->get('/speakers/{id}/demote', 'OpenCFP\Http\Controller\Admin\SpeakersController::demoteAction')
-            ->bind('admin_speaker_demote')->before($csrfChecker);
+            ->bind('admin_speaker_demote')->value('_require_csrf_token', true);
         $admin->get('/speakers/delete/{id}', 'OpenCFP\Http\Controller\Admin\SpeakersController::deleteAction')
-            ->bind('admin_speaker_delete')->before($csrfChecker);
+            ->bind('admin_speaker_delete')->value('_require_csrf_token', true);
 
         // CSV Exports
         $admin->get('/export/csv', 'OpenCFP\Http\Controller\Admin\ExportsController::attributedTalksExportAction')
@@ -341,6 +332,10 @@ class WebGatewayProvider implements BootableProviderInterface, ServiceProviderIn
     {
         $dispatcher->addSubscriber(new AuthenticationListener(
             $app[Authentication::class],
+            $app['url_generator']
+        ));
+        $dispatcher->addSubscriber(new CsrfValidationListener(
+            $app[CsrfValidator::class],
             $app['url_generator']
         ));
     }

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -64,6 +64,7 @@ final class ProjectCodeTest extends Framework\TestCase
                 Http\Form\ResetForm::class,
                 Http\View\TalkHelper::class,
                 Infrastructure\Event\AuthenticationListener::class,
+                Infrastructure\Event\CsrfValidationListener::class,
                 Infrastructure\Event\ExceptionListener::class,
                 Infrastructure\Event\TwigGlobalsListener::class,
                 Infrastructure\Templating\TwigExtension::class,


### PR DESCRIPTION
CSRF tokens are being checked in an event subscriber now.

This one is a bit tricky. Since Symfony does not offer the possibility to attach listeners to routes, I'm marking the affected routes with a request attribute.

As a auggestion: You should consider using Symfony forms because would gain CSRF protection out of the box.

Related to #618.
