### PR TITLE
Fix: Remove app reference in security controller

### DIFF
--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -60,7 +60,7 @@ class SecurityController extends BaseController
                 'security/login.twig',
                 [
                     'email' => $request->get('email'),
-                    'flash' => $this->app['session']->get('flash'),
+                    'flash' => $request->getSession()->get('flash'),
                 ],
                 Response::HTTP_BAD_REQUEST
             );


### PR DESCRIPTION
This PR

* [x] Removes a ```$this->app``` reference in the security controller

This caused a fatal error when trying to log in with wrong credentials