### PR TITLE
Reduce twig priority

### DIFF
--- a/classes/Infrastructure/Event/TwigGlobalsListener.php
+++ b/classes/Infrastructure/Event/TwigGlobalsListener.php
@@ -59,7 +59,7 @@ class TwigGlobalsListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::REQUEST => ['onKernelRequest', 512],
+            KernelEvents::REQUEST => ['onKernelRequest', 256],
         ];
     }
 


### PR DESCRIPTION
This PR

* [x] Reduces the priority of the twig global listener

Due to this having a priority of 512, the same as the ```DatabaseSetupListener``` ,it would fire before the db connection was set up and would throw a fatal error.