### PR TITLE
Construct the console application via DI

### DIFF
--- a/bin/opencfp
+++ b/bin/opencfp
@@ -1,38 +1,24 @@
 #!/usr/bin/env php
 <?php
 
+namespace OpenCFP;
+
+use Symfony\Component\Console\Input\ArgvInput;
+
 \set_time_limit(0);
 
 require_once __DIR__ . '/../vendor/autoload.php';
-
-use OpenCFP\Application as ApplicationContainer;
-use OpenCFP\Console\Application;
-use OpenCFP\Console\Command;
-use OpenCFP\Domain\Services;
-use OpenCFP\Environment;
-use OpenCFP\PathInterface;
-use Symfony\Component\Console\Input\ArgvInput;
 
 $basePath    = \realpath(\dirname(__DIR__));
 $input       = new ArgvInput();
 $environment = $input->getParameterOption(['--env'], \getenv('CFP_ENV') ?: 'development');
 
-$container = new ApplicationContainer($basePath, Environment::fromString($environment));
+$container = new Application($basePath, Environment::fromString($environment));
+$container->boot();
 
-/** @var Services\AccountManagement $accountManagement */
-$accountManagement = $container[Services\AccountManagement::class];
+/** @var Console\Application $app */
+$app = $container[Console\Application::class];
 
-/** @var PathInterface $path */
-$path = $container['path'];
-
-$app = new Application($container);
-
-$app->addCommands([
-    new Command\ClearCacheCommand($path),
-    new Command\UserCreateCommand($accountManagement),
-    new Command\UserDemoteCommand($accountManagement),
-    new Command\UserPromoteCommand($accountManagement),
-]);
 $status = $app->run($input);
 
 exit($status);

--- a/classes/Application.php
+++ b/classes/Application.php
@@ -18,6 +18,7 @@ use OpenCFP\Infrastructure\Event\ExceptionListener;
 use OpenCFP\Provider\ApplicationServiceProvider;
 use OpenCFP\Provider\CallForPapersProvider;
 use OpenCFP\Provider\ControllerResolverServiceProvider;
+use OpenCFP\Provider\Gateways\ConsoleGatewayProvider;
 use OpenCFP\Provider\Gateways\WebGatewayProvider;
 use OpenCFP\Provider\HtmlPurifierServiceProvider;
 use OpenCFP\Provider\ImageProcessorProvider;
@@ -59,6 +60,7 @@ class Application extends SilexApplication
 
         // Register Gateways...
         $this->register(new WebGatewayProvider());
+        $this->register(new ConsoleGatewayProvider());
 
         // Services...
         $this->register(new SessionServiceProvider());

--- a/classes/Console/Command/ClearCacheCommand.php
+++ b/classes/Console/Command/ClearCacheCommand.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace OpenCFP\Console\Command;
 
-use OpenCFP\PathInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,15 +21,15 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class ClearCacheCommand extends Command
 {
     /**
-     * @var PathInterface
+     * @var string[]
      */
-    private $path;
+    private $paths;
 
-    public function __construct(PathInterface $path)
+    public function __construct(array $paths)
     {
         parent::__construct('cache:clear');
 
-        $this->path = $path;
+        $this->paths = $paths;
     }
 
     protected function configure()
@@ -49,12 +48,7 @@ final class ClearCacheCommand extends Command
 
         $io->section('Clearing caches');
 
-        $paths = [
-            $this->path->cachePurifierPath(),
-            $this->path->cacheTwigPath(),
-        ];
-
-        \array_walk($paths, function ($path) use ($io) {
+        \array_walk($this->paths, function ($path) use ($io) {
             $count = $this->deleteFilesAndDirectoriesIn($path);
 
             $io->writeln(\sprintf(

--- a/classes/Provider/Gateways/ConsoleGatewayProvider.php
+++ b/classes/Provider/Gateways/ConsoleGatewayProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Provider\Gateways;
+
+use OpenCFP\Console\Application;
+use OpenCFP\Console\Command\ClearCacheCommand;
+use OpenCFP\Console\Command\UserCreateCommand;
+use OpenCFP\Console\Command\UserDemoteCommand;
+use OpenCFP\Console\Command\UserPromoteCommand;
+use OpenCFP\Domain\Services\AccountManagement;
+use OpenCFP\Path;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+final class ConsoleGatewayProvider implements ServiceProviderInterface
+{
+    public function register(Container $app)
+    {
+        $app[ClearCacheCommand::class] = function ($app) {
+            /** @var Path $path */
+            $path = $app['path'];
+
+            return new ClearCacheCommand([
+                $path->cachePurifierPath(),
+                $path->cacheTwigPath(),
+            ]);
+        };
+
+        $app[UserCreateCommand::class] = function ($app) {
+            return new UserCreateCommand(
+                $app[AccountManagement::class]
+            );
+        };
+
+        $app[UserDemoteCommand::class] = function ($app) {
+            return new UserDemoteCommand(
+                $app[AccountManagement::class]
+            );
+        };
+
+        $app[UserPromoteCommand::class] = function ($app) {
+            return new UserPromoteCommand(
+                $app[AccountManagement::class]
+            );
+        };
+
+        $app[Application::class] = function ($app) {
+            $console = new Application();
+
+            $console->setDispatcher($app['dispatcher']);
+            $console->addCommands([
+                $app[ClearCacheCommand::class],
+                $app[UserCreateCommand::class],
+                $app[UserDemoteCommand::class],
+                $app[UserPromoteCommand::class],
+            ]);
+
+            return $console;
+        };
+    }
+}

--- a/tests/Unit/Console/Command/ClearCacheCommandTest.php
+++ b/tests/Unit/Console/Command/ClearCacheCommandTest.php
@@ -15,7 +15,6 @@ namespace OpenCFP\Test\Unit\Console\Command;
 
 use Localheinz\Test\Util\Helper;
 use OpenCFP\Console\Command\ClearCacheCommand;
-use OpenCFP\PathInterface;
 use org\bovigo\vfs;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
@@ -49,7 +48,7 @@ final class ClearCacheCommandTest extends Framework\TestCase
 
     public function testHasNameAndDescription()
     {
-        $command = new ClearCacheCommand($this->createPathMock());
+        $command = new ClearCacheCommand([]);
 
         $this->assertSame('cache:clear', $command->getName());
         $this->assertSame('Clears the caches', $command->getDescription());
@@ -57,28 +56,12 @@ final class ClearCacheCommandTest extends Framework\TestCase
 
     public function testExecuteRemovesFilesWithinCacheDirectories()
     {
-        $accessors = [
-            'cachePurifierPath',
-            'cacheTwigPath',
+        $directories = [
+            $this->createDirectoryWithFilesAndDirectories($this->root->url()),
+            $this->createDirectoryWithFilesAndDirectories($this->root->url()),
         ];
 
-        $directories = \array_combine(
-            $accessors,
-            \array_map(function () {
-                return $this->createDirectoryWithFilesAndDirectories($this->root->url());
-            }, $accessors)
-        );
-
-        $path = $this->createPathMock();
-
-        foreach ($directories as $accessor => $directory) {
-            $path
-                ->expects($this->once())
-                ->method($accessor)
-                ->willReturn($directory);
-        }
-
-        $command = new ClearCacheCommand($path);
+        $command = new ClearCacheCommand($directories);
 
         $commandTester = new Console\Tester\CommandTester($command);
 
@@ -102,14 +85,6 @@ final class ClearCacheCommandTest extends Framework\TestCase
 
             $this->assertCount(0, $filesAndDirectories);
         }
-    }
-
-    /**
-     * @return PathInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private function createPathMock(): PathInterface
-    {
-        return $this->createMock(PathInterface::class);
     }
 
     private function createDirectoryWithFilesAndDirectories(string $rootDirectory, int $currentDepth = 0, $maxDepth = 3)

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -73,6 +73,7 @@ final class ProjectCodeTest extends Framework\TestCase
                 Provider\ControllerResolverServiceProvider::class,
                 Provider\Gateways\RequestCleaner::class,
                 Provider\Gateways\WebGatewayProvider::class,
+                Provider\Gateways\ConsoleGatewayProvider::class,
                 Provider\HtmlPurifierServiceProvider::class,
                 Provider\ImageProcessorProvider::class,
                 Provider\ResetEmailerServiceProvider::class,


### PR DESCRIPTION
This PR moves the construction of the console application to the DI container. It also decouples the cache clear command from the `Path` object which simplifies some test cases.