### PR TITLE
Remove unused variable being passed to twig template

### DIFF
--- a/classes/Http/Controller/PagesController.php
+++ b/classes/Http/Controller/PagesController.php
@@ -20,21 +20,18 @@ class PagesController extends BaseController
 {
     public function showHomepage(): Response
     {
-        return $this->render('home.twig', $this->getContextWithTalksCount());
+        return $this->render('home.twig', [
+            'number_of_talks' => Talk::count(),
+        ]);
     }
 
     public function showSpeakerPackage(): Response
     {
-        return $this->render('package.twig', $this->getContextWithTalksCount());
+        return $this->render('package.twig');
     }
 
     public function showTalkIdeas(): Response
     {
-        return $this->render('ideas.twig', $this->getContextWithTalksCount());
-    }
-
-    private function getContextWithTalksCount()
-    {
-        return ['number_of_talks' => Talk::count()];
+        return $this->render('ideas.twig');
     }
 }


### PR DESCRIPTION
This PR

* [x] removes unneeded information passed to twig templates 

Only the home page uses the number_of_talks variable, so there was no need to pass it to the other templates.