### PR TITLE
Use a mockable authenticator instead of service swapping

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -27,6 +27,7 @@ use OpenCFP\Provider\TalkFilterProvider;
 use OpenCFP\Provider\TalkHandlerProvider;
 use OpenCFP\Provider\TalkHelperProvider;
 use OpenCFP\Provider\TalkRatingProvider;
+use OpenCFP\Provider\TestingServiceProvider;
 use OpenCFP\Provider\TwigServiceProvider;
 use OpenCFP\Provider\YamlConfigDriver;
 use Silex\Application as SilexApplication;
@@ -62,7 +63,9 @@ class Application extends SilexApplication
         $this->register(new ConsoleGatewayProvider());
 
         // Services...
-        $this->register(new SessionServiceProvider());
+        $this->register(new SessionServiceProvider(), [
+            'session.test' => $environment->isTesting(),
+        ]);
         $this->register(new FormServiceProvider());
         $this->register(new CsrfServiceProvider());
         $this->register(new ControllerResolverServiceProvider());
@@ -100,6 +103,11 @@ class Application extends SilexApplication
 
         // Application Services...
         $this->register(new ApplicationServiceProvider());
+
+        // Testing
+        if ($environment->isTesting()) {
+            $this->register(new TestingServiceProvider());
+        }
 
         $this->registerGlobalErrorHandler();
     }

--- a/classes/Provider/TestingServiceProvider.php
+++ b/classes/Provider/TestingServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Provider;
+
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Test\Helper\MockableAuthenticator;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+final class TestingServiceProvider implements ServiceProviderInterface
+{
+    public function register(Container $app)
+    {
+        $app->extend(Authentication::class, function (Authentication $authentication) {
+            return new MockableAuthenticator($authentication);
+        });
+    }
+}

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -61,10 +61,7 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 
     public function createApplication(): Application
     {
-        $app                 = new Application(__DIR__ . '/..', Environment::testing());
-        $app['session.test'] = true;
-
-        return $app;
+        return new Application(__DIR__ . '/..', Environment::testing());
     }
 
     public function refreshApplication()

--- a/tests/Helper/MockableAuthenticator.php
+++ b/tests/Helper/MockableAuthenticator.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Helper;
+
+use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\NotAuthenticatedException;
+use OpenCFP\Infrastructure\Auth\UserInterface;
+
+final class MockableAuthenticator implements Authentication
+{
+    /**
+     * @var Authentication
+     */
+    private $wrapped;
+
+    /**
+     * @var null|bool
+     */
+    private $isAuthenticated;
+
+    /**
+     * @var null|UserInterface
+     */
+    private $user;
+
+    public function __construct(Authentication $wrapped)
+    {
+        $this->wrapped = $wrapped;
+    }
+
+    /**
+     * Assume that the given user is logged in.
+     *
+     * @param UserInterface $user
+     */
+    public function overrideUser(UserInterface $user)
+    {
+        $this->isAuthenticated = true;
+        $this->user            = $user;
+    }
+
+    /**
+     * Assume that no user is authenticated.
+     */
+    public function overrideUnauthenticated()
+    {
+        $this->isAuthenticated = false;
+        $this->user            = null;
+    }
+
+    /**
+     * Switch back to the wrapped authenticator.
+     */
+    public function reset()
+    {
+        $this->isAuthenticated = $this->user = null;
+    }
+
+    public function authenticate($username, $password)
+    {
+        $this->wrapped->authenticate($username, $password);
+    }
+
+    public function user(): UserInterface
+    {
+        if ($this->isAuthenticated === false) {
+            throw new NotAuthenticatedException();
+        }
+
+        return $this->user ?: $this->wrapped->user();
+    }
+
+    public function isAuthenticated(): bool
+    {
+        if ($this->isAuthenticated !== null) {
+            return $this->isAuthenticated;
+        }
+
+        return $this->wrapped->isAuthenticated();
+    }
+
+    public function logout()
+    {
+        $this->reset();
+        $this->wrapped->logout();
+    }
+}

--- a/tests/Integration/Http/Controller/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/DashboardControllerTest.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Integration\Http\Controller;
 
 use Mockery as m;
-use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
-use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\Integration\WebTestCase;
 
 /**
@@ -33,16 +31,7 @@ final class DashboardControllerTest extends WebTestCase
      */
     public function indexDisplaysUserAndTalks()
     {
-        $user = m::mock(UserInterface::class);
-        $user->shouldReceive('id')->andReturn(1);
-        $user->shouldReceive('getId')->andReturn(1);
-        $user->shouldReceive('hasAccess')->with('admin')->andReturn(true);
-        $user->shouldReceive('hasAccess')->with('reviewer')->andReturn(false);
-
-        $auth = m::mock(Authentication::class);
-        $auth->shouldReceive('isAuthenticated')->andReturn(true);
-        $auth->shouldReceive('user')->andReturn($user);
-        $this->swap(Authentication::class, $auth);
+        $this->asAdmin();
 
         // Create a test double for a talk in profile
         $talk = m::mock(\stdClass::class);
@@ -78,16 +67,7 @@ final class DashboardControllerTest extends WebTestCase
     {
         $faker = $this->faker();
 
-        $user = m::mock(UserInterface::class);
-        $user->shouldReceive('hasPermission')->with('admin')->andReturn(true);
-        $user->shouldReceive('getId')->andReturn(1);
-        $user->shouldReceive('id')->andReturn(1);
-        $user->shouldReceive('hasAccess')->with('admin')->andReturn(false);
-        $auth = m::mock(Authentication::class);
-        $auth->shouldReceive('isAuthenticated')->andReturn(true);
-        $auth->shouldReceive('user')->andReturn($user);
-        $this->swap(Authentication::class, $auth);
-        $this->swap('user', $user);
+        $this->asLoggedInSpeaker();
 
         // Create a test double for SpeakerProfile
         // We  have benefit of being able to stub an application

--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -20,6 +20,7 @@ use OpenCFP\Domain\Services\RequestValidator;
 use OpenCFP\Infrastructure\Auth\CsrfValidator;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\BaseTestCase;
+use OpenCFP\Test\Helper\MockableAuthenticator;
 use OpenCFP\Test\Helper\ResponseHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -179,10 +180,9 @@ abstract class WebTestCase extends BaseTestCase
         $user->shouldReceive('hasPermission')->with('reviewer')->andReturn(false);
         $user->shouldReceive('getLogin')->andReturn('my@email.com');
 
-        $auth = Mockery::mock(Authentication::class);
-        $auth->shouldReceive('isAuthenticated')->andReturn(true);
-        $auth->shouldReceive('user')->andReturn($user);
-        $this->swap(Authentication::class, $auth);
+        /** @var MockableAuthenticator $authentication */
+        $authentication = $this->container->get(Authentication::class);
+        $authentication->overrideUser($user);
 
         return $this;
     }
@@ -196,12 +196,10 @@ abstract class WebTestCase extends BaseTestCase
         $user->shouldReceive('hasPermission')->with('admin')->andReturn(true);
         $user->shouldReceive('hasAccess')->with('reviewer')->andReturn(false);
         $user->shouldReceive('hasPermission')->with('reviewer')->andReturn(false);
-        $auth = Mockery::mock(Authentication::class);
 
-        $auth->shouldReceive('isAuthenticated')->andReturn(true);
-        $auth->shouldReceive('user')->andReturn($user);
-        $auth->shouldReceive('userId')->andReturn($id);
-        $this->swap(Authentication::class, $auth);
+        /** @var MockableAuthenticator $authentication */
+        $authentication = $this->container->get(Authentication::class);
+        $authentication->overrideUser($user);
 
         return $this;
     }
@@ -216,10 +214,9 @@ abstract class WebTestCase extends BaseTestCase
         $user->shouldReceive('hasAccess')->with('reviewer')->andReturn(true);
         $user->shouldReceive('hasPermission')->with('reviewer')->andReturn(true);
 
-        $auth = Mockery::mock(Authentication::class);
-        $auth->shouldReceive('isAuthenticated')->andReturn(true);
-        $auth->shouldReceive('user')->andReturn($user);
-        $this->swap(Authentication::class, $auth);
+        /** @var MockableAuthenticator $authentication */
+        $authentication = $this->container->get(Authentication::class);
+        $authentication->overrideUser($user);
 
         return $this;
     }

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -83,6 +83,7 @@ final class ProjectCodeTest extends Framework\TestCase
                 Provider\TalkHandlerProvider::class,
                 Provider\TalkHelperProvider::class,
                 Provider\TalkRatingProvider::class,
+                Provider\TestingServiceProvider::class,
                 Provider\TwigServiceProvider::class,
                 Provider\YamlConfigDriver::class,
             ]


### PR DESCRIPTION
Swapping services is really not fun with the Symfony container. With this PR, I tried to get around swapping services for authentication. WDYT?

Related to #618.
