### PR TITLE
Enhancement: Enable and configure php_unit_test_annotation fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -114,6 +114,9 @@ return PhpCsFixer\Config::create()
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,
         'php_unit_strict' => true,
+        'php_unit_test_annotation' => [
+            'style' => 'annotation'
+        ],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,

--- a/tests/Integration/Domain/Model/AirportTest.php
+++ b/tests/Integration/Domain/Model/AirportTest.php
@@ -52,7 +52,10 @@ final class AirportTest extends WebTestCase
         $this->airports->withCode('foobarbaz');
     }
 
-    public function testItIsNotCaseSensitive()
+    /**
+     * @test
+     */
+    public function itIsNotCaseSensitive()
     {
         $airport = $this->airports->withCode('aac');
 
@@ -61,7 +64,10 @@ final class AirportTest extends WebTestCase
         $this->assertSame('Egypt', $airport->country);
     }
 
-    public function testItThrowsTheCorrectError()
+    /**
+     * @test
+     */
+    public function itThrowsTheCorrectError()
     {
         $this->expectException(EntityNotFoundException::class);
         $this->expectExceptionMessage('not found');

--- a/tests/Integration/Http/Action/Forgot/ResetProcessActionTest.php
+++ b/tests/Integration/Http/Action/Forgot/ResetProcessActionTest.php
@@ -20,7 +20,10 @@ use Symfony\Component\HttpFoundation;
 
 final class ResetProcessActionTest extends WebTestCase implements TransactionalTestCase
 {
-    public function testRendersResetPasswordFormIfFormIsNotSubmitted()
+    /**
+     * @test
+     */
+    public function rendersResetPasswordFormIfFormIsNotSubmitted()
     {
         $resetCode = $this->faker()->sha256;
 

--- a/tests/Integration/Http/Action/Forgot/UpdatePasswordActionTest.php
+++ b/tests/Integration/Http/Action/Forgot/UpdatePasswordActionTest.php
@@ -17,7 +17,10 @@ use OpenCFP\Test\Integration\WebTestCase;
 
 final class UpdatePasswordActionTest extends WebTestCase
 {
-    public function testRendersResetPasswordFormIfFormIsInvalid()
+    /**
+     * @test
+     */
+    public function rendersResetPasswordFormIfFormIsInvalid()
     {
         $response = $this->post('/updatepassword');
 

--- a/tests/Integration/Http/Action/Profile/ChangePasswordProcessActionTest.php
+++ b/tests/Integration/Http/Action/Profile/ChangePasswordProcessActionTest.php
@@ -19,7 +19,10 @@ use OpenCFP\Test\Integration\WebTestCase;
 
 final class ChangePasswordProcessActionTest extends WebTestCase implements TransactionalTestCase
 {
-    public function testRedirectsToPasswordEditIfDataIsMissing()
+    /**
+     * @test
+     */
+    public function redirectsToPasswordEditIfDataIsMissing()
     {
         /** @var Model\User $user */
         $user = factory(Model\User::class)->create()->first();
@@ -33,7 +36,10 @@ final class ChangePasswordProcessActionTest extends WebTestCase implements Trans
         $this->assertSessionHasFlashMessage('Missing passwords', $this->session());
     }
 
-    public function testRedirectsToPasswordEditIfPasswordAndPasswordConfirmationAreEmptyStrings()
+    /**
+     * @test
+     */
+    public function redirectsToPasswordEditIfPasswordAndPasswordConfirmationAreEmptyStrings()
     {
         /** @var Model\User $user */
         $user = factory(Model\User::class)->create()->first();
@@ -50,7 +56,10 @@ final class ChangePasswordProcessActionTest extends WebTestCase implements Trans
         $this->assertSessionHasFlashMessage('Missing passwords', $this->session());
     }
 
-    public function testRedirectsToPasswordEditIfPasswordDoesNotEqualPasswordConfirmation()
+    /**
+     * @test
+     */
+    public function redirectsToPasswordEditIfPasswordDoesNotEqualPasswordConfirmation()
     {
         $faker = $this->faker();
 

--- a/tests/Integration/Http/Action/Security/IndexActionTest.php
+++ b/tests/Integration/Http/Action/Security/IndexActionTest.php
@@ -17,7 +17,10 @@ use OpenCFP\Test\Integration\WebTestCase;
 
 final class IndexActionTest extends WebTestCase
 {
-    public function testIndexShowsLoginForm()
+    /**
+     * @test
+     */
+    public function indexShowsLoginForm()
     {
         $this->callForPapersIsOpen();
 

--- a/tests/Integration/Http/Action/Security/LogInActionTest.php
+++ b/tests/Integration/Http/Action/Security/LogInActionTest.php
@@ -20,7 +20,10 @@ use Symfony\Component\HttpFoundation;
 
 final class LogInActionTest extends WebTestCase implements TransactionalTestCase
 {
-    public function testRendersLoginFormIfAuthenticationFailed()
+    /**
+     * @test
+     */
+    public function rendersLoginFormIfAuthenticationFailed()
     {
         /** @var Model\User $user */
         $user = factory(Model\User::class)->create()->first();

--- a/tests/Integration/Http/Action/Security/LogOutActionTest.php
+++ b/tests/Integration/Http/Action/Security/LogOutActionTest.php
@@ -20,7 +20,10 @@ use OpenCFP\Test\Integration\WebTestCase;
 
 final class LogOutActionTest extends WebTestCase implements TransactionalTestCase
 {
-    public function testLogsOutUserAndRedirectsToHomepage()
+    /**
+     * @test
+     */
+    public function logsOutUserAndRedirectsToHomepage()
     {
         /** @var Model\User $user */
         $user = factory(Model\User::class)->create()->first();

--- a/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -53,7 +53,10 @@ final class SentinelAccountManagementTest extends WebTestCase implements Transac
         $this->assertSame('Test Account', "{$user->getUser()->first_name} {$user->getUser()->last_name}");
     }
 
-    public function testCreatingDuplicateUserThrowsError()
+    /**
+     * @test
+     */
+    public function creatingDuplicateUserThrowsError()
     {
         $this->sut->create('test@example.com', 'secret', [
             'first_name' => 'Test',

--- a/tests/Integration/Infrastructure/Event/AuthenticationListenerTest.php
+++ b/tests/Integration/Infrastructure/Event/AuthenticationListenerTest.php
@@ -19,14 +19,20 @@ use Symfony\Component\HttpFoundation;
 
 final class AuthenticationListenerTest extends WebTestCase
 {
-    public function testNoLoginRequired()
+    /**
+     * @test
+     */
+    public function noLoginRequired()
     {
         $response = $this->get('/');
 
         $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_OK, $response);
     }
 
-    public function testTalksRouteRequireLogin()
+    /**
+     * @test
+     */
+    public function talksRouteRequireLogin()
     {
         $response = $this->get('/talk/create');
 
@@ -35,7 +41,10 @@ final class AuthenticationListenerTest extends WebTestCase
         $this->assertRedirectResponseUrlEquals($url, $response);
     }
 
-    public function testTalksRouteWithLogin()
+    /**
+     * @test
+     */
+    public function talksRouteWithLogin()
     {
         /** @var Model\User $speaker */
         $speaker = factory(Model\User::class)->create()->first();
@@ -47,7 +56,10 @@ final class AuthenticationListenerTest extends WebTestCase
         $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_OK, $response);
     }
 
-    public function testReviewerDashboardRequiresLogin()
+    /**
+     * @test
+     */
+    public function reviewerDashboardRequiresLogin()
     {
         $response = $this->get('/reviewer/');
 
@@ -56,7 +68,10 @@ final class AuthenticationListenerTest extends WebTestCase
         $this->assertRedirectResponseUrlEquals($url, $response);
     }
 
-    public function testReviewerDashboardRequiresReviewer()
+    /**
+     * @test
+     */
+    public function reviewerDashboardRequiresReviewer()
     {
         /** @var Model\User $speaker */
         $speaker = factory(Model\User::class)->create()->first();
@@ -70,7 +85,10 @@ final class AuthenticationListenerTest extends WebTestCase
         $this->assertRedirectResponseUrlEquals($url, $response);
     }
 
-    public function testReviewerDashboardAsReviewer()
+    /**
+     * @test
+     */
+    public function reviewerDashboardAsReviewer()
     {
         /** @var Model\User $reviewer */
         $reviewer = factory(Model\User::class)->create()->first();
@@ -82,7 +100,10 @@ final class AuthenticationListenerTest extends WebTestCase
         $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_OK, $response);
     }
 
-    public function testAdminDashboardRequiresLogin()
+    /**
+     * @test
+     */
+    public function adminDashboardRequiresLogin()
     {
         $response = $this->get('/admin/');
 
@@ -91,7 +112,10 @@ final class AuthenticationListenerTest extends WebTestCase
         $this->assertRedirectResponseUrlEquals($url, $response);
     }
 
-    public function testAdminDashboardRequiresAdmin()
+    /**
+     * @test
+     */
+    public function adminDashboardRequiresAdmin()
     {
         /** @var Model\User $speaker */
         $speaker = factory(Model\User::class)->create()->first();
@@ -105,7 +129,10 @@ final class AuthenticationListenerTest extends WebTestCase
         $this->assertRedirectResponseUrlEquals($url, $response);
     }
 
-    public function testAdminDashboardAsAdmin()
+    /**
+     * @test
+     */
+    public function adminDashboardAsAdmin()
     {
         /** @var Model\User $admin */
         $admin = factory(Model\User::class)->create()->first();

--- a/tests/Integration/Infrastructure/Event/ExceptionListenerTest.php
+++ b/tests/Integration/Infrastructure/Event/ExceptionListenerTest.php
@@ -19,7 +19,10 @@ use Symfony\Component\HttpFoundation;
 
 final class ExceptionListenerTest extends WebTestCase
 {
-    public function testJsonOn404()
+    /**
+     * @test
+     */
+    public function jsonOn404()
     {
         $response = $this->get('/invalid/uri', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
 
@@ -28,7 +31,10 @@ final class ExceptionListenerTest extends WebTestCase
         $this->assertResponseBodyJson('{"error": "No route found for \\"GET /invalid/uri\\""}', $response);
     }
 
-    public function testHtmlOn404()
+    /**
+     * @test
+     */
+    public function htmlOn404()
     {
         $response = $this->get('/invalid/uri');
 

--- a/tests/Integration/Infrastructure/Event/TwigGlobalsListenerTest.php
+++ b/tests/Integration/Infrastructure/Event/TwigGlobalsListenerTest.php
@@ -32,8 +32,10 @@ final class TwigGlobalsListenerTest extends TestCase
 {
     /**
      * @dataProvider provideTestSetup
+     *
+     * @test
      */
-    public function testGlobals(Authentication $authentication, bool $isOpen, string $uri, string $flash = null, string $fixture)
+    public function globals(Authentication $authentication, bool $isOpen, string $uri, string $flash = null, string $fixture)
     {
         $twig    = new Twig_Environment(new \Twig_Loader_Filesystem(__DIR__ . '/Fixtures'));
         $session = new Session(new MockArraySessionStorage());

--- a/tests/Integration/Infrastructure/Templating/TwigExtensionTest.php
+++ b/tests/Integration/Infrastructure/Templating/TwigExtensionTest.php
@@ -25,7 +25,10 @@ use Symfony\Component\Routing\RouteCollection;
 
 final class TwigExtensionTest extends TestCase
 {
-    public function testExtension()
+    /**
+     * @test
+     */
+    public function extension()
     {
         $requestStack = new RequestStack();
         $requestStack->push(Request::create('/dashboard'));

--- a/tests/Integration/Provider/SentinelServiceProviderTest.php
+++ b/tests/Integration/Provider/SentinelServiceProviderTest.php
@@ -18,7 +18,10 @@ use OpenCFP\Test\Integration\WebTestCase;
 
 final class SentinelServiceProviderTest extends WebTestCase
 {
-    public function testAllRepositoriesAreSet()
+    /**
+     * @test
+     */
+    public function allRepositoriesAreSet()
     {
         /** @var Sentinel $sentinel */
         $sentinel = $this->container->get(Sentinel::class);

--- a/tests/Unit/Application/NotAuthorizedExceptionTest.php
+++ b/tests/Unit/Application/NotAuthorizedExceptionTest.php
@@ -21,7 +21,10 @@ final class NotAuthorizedExceptionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsException()
+    /**
+     * @test
+     */
+    public function isException()
     {
         $this->assertClassExtends(\Exception::class, NotAuthorizedException::class);
     }

--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -24,17 +24,26 @@ final class UserCreateCommandTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(UserCreateCommand::class);
     }
 
-    public function testExtendsCommand()
+    /**
+     * @test
+     */
+    public function extendsCommand()
     {
         $this->assertClassExtends(Console\Command\Command::class, UserCreateCommand::class);
     }
 
-    public function testHasNameAndDescription()
+    /**
+     * @test
+     */
+    public function hasNameAndDescription()
     {
         $command = new UserCreateCommand($this->createAccountManagementMock());
 
@@ -42,7 +51,10 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertSame('Creates a new user', $command->getDescription());
     }
 
-    public function testHasFirstNameOption()
+    /**
+     * @test
+     */
+    public function hasFirstNameOption()
     {
         $command = new UserCreateCommand($this->createAccountManagementMock());
 
@@ -59,7 +71,10 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertFalse($option->isArray());
     }
 
-    public function testHasLastNameOption()
+    /**
+     * @test
+     */
+    public function hasLastNameOption()
     {
         $command = new UserCreateCommand($this->createAccountManagementMock());
 
@@ -76,7 +91,10 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertFalse($option->isArray());
     }
 
-    public function testHasEmailOption()
+    /**
+     * @test
+     */
+    public function hasEmailOption()
     {
         $command = new UserCreateCommand($this->createAccountManagementMock());
 
@@ -93,7 +111,10 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertFalse($option->isArray());
     }
 
-    public function testHasPasswordOption()
+    /**
+     * @test
+     */
+    public function hasPasswordOption()
     {
         $command = new UserCreateCommand($this->createAccountManagementMock());
 
@@ -110,7 +131,10 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertFalse($option->isArray());
     }
 
-    public function testHasAdminOption()
+    /**
+     * @test
+     */
+    public function hasAdminOption()
     {
         $command = new UserCreateCommand($this->createAccountManagementMock());
 
@@ -127,7 +151,10 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertFalse($option->isArray());
     }
 
-    public function testHasReviewerOption()
+    /**
+     * @test
+     */
+    public function hasReviewerOption()
     {
         $command = new UserCreateCommand($this->createAccountManagementMock());
 
@@ -144,7 +171,10 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertFalse($option->isArray());
     }
 
-    public function testExecuteFailsIfUserExists()
+    /**
+     * @test
+     */
+    public function executeFailsIfUserExists()
     {
         $faker = $this->faker();
 
@@ -191,7 +221,10 @@ final class UserCreateCommandTest extends Framework\TestCase
         $this->assertContains($message, $commandTester->getDisplay());
     }
 
-    public function testExecuteSucceedsIfUserDoesNotExist()
+    /**
+     * @test
+     */
+    public function executeSucceedsIfUserDoesNotExist()
     {
         $faker = $this->faker();
 
@@ -252,8 +285,10 @@ final class UserCreateCommandTest extends Framework\TestCase
      *
      * @param string[] $options
      * @param string[] $roles
+     *
+     * @test
      */
-    public function testExecuteSucceedsIfUserDoesNotExistAndPromotesUser(array $options, array $roles)
+    public function executeSucceedsIfUserDoesNotExistAndPromotesUser(array $options, array $roles)
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Console/Command/UserDemoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserDemoteCommandTest.php
@@ -24,17 +24,26 @@ final class UserDemoteCommandTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(UserDemoteCommand::class);
     }
 
-    public function testExtendsCommand()
+    /**
+     * @test
+     */
+    public function extendsCommand()
     {
         $this->assertClassExtends(Console\Command\Command::class, UserDemoteCommand::class);
     }
 
-    public function testHasNameAndDescription()
+    /**
+     * @test
+     */
+    public function hasNameAndDescription()
     {
         $command = new UserDemoteCommand($this->createAccountManagementMock());
 
@@ -42,7 +51,10 @@ final class UserDemoteCommandTest extends Framework\TestCase
         $this->assertSame('Demote an existing user from a role', $command->getDescription());
     }
 
-    public function testHasEmailArgument()
+    /**
+     * @test
+     */
+    public function hasEmailArgument()
     {
         $command = new UserDemoteCommand($this->createAccountManagementMock());
 
@@ -58,7 +70,10 @@ final class UserDemoteCommandTest extends Framework\TestCase
         $this->assertFalse($argument->isArray());
     }
 
-    public function testHasRoleNameArgument()
+    /**
+     * @test
+     */
+    public function hasRoleNameArgument()
     {
         $command = new UserDemoteCommand($this->createAccountManagementMock());
 
@@ -74,7 +89,10 @@ final class UserDemoteCommandTest extends Framework\TestCase
         $this->assertFalse($argument->isArray());
     }
 
-    public function testExecuteFailsIfUserWasNotFound()
+    /**
+     * @test
+     */
+    public function executeFailsIfUserWasNotFound()
     {
         $faker = $this->faker();
 
@@ -119,7 +137,10 @@ final class UserDemoteCommandTest extends Framework\TestCase
         $this->assertContains($failureMessage, $commandTester->getDisplay());
     }
 
-    public function testExecuteFailsIfRoleWasNotFound()
+    /**
+     * @test
+     */
+    public function executeFailsIfRoleWasNotFound()
     {
         $faker = $this->faker();
 
@@ -164,7 +185,10 @@ final class UserDemoteCommandTest extends Framework\TestCase
         $this->assertContains($failureMessage, $commandTester->getDisplay());
     }
 
-    public function testExecuteFailsIfDemoteFromThrowsGenericException()
+    /**
+     * @test
+     */
+    public function executeFailsIfDemoteFromThrowsGenericException()
     {
         $faker = $this->faker();
 
@@ -209,7 +233,10 @@ final class UserDemoteCommandTest extends Framework\TestCase
         $this->assertContains($failureMessage, $commandTester->getDisplay());
     }
 
-    public function testExecuteSucceedsIfUserAndRoleWereFound()
+    /**
+     * @test
+     */
+    public function executeSucceedsIfUserAndRoleWereFound()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Console/Command/UserPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserPromoteCommandTest.php
@@ -24,17 +24,26 @@ final class UserPromoteCommandTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(UserPromoteCommand::class);
     }
 
-    public function testExtendsCommand()
+    /**
+     * @test
+     */
+    public function extendsCommand()
     {
         $this->assertClassExtends(Console\Command\Command::class, UserPromoteCommand::class);
     }
 
-    public function testHasNameAndDescription()
+    /**
+     * @test
+     */
+    public function hasNameAndDescription()
     {
         $command = new UserPromoteCommand($this->createAccountManagementMock());
 
@@ -42,7 +51,10 @@ final class UserPromoteCommandTest extends Framework\TestCase
         $this->assertSame('Promote an existing user to a role', $command->getDescription());
     }
 
-    public function testHasEmailArgument()
+    /**
+     * @test
+     */
+    public function hasEmailArgument()
     {
         $command = new UserPromoteCommand($this->createAccountManagementMock());
 
@@ -58,7 +70,10 @@ final class UserPromoteCommandTest extends Framework\TestCase
         $this->assertFalse($argument->isArray());
     }
 
-    public function testHasRoleNameArgument()
+    /**
+     * @test
+     */
+    public function hasRoleNameArgument()
     {
         $command = new UserPromoteCommand($this->createAccountManagementMock());
 
@@ -74,7 +89,10 @@ final class UserPromoteCommandTest extends Framework\TestCase
         $this->assertFalse($argument->isArray());
     }
 
-    public function testExecuteFailsIfUserWasNotFound()
+    /**
+     * @test
+     */
+    public function executeFailsIfUserWasNotFound()
     {
         $faker = $this->faker();
 
@@ -119,7 +137,10 @@ final class UserPromoteCommandTest extends Framework\TestCase
         $this->assertContains($failureMessage, $commandTester->getDisplay());
     }
 
-    public function testExecuteFailsIfRoleWasNotFound()
+    /**
+     * @test
+     */
+    public function executeFailsIfRoleWasNotFound()
     {
         $faker = $this->faker();
 
@@ -164,7 +185,10 @@ final class UserPromoteCommandTest extends Framework\TestCase
         $this->assertContains($failureMessage, $commandTester->getDisplay());
     }
 
-    public function testExecuteFailsIfPromoteToThrowsGenericException()
+    /**
+     * @test
+     */
+    public function executeFailsIfPromoteToThrowsGenericException()
     {
         $faker = $this->faker();
 
@@ -209,7 +233,10 @@ final class UserPromoteCommandTest extends Framework\TestCase
         $this->assertContains($failureMessage, $commandTester->getDisplay());
     }
 
-    public function testExecuteSucceedsIfUserAndRoleWereFound()
+    /**
+     * @test
+     */
+    public function executeSucceedsIfUserAndRoleWereFound()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Domain/EntityNotFoundExceptionTest.php
+++ b/tests/Unit/Domain/EntityNotFoundExceptionTest.php
@@ -21,7 +21,10 @@ final class EntityNotFoundExceptionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsException()
+    /**
+     * @test
+     */
+    public function isException()
     {
         $this->assertClassExtends(\Exception::class, EntityNotFoundException::class);
     }

--- a/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
+++ b/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
@@ -21,17 +21,26 @@ final class AuthenticationExceptionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(AuthenticationException::class);
     }
 
-    public function testIsRuntimeException()
+    /**
+     * @test
+     */
+    public function isRuntimeException()
     {
         $this->assertClassExtends(\RuntimeException::class, AuthenticationException::class);
     }
 
-    public function testLoginFailureHasCorrectMessage()
+    /**
+     * @test
+     */
+    public function loginFailureHasCorrectMessage()
     {
         $exception = AuthenticationException::loginFailure();
 
@@ -39,7 +48,10 @@ final class AuthenticationExceptionTest extends Framework\TestCase
         $this->assertSame(0, $exception->getCode());
     }
 
-    public function testLoginFailureReturnsAnAuthenticationException()
+    /**
+     * @test
+     */
+    public function loginFailureReturnsAnAuthenticationException()
     {
         $exception = AuthenticationException::loginFailure();
         $this->assertInstanceOf(AuthenticationException::class, $exception);

--- a/tests/Unit/Domain/Services/NotAuthenticatedExceptionTest.php
+++ b/tests/Unit/Domain/Services/NotAuthenticatedExceptionTest.php
@@ -21,7 +21,10 @@ final class NotAuthenticatedExceptionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsException()
+    /**
+     * @test
+     */
+    public function isException()
     {
         $this->assertClassExtends(\Exception::class, NotAuthenticatedException::class);
     }

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
@@ -21,12 +21,18 @@ final class TalkRatingExceptionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsRuntimeException()
+    /**
+     * @test
+     */
+    public function isRuntimeException()
     {
         $this->assertClassExtends(\RuntimeException::class, TalkRatingException::class);
     }
 
-    public function testInvalidRatinhReturnsException()
+    /**
+     * @test
+     */
+    public function invalidRatinhReturnsException()
     {
         $rating = 9001;
 

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
@@ -25,7 +25,10 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
  */
 final class TalkRatingTest extends \PHPUnit\Framework\TestCase
 {
-    public function testRateThrowsExceptionOnInvalidRating()
+    /**
+     * @test
+     */
+    public function rateThrowsExceptionOnInvalidRating()
     {
         $user = Mockery::mock(UserInterface::class);
         $user->shouldReceive('getId')->andReturn(1);
@@ -42,7 +45,10 @@ final class TalkRatingTest extends \PHPUnit\Framework\TestCase
         $sut->rate(7, 9001);
     }
 
-    public function testRate()
+    /**
+     * @test
+     */
+    public function rate()
     {
         $user = Mockery::mock(UserInterface::class);
         $user->shouldReceive('getId')->andReturn(1);

--- a/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -26,8 +26,10 @@ final class YesNoRatingTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider ratingProvider
+     *
+     * @test
      */
-    public function testValidRatings($rating, $valid)
+    public function validRatings($rating, $valid)
     {
         $user = Mockery::mock(UserInterface::class);
         $user->shouldReceive('getId')->andReturn(1);

--- a/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
+++ b/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
@@ -21,12 +21,18 @@ final class NotAllowedExceptionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsException()
+    /**
+     * @test
+     */
+    public function isException()
     {
         $this->assertClassExtends(\Exception::class, NotAllowedException::class);
     }
 
-    public function testNotAllowedToViewReturnsException()
+    /**
+     * @test
+     */
+    public function notAllowedToViewReturnsException()
     {
         $property = 'foo';
 

--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -24,7 +24,10 @@ final class SpeakerProfileTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsAllowedToSeeReturnsFalseIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function isAllowedToSeeReturnsFalseIfPropertyIsHidden()
     {
         $property = $this->faker()->word;
 
@@ -40,7 +43,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertFalse($profile->isAllowedToSee($property));
     }
 
-    public function testIsAllowedToSeeReturnsTrueIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function isAllowedToSeeReturnsTrueIfPropertyIsNotHidden()
     {
         $property = $this->faker()->word;
 
@@ -49,7 +55,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertTrue($profile->isAllowedToSee($property));
     }
 
-    public function testNeedsProfileReturnsFalseIfUserHasMadeProfile()
+    /**
+     * @test
+     */
+    public function needsProfileReturnsFalseIfUserHasMadeProfile()
     {
         $hasMadeProfile = 1;
 
@@ -62,7 +71,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertFalse($profile->needsProfile());
     }
 
-    public function testNeedsProfileReturnsTrueIfUserHasNotMadeProfile()
+    /**
+     * @test
+     */
+    public function needsProfileReturnsTrueIfUserHasNotMadeProfile()
     {
         $hasMadeProfile = 0;
 
@@ -75,7 +87,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertTrue($profile->needsProfile());
     }
 
-    public function testGetTalksThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getTalksThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'talks',
@@ -90,7 +105,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getTalks();
     }
 
-    public function testGetTalksReturnsTalksIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getTalksReturnsTalksIfPropertyIsNotHidden()
     {
         $talks = [
             $this->createTalkMock(),
@@ -109,7 +127,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertSame($talks, $profile->getTalks());
     }
 
-    public function testGetNameThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getNameThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'name',
@@ -124,7 +145,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getName();
     }
 
-    public function testGetNameReturnsNameIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getNameReturnsNameIfPropertyIsNotHidden()
     {
         $faker = $this->faker();
 
@@ -147,7 +171,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertSame($name, $profile->getName());
     }
 
-    public function testGetEmailThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getEmailThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'email',
@@ -162,7 +189,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getEmail();
     }
 
-    public function testGetEmailReturnsEmailIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getEmailReturnsEmailIfPropertyIsNotHidden()
     {
         $email = $this->faker()->email;
 
@@ -175,7 +205,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertSame($email, $profile->getEmail());
     }
 
-    public function testGetCompanyThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getCompanyThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'company',
@@ -190,7 +223,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getCompany();
     }
 
-    public function testGetCompanyReturnsCompanyIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getCompanyReturnsCompanyIfPropertyIsNotHidden()
     {
         $company = $this->faker()->company;
 
@@ -203,7 +239,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertSame($company, $profile->getCompany());
     }
 
-    public function testGetTwitterThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getTwitterThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'twitter',
@@ -218,7 +257,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getTwitter();
     }
 
-    public function testGetTwitterReturnsTwitterIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getTwitterReturnsTwitterIfPropertyIsNotHidden()
     {
         $twitter = $this->faker()->userName;
 
@@ -231,7 +273,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertSame($twitter, $profile->getTwitter());
     }
 
-    public function testGetUrlThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getUrlThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'url',
@@ -246,7 +291,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getUrl();
     }
 
-    public function testGetUrlReturnsUrlIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getUrlReturnsUrlIfPropertyIsNotHidden()
     {
         $url = $this->faker()->url;
 
@@ -259,7 +307,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertSame($url, $profile->getUrl());
     }
 
-    public function testGetInfoThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getInfoThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'info',
@@ -274,7 +325,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getInfo();
     }
 
-    public function testGetInfoReturnsInfoIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getInfoReturnsInfoIfPropertyIsNotHidden()
     {
         $info = $this->faker()->text;
 
@@ -287,7 +341,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertSame($info, $profile->getInfo());
     }
 
-    public function testGetBioThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getBioThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'bio',
@@ -302,7 +359,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getBio();
     }
 
-    public function testGetBioReturnsBioIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getBioReturnsBioIfPropertyIsNotHidden()
     {
         $bio = $this->faker()->text;
 
@@ -315,7 +375,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertSame($bio, $profile->getBio());
     }
 
-    public function testGetTransportationThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getTransportationThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'transportation',
@@ -334,8 +397,10 @@ final class SpeakerProfileTest extends Framework\TestCase
      * @dataProvider providerDoesNotNeedTransportation
      *
      * @param mixed $transportation
+     *
+     * @test
      */
-    public function testGetTransportationReturnsFalseIfPropertyIsNotHidden($transportation)
+    public function getTransportationReturnsFalseIfPropertyIsNotHidden($transportation)
     {
         $speaker = $this->createUserMock([
             'transportation' => $transportation,
@@ -360,7 +425,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         }
     }
 
-    public function testGetTransportationReturnsTrueIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getTransportationReturnsTrueIfPropertyIsNotHidden()
     {
         $transportation = 1;
 
@@ -373,7 +441,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertTrue($profile->getTransportation());
     }
 
-    public function testGetHotelThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getHotelThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'hotel',
@@ -388,7 +459,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getHotel();
     }
 
-    public function testGetHotelReturnsFalseIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getHotelReturnsFalseIfPropertyIsNotHidden()
     {
         $hotel = 0;
 
@@ -401,7 +475,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertFalse($profile->getHotel());
     }
 
-    public function testGetHotelReturnsTrueIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getHotelReturnsTrueIfPropertyIsNotHidden()
     {
         $hotel = 1;
 
@@ -414,7 +491,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertTrue($profile->getHotel());
     }
 
-    public function testGetAirportThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getAirportThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'airport',
@@ -429,7 +509,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getAirport();
     }
 
-    public function testGetAirportReturnsAirportIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getAirportReturnsAirportIfPropertyIsNotHidden()
     {
         $airport = $this->faker()->company;
 
@@ -442,7 +525,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $this->assertSame($airport, $profile->getAirport());
     }
 
-    public function testGetPhotoThrowsNotAllowedExceptionIfPropertyIsHidden()
+    /**
+     * @test
+     */
+    public function getPhotoThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'photo',
@@ -457,7 +543,10 @@ final class SpeakerProfileTest extends Framework\TestCase
         $profile->getPhoto();
     }
 
-    public function testGetPhotoReturnsPhotoIfPropertyIsNotHidden()
+    /**
+     * @test
+     */
+    public function getPhotoReturnsPhotoIfPropertyIsNotHidden()
     {
         $photo = $this->faker()->url;
 

--- a/tests/Unit/Domain/Talk/TalkProfileTest.php
+++ b/tests/Unit/Domain/Talk/TalkProfileTest.php
@@ -193,7 +193,10 @@ final class TalkProfileTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(0, $comments);
     }
 
-    public function testGetRatingReturnsZeroWhenTalkHasNoMeta()
+    /**
+     * @test
+     */
+    public function getRatingReturnsZeroWhenTalkHasNoMeta()
     {
         $userId = $this->faker()->numberBetween(1);
 

--- a/tests/Unit/Domain/ValidationExceptionTest.php
+++ b/tests/Unit/Domain/ValidationExceptionTest.php
@@ -21,12 +21,18 @@ final class ValidationExceptionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsException()
+    /**
+     * @test
+     */
+    public function isException()
     {
         $this->assertClassExtends(\Exception::class, ValidationException::class);
     }
 
-    public function testWithErrorsReturnsException()
+    /**
+     * @test
+     */
+    public function withErrorsReturnsException()
     {
         $errors = $this->faker()->sentences;
 

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -17,14 +17,20 @@ use OpenCFP\Environment;
 
 final class EnvironmentTest extends \PHPUnit\Framework\TestCase
 {
-    public function testConstants()
+    /**
+     * @test
+     */
+    public function constants()
     {
         $this->assertSame('production', Environment::TYPE_PRODUCTION);
         $this->assertSame('development', Environment::TYPE_DEVELOPMENT);
         $this->assertSame('testing', Environment::TYPE_TESTING);
     }
 
-    public function testProductionReturnsEnvironment()
+    /**
+     * @test
+     */
+    public function productionReturnsEnvironment()
     {
         $environment = Environment::production();
 
@@ -35,7 +41,10 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(Environment::TYPE_PRODUCTION, (string) $environment);
     }
 
-    public function testDevelopmentReturnsEnvironment()
+    /**
+     * @test
+     */
+    public function developmentReturnsEnvironment()
     {
         $environment = Environment::development();
 
@@ -46,7 +55,10 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(Environment::TYPE_DEVELOPMENT, (string) $environment);
     }
 
-    public function testTestingReturnsEnvironment()
+    /**
+     * @test
+     */
+    public function testingReturnsEnvironment()
     {
         $environment = Environment::testing();
 
@@ -77,8 +89,10 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
      * @dataProvider providerEnvironment
      *
      * @param string $type
+     *
+     * @test
      */
-    public function testFromServerReturnsEnvironment(string $type)
+    public function fromServerReturnsEnvironment(string $type)
     {
         $environment = Environment::fromServer([
             'CFP_ENV' => $type,
@@ -140,7 +154,10 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
         Environment::fromString($type);
     }
 
-    public function testEqualsReturnsFalseIfTypeIsDifferent()
+    /**
+     * @test
+     */
+    public function equalsReturnsFalseIfTypeIsDifferent()
     {
         $one = Environment::fromString(Environment::TYPE_TESTING);
         $two = Environment::fromString(Environment::TYPE_DEVELOPMENT);
@@ -148,7 +165,10 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($one->equals($two));
     }
 
-    public function testEqualsReturnsTrueIfTypeIsSame()
+    /**
+     * @test
+     */
+    public function equalsReturnsTrueIfTypeIsSame()
     {
         $one = Environment::fromString(Environment::TYPE_TESTING);
         $two = Environment::fromString(Environment::TYPE_TESTING);

--- a/tests/Unit/Http/Action/Admin/Speaker/PromoteActionTest.php
+++ b/tests/Unit/Http/Action/Admin/Speaker/PromoteActionTest.php
@@ -26,7 +26,10 @@ final class PromoteActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testRedirectsToAdminSpeakersIfUserNotFound()
+    /**
+     * @test
+     */
+    public function redirectsToAdminSpeakersIfUserNotFound()
     {
         $faker = $this->faker();
 
@@ -95,7 +98,10 @@ final class PromoteActionTest extends Framework\TestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRedirectsToAdminSpeakersIfUserAlreadyBelongsToRole()
+    /**
+     * @test
+     */
+    public function redirectsToAdminSpeakersIfUserAlreadyBelongsToRole()
     {
         $faker = $this->faker();
 
@@ -171,7 +177,10 @@ final class PromoteActionTest extends Framework\TestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRedirectsToAdminSpeakersIfRoleNotFound()
+    /**
+     * @test
+     */
+    public function redirectsToAdminSpeakersIfRoleNotFound()
     {
         $faker = $this->faker();
 
@@ -261,7 +270,10 @@ final class PromoteActionTest extends Framework\TestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRedirectsToAdminSpeakersIfPromotingToAdminSucceeded()
+    /**
+     * @test
+     */
+    public function redirectsToAdminSpeakersIfPromotingToAdminSucceeded()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Admin/Talk/ViewActionTest.php
+++ b/tests/Unit/Http/Action/Admin/Talk/ViewActionTest.php
@@ -26,7 +26,10 @@ final class ViewActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testRedirectsToDashboardIfTalkCannotBeViewed()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfTalkCannotBeViewed()
     {
         $faker = $this->faker();
 
@@ -90,7 +93,10 @@ final class ViewActionTest extends Framework\TestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRendersTalkIfTalkCanBeViewed()
+    /**
+     * @test
+     */
+    public function rendersTalkIfTalkCanBeViewed()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/DashboardActionTest.php
+++ b/tests/Unit/Http/Action/DashboardActionTest.php
@@ -22,7 +22,10 @@ use Symfony\Component\HttpFoundation;
 
 final class DashboardActionTest extends AbstractActionTestCase
 {
-    public function testRedirectsToLoginIfUserIsNotAuthenticated()
+    /**
+     * @test
+     */
+    public function redirectsToLoginIfUserIsNotAuthenticated()
     {
         $url = $this->faker()->slug();
 
@@ -54,7 +57,10 @@ final class DashboardActionTest extends AbstractActionTestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRendersDashboardIfUserIsAuthenticated()
+    /**
+     * @test
+     */
+    public function rendersDashboardIfUserIsAuthenticated()
     {
         $speakerProfile = $this->createSpeakerProfileMock();
 

--- a/tests/Unit/Http/Action/Forgot/IndexActionTest.php
+++ b/tests/Unit/Http/Action/Forgot/IndexActionTest.php
@@ -19,7 +19,10 @@ use Symfony\Component\Form;
 
 final class IndexActionTest extends Framework\TestCase
 {
-    public function testRendersForgotPassword()
+    /**
+     * @test
+     */
+    public function rendersForgotPassword()
     {
         $resetFormView = $this->prophesize(Form\FormView::class);
 

--- a/tests/Unit/Http/Action/Forgot/ResetProcessActionTest.php
+++ b/tests/Unit/Http/Action/Forgot/ResetProcessActionTest.php
@@ -32,8 +32,10 @@ final class ResetProcessActionTest extends Framework\TestCase
      * @dataProvider providerEmptyResetCode
      *
      * @param mixed $resetCode
+     *
+     * @test
      */
-    public function testThrowsExceptionIfResetCodeIsEmpty($resetCode)
+    public function throwsExceptionIfResetCodeIsEmpty($resetCode)
     {
         $userId = $this->faker()->numberBetween(1);
 
@@ -79,7 +81,10 @@ final class ResetProcessActionTest extends Framework\TestCase
         }, $values);
     }
 
-    public function testRendersFormIfFormIsNotSubmitted()
+    /**
+     * @test
+     */
+    public function rendersFormIfFormIsNotSubmitted()
     {
         $faker = $this->faker();
 
@@ -166,7 +171,10 @@ final class ResetProcessActionTest extends Framework\TestCase
         $this->assertSame($content, $response->getContent());
     }
 
-    public function testRendersFormIfFormIsSubmittedButNotValid()
+    /**
+     * @test
+     */
+    public function rendersFormIfFormIsSubmittedButNotValid()
     {
         $faker = $this->faker();
 
@@ -258,7 +266,10 @@ final class ResetProcessActionTest extends Framework\TestCase
         $this->assertSame($content, $response->getContent());
     }
 
-    public function testRedirectsToForgotPasswordIfUserWasNotFound()
+    /**
+     * @test
+     */
+    public function redirectsToForgotPasswordIfUserWasNotFound()
     {
         $faker = $this->faker();
 
@@ -342,7 +353,10 @@ final class ResetProcessActionTest extends Framework\TestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRedirectsToForgotPasswordIfResetCodeIsInvalid()
+    /**
+     * @test
+     */
+    public function redirectsToForgotPasswordIfResetCodeIsInvalid()
     {
         $faker = $this->faker();
 
@@ -433,7 +447,10 @@ final class ResetProcessActionTest extends Framework\TestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRedirectsToForgotPasswordIfResetCodeIsValid()
+    /**
+     * @test
+     */
+    public function redirectsToForgotPasswordIfResetCodeIsValid()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Forgot/UpdatePasswordActionTest.php
+++ b/tests/Unit/Http/Action/Forgot/UpdatePasswordActionTest.php
@@ -28,7 +28,10 @@ final class UpdatePasswordActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testRendersFormIfFormIsNotSubmitted()
+    /**
+     * @test
+     */
+    public function rendersFormIfFormIsNotSubmitted()
     {
         $content = $this->faker()->text;
 
@@ -78,7 +81,10 @@ final class UpdatePasswordActionTest extends Framework\TestCase
         $this->assertSame($content, $response->getContent());
     }
 
-    public function testRendersFormIfFormIsSubmittedButNotValid()
+    /**
+     * @test
+     */
+    public function rendersFormIfFormIsSubmittedButNotValid()
     {
         $content = $this->faker()->text;
 
@@ -137,8 +143,10 @@ final class UpdatePasswordActionTest extends Framework\TestCase
      * @dataProvider providerEmptyResetCode
      *
      * @param mixed $resetCode
+     *
+     * @test
      */
-    public function testThrowsExceptionIfResetCodeIsEmpty($resetCode)
+    public function throwsExceptionIfResetCodeIsEmpty($resetCode)
     {
         $faker = $this->faker();
 
@@ -202,7 +210,10 @@ final class UpdatePasswordActionTest extends Framework\TestCase
         }, $values);
     }
 
-    public function testRedirectsToLoginIfNewPasswordMatchesOldPassword()
+    /**
+     * @test
+     */
+    public function redirectsToLoginIfNewPasswordMatchesOldPassword()
     {
         $faker = $this->faker();
 
@@ -293,7 +304,10 @@ final class UpdatePasswordActionTest extends Framework\TestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRedirectsToHomepageIfAttemptToResetPasswordFailed()
+    /**
+     * @test
+     */
+    public function redirectsToHomepageIfAttemptToResetPasswordFailed()
     {
         $faker = $this->faker();
 
@@ -391,7 +405,10 @@ final class UpdatePasswordActionTest extends Framework\TestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRedirectsToLoginIfAttemptToResetPasswordSucceeded()
+    /**
+     * @test
+     */
+    public function redirectsToLoginIfAttemptToResetPasswordSucceeded()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Page/HomePageActionTest.php
+++ b/tests/Unit/Http/Action/Page/HomePageActionTest.php
@@ -18,7 +18,10 @@ use PHPUnit\Framework\TestCase;
 
 final class HomePageActionTest extends TestCase
 {
-    public function testItReturnsTheCorrectContentIfNoSubmissionCountNeedsToBeShown()
+    /**
+     * @test
+     */
+    public function itReturnsTheCorrectContentIfNoSubmissionCountNeedsToBeShown()
     {
         $action = new HomePageAction(false);
 

--- a/tests/Unit/Http/Action/Profile/EditActionTest.php
+++ b/tests/Unit/Http/Action/Profile/EditActionTest.php
@@ -28,7 +28,10 @@ final class EditActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testRedirectsToDashboardIfAuthenticatedUserRequestSomeoneElsesProfile()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfAuthenticatedUserRequestSomeoneElsesProfile()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Profile/ProcessActionTest.php
+++ b/tests/Unit/Http/Action/Profile/ProcessActionTest.php
@@ -28,7 +28,10 @@ final class ProcessActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testRedirectsToDashboardIfAuthenticatedUserRequestSomeoneElsesProfile()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfAuthenticatedUserRequestSomeoneElsesProfile()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Reviewer/Talk/ViewActionTest.php
+++ b/tests/Unit/Http/Action/Reviewer/Talk/ViewActionTest.php
@@ -26,7 +26,10 @@ final class ViewActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testRedirectsToDashboardIfTalkCannotBeViewed()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfTalkCannotBeViewed()
     {
         $faker = $this->faker();
 
@@ -90,7 +93,10 @@ final class ViewActionTest extends Framework\TestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRendersTalkIfTalkCanBeViewed()
+    /**
+     * @test
+     */
+    public function rendersTalkIfTalkCanBeViewed()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Security/LogInActionTest.php
+++ b/tests/Unit/Http/Action/Security/LogInActionTest.php
@@ -26,7 +26,10 @@ final class LogInActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testRendersLogInFormIfAuthenticationFailed()
+    /**
+     * @test
+     */
+    public function rendersLogInFormIfAuthenticationFailed()
     {
         $faker = $this->faker();
 
@@ -106,7 +109,10 @@ final class LogInActionTest extends Framework\TestCase
         $this->assertSame($content, $response->getContent());
     }
 
-    public function testRedirectsToDashboardIfAuthenticationSucceeded()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfAuthenticationSucceeded()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Security/LogOutActionTest.php
+++ b/tests/Unit/Http/Action/Security/LogOutActionTest.php
@@ -25,7 +25,10 @@ final class LogOutActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testLogsOutUserAndRedirectsToHomepage()
+    /**
+     * @test
+     */
+    public function logsOutUserAndRedirectsToHomepage()
     {
         $url = $this->faker()->url;
 

--- a/tests/Unit/Http/Action/Signup/IndexActionTest.php
+++ b/tests/Unit/Http/Action/Signup/IndexActionTest.php
@@ -21,7 +21,10 @@ use Symfony\Component\HttpFoundation;
 
 final class IndexActionTest extends AbstractActionTestCase
 {
-    public function testRedirectsToDashboardIfSignedIn()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfSignedIn()
     {
         $url = $this->faker()->url;
 
@@ -73,7 +76,10 @@ final class IndexActionTest extends AbstractActionTestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRedirectsToHomePageNotSignedInAndCallForPapersIsClosed()
+    /**
+     * @test
+     */
+    public function redirectsToHomePageNotSignedInAndCallForPapersIsClosed()
     {
         $url = $this->faker()->url;
 
@@ -141,7 +147,10 @@ final class IndexActionTest extends AbstractActionTestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRendersSignupWhenNotSignedInAndCallForPapersIsOpen()
+    /**
+     * @test
+     */
+    public function rendersSignupWhenNotSignedInAndCallForPapersIsOpen()
     {
         $content = $this->faker()->text;
 

--- a/tests/Unit/Http/Action/Talk/CreateActionTest.php
+++ b/tests/Unit/Http/Action/Talk/CreateActionTest.php
@@ -22,7 +22,10 @@ use Symfony\Component\HttpFoundation;
 
 final class CreateActionTest extends AbstractActionTestCase
 {
-    public function testRedirectsToDashboardIfCallForPapersIsClosed()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfCallForPapersIsClosed()
     {
         $url = $this->faker()->url;
 
@@ -89,7 +92,10 @@ final class CreateActionTest extends AbstractActionTestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRendersTalkCreationIfCallForPapersIsOpen()
+    /**
+     * @test
+     */
+    public function rendersTalkCreationIfCallForPapersIsOpen()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Talk/CreateProcessActionTest.php
+++ b/tests/Unit/Http/Action/Talk/CreateProcessActionTest.php
@@ -28,7 +28,10 @@ final class CreateProcessActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testRedirectsToDashboardIfCallForPapersIsClosed()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfCallForPapersIsClosed()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Talk/DeleteActionTest.php
+++ b/tests/Unit/Http/Action/Talk/DeleteActionTest.php
@@ -21,7 +21,10 @@ use Symfony\Component\HttpFoundation;
 
 final class DeleteActionTest extends AbstractActionTestCase
 {
-    public function testRespondsWithNoIfCallForPapersIsClosed()
+    /**
+     * @test
+     */
+    public function respondsWithNoIfCallForPapersIsClosed()
     {
         $request = $this->createRequestMock();
 

--- a/tests/Unit/Http/Action/Talk/EditActionTest.php
+++ b/tests/Unit/Http/Action/Talk/EditActionTest.php
@@ -22,7 +22,10 @@ use Symfony\Component\HttpFoundation;
 
 final class EditActionTest extends AbstractActionTestCase
 {
-    public function testRedirectsToDashboardIfCallForPapersIsClosed()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfCallForPapersIsClosed()
     {
         $faker = $this->faker();
 
@@ -103,7 +106,10 @@ final class EditActionTest extends AbstractActionTestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRedirectsToDashboardIfCallForPapersIsOpenButTalkIdIsEmpty()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfCallForPapersIsOpenButTalkIdIsEmpty()
     {
         $talkId = 0;
         $url    = $this->faker()->slug();

--- a/tests/Unit/Http/Action/Talk/UpdateActionTest.php
+++ b/tests/Unit/Http/Action/Talk/UpdateActionTest.php
@@ -29,7 +29,10 @@ final class UpdateActionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testRedirectsToDashboardIfCallForPapersIsClosed()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfCallForPapersIsClosed()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Action/Talk/ViewActionTest.php
+++ b/tests/Unit/Http/Action/Talk/ViewActionTest.php
@@ -23,7 +23,10 @@ use Symfony\Component\HttpFoundation;
 
 final class ViewActionTest extends AbstractActionTestCase
 {
-    public function testRedirectsToDashboardIfUserIsNotAuthorized()
+    /**
+     * @test
+     */
+    public function redirectsToDashboardIfUserIsNotAuthorized()
     {
         $faker = $this->faker();
 
@@ -67,7 +70,10 @@ final class ViewActionTest extends AbstractActionTestCase
         $this->assertSame($url, $response->getTargetUrl());
     }
 
-    public function testRendersDashboardIfUserIsAuthenticated()
+    /**
+     * @test
+     */
+    public function rendersDashboardIfUserIsAuthenticated()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Http/Form/FormFactoryTest.php
+++ b/tests/Unit/Http/Form/FormFactoryTest.php
@@ -23,7 +23,10 @@ final class FormFactoryTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testCreateCreatesForm()
+    /**
+     * @test
+     */
+    public function createCreatesForm()
     {
         $formType = $this->faker()->word;
 

--- a/tests/Unit/Http/View/TalkHelperTest.php
+++ b/tests/Unit/Http/View/TalkHelperTest.php
@@ -21,7 +21,10 @@ final class TalkHelperTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testGetTalkCategoriesReturnsDefaultCategoriesIfNoneHaveBeenInjected()
+    /**
+     * @test
+     */
+    public function getTalkCategoriesReturnsDefaultCategoriesIfNoneHaveBeenInjected()
     {
         $helper = new TalkHelper(
             null,
@@ -47,7 +50,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($defaultCategories, $helper->getTalkCategories());
     }
 
-    public function testGetTalkCategoriesReturnsInjectedCategories()
+    /**
+     * @test
+     */
+    public function getTalkCategoriesReturnsInjectedCategories()
     {
         $faker = $this->faker();
 
@@ -65,7 +71,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($categories, $helper->getTalkCategories());
     }
 
-    public function testGetCategoryDisplayNameReturnsCategoryIfNotMapped()
+    /**
+     * @test
+     */
+    public function getCategoryDisplayNameReturnsCategoryIfNotMapped()
     {
         $faker = $this->faker();
 
@@ -80,7 +89,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($category, $helper->getCategoryDisplayName($category));
     }
 
-    public function testGetCategoryDisplayNameReturnsCategoryDisplayNameIfMapped()
+    /**
+     * @test
+     */
+    public function getCategoryDisplayNameReturnsCategoryDisplayNameIfMapped()
     {
         $faker = $this->faker();
 
@@ -100,7 +112,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($categoryDisplayName, $helper->getCategoryDisplayName($category));
     }
 
-    public function testGetTalkTypesReturnsDefaultTypesIfNoneHaveBeenInjected()
+    /**
+     * @test
+     */
+    public function getTalkTypesReturnsDefaultTypesIfNoneHaveBeenInjected()
     {
         $helper = new TalkHelper(
             null,
@@ -116,7 +131,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($defaultTypes, $helper->getTalkTypes());
     }
 
-    public function testGetTalkTypesReturnsInjectedTypes()
+    /**
+     * @test
+     */
+    public function getTalkTypesReturnsInjectedTypes()
     {
         $faker = $this->faker();
 
@@ -134,7 +152,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($types, $helper->getTalkTypes());
     }
 
-    public function testGetTypeDisplayNameReturnsTypeIfNotMapped()
+    /**
+     * @test
+     */
+    public function getTypeDisplayNameReturnsTypeIfNotMapped()
     {
         $faker = $this->faker();
 
@@ -149,7 +170,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($type, $helper->getTypeDisplayName($type));
     }
 
-    public function testGetTypeDisplayNameReturnsTypeDisplayNameIfMapped()
+    /**
+     * @test
+     */
+    public function getTypeDisplayNameReturnsTypeDisplayNameIfMapped()
     {
         $faker = $this->faker();
 
@@ -169,7 +193,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($typeDisplayName, $helper->getTypeDisplayName($type));
     }
 
-    public function testGetTalkLevelsReturnsDefaultTypesIfNoneHaveBeenInjected()
+    /**
+     * @test
+     */
+    public function getTalkLevelsReturnsDefaultTypesIfNoneHaveBeenInjected()
     {
         $helper = new TalkHelper(
             null,
@@ -186,7 +213,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($defaultLevels, $helper->getTalkLevels());
     }
 
-    public function testGetTalkLevelsReturnsInjectedLevels()
+    /**
+     * @test
+     */
+    public function getTalkLevelsReturnsInjectedLevels()
     {
         $faker = $this->faker();
 
@@ -204,7 +234,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($levels, $helper->getTalkLevels());
     }
 
-    public function testGetLevelDisplayNameReturnsLevelIfNotMapped()
+    /**
+     * @test
+     */
+    public function getLevelDisplayNameReturnsLevelIfNotMapped()
     {
         $faker = $this->faker();
 
@@ -219,7 +252,10 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($level, $helper->getLevelDisplayName($level));
     }
 
-    public function testGetLevelDisplayNameReturnsLevelDisplayNameIfMapped()
+    /**
+     * @test
+     */
+    public function getLevelDisplayNameReturnsLevelDisplayNameIfMapped()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
+++ b/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
@@ -26,17 +26,26 @@ final class CsrfValidatorTest extends \PHPUnit\Framework\TestCase
     use Helper;
     use MockeryPHPUnitIntegration;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(CsrfValidator::class);
     }
 
-    public function testIsInstanceOfRequestValidator()
+    /**
+     * @test
+     */
+    public function isInstanceOfRequestValidator()
     {
         $this->assertClassImplementsInterface(RequestValidator::class, CsrfValidator::class);
     }
 
-    public function testReturnsTrueWhenTokenMangerReturnsTrue()
+    /**
+     * @test
+     */
+    public function returnsTrueWhenTokenMangerReturnsTrue()
     {
         $manager = Mockery::mock(CsrfTokenManagerInterface::class);
         $manager->shouldReceive('isTokenValid')->andReturn(true);
@@ -48,7 +57,10 @@ final class CsrfValidatorTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($csrf->isValid($request));
     }
 
-    public function testReturnsFalseWhenTokenManagersReturnsFalse()
+    /**
+     * @test
+     */
+    public function returnsFalseWhenTokenManagersReturnsFalse()
     {
         $manager = Mockery::mock(CsrfTokenManagerInterface::class);
         $manager->shouldReceive('isTokenValid')->andReturn(false);

--- a/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
@@ -26,7 +26,10 @@ final class RoleAccessTest extends \PHPUnit\Framework\TestCase
     use Helper;
     use MockeryPHPUnitIntegration;
 
-    public function testReturnsRedirectResponseIfCheckFailed()
+    /**
+     * @test
+     */
+    public function returnsRedirectResponseIfCheckFailed()
     {
         $role = $this->faker()->word;
 
@@ -36,7 +39,10 @@ final class RoleAccessTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(RedirectResponse::class, RoleAccess::userHasAccess($auth, $role));
     }
 
-    public function testReturnsRedirectResponseIfCheckSucceededButUserHasAccess()
+    /**
+     * @test
+     */
+    public function returnsRedirectResponseIfCheckSucceededButUserHasAccess()
     {
         $role = $this->faker()->word;
 
@@ -50,7 +56,10 @@ final class RoleAccessTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(RedirectResponse::class, RoleAccess::userHasAccess($auth, $role));
     }
 
-    public function testReturnsNothingIfCheckSucceededAndUserHasAccess()
+    /**
+     * @test
+     */
+    public function returnsNothingIfCheckSucceededAndUserHasAccess()
     {
         $role = $this->faker()->word;
 

--- a/tests/Unit/Infrastructure/Auth/RoleNotFoundExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleNotFoundExceptionTest.php
@@ -20,17 +20,26 @@ final class RoleNotFoundExceptionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(RoleNotFoundException::class);
     }
 
-    public function testIsRuntimeException()
+    /**
+     * @test
+     */
+    public function isRuntimeException()
     {
         $this->assertClassExtends(\RuntimeException::class, RoleNotFoundException::class);
     }
 
-    public function testFromNameReturnsException()
+    /**
+     * @test
+     */
+    public function fromNameReturnsException()
     {
         $name = $this->faker()->word;
 

--- a/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -32,17 +32,26 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
     use Helper;
     use MockeryPHPUnitIntegration;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(SentinelAccountManagement::class);
     }
 
-    public function testInstanceOfAccountManagement()
+    /**
+     * @test
+     */
+    public function instanceOfAccountManagement()
     {
         $this->assertClassImplementsInterface(AccountManagement::class, SentinelAccountManagement::class);
     }
 
-    public function testFindByIdThrowsCorrectError()
+    /**
+     * @test
+     */
+    public function findByIdThrowsCorrectError()
     {
         $sentinel = Mockery::mock(Sentinel::class);
         $sentinel->shouldReceive('getUserRepository->findById')->andReturn(null);
@@ -51,7 +60,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $account->findById(3);
     }
 
-    public function testFindByIdReturnsSentinelUser()
+    /**
+     * @test
+     */
+    public function findByIdReturnsSentinelUser()
     {
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class)->makePartial();
         $sentinel = Mockery::mock(Sentinel::class);
@@ -60,7 +72,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(SentinelUser::class, $account->findById(3));
     }
 
-    public function testFindByLoginThrowsCorrectError()
+    /**
+     * @test
+     */
+    public function findByLoginThrowsCorrectError()
     {
         $sentinel = Mockery::mock(Sentinel::class);
         $sentinel->shouldReceive('getUserRepository->findByCredentials')->andReturn(null);
@@ -69,7 +84,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $account->findByLogin('mail@mail.mail');
     }
 
-    public function testFindByLoginReturnsSentinelUser()
+    /**
+     * @test
+     */
+    public function findByLoginReturnsSentinelUser()
     {
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class)->makePartial();
         $sentinel = Mockery::mock(Sentinel::class);
@@ -78,7 +96,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(SentinelUser::class, $account->findByLogin('mail@mail.mail'));
     }
 
-    public function testFindByRoleThrowsRoleNotFoundExceptionIfRoleWasNotFound()
+    /**
+     * @test
+     */
+    public function findByRoleThrowsRoleNotFoundExceptionIfRoleWasNotFound()
     {
         $name = $this->faker()->word;
 
@@ -106,7 +127,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $accountManagement->findByRole($name);
     }
 
-    public function testFindByRoleReturnsArrayOfUsers()
+    /**
+     * @test
+     */
+    public function findByRoleReturnsArrayOfUsers()
     {
         $name = $this->faker()->word;
 
@@ -146,7 +170,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($users, $accounts->findByRole($name));
     }
 
-    public function testCreateThrowsCorrectErrorWhenUserAlreadyExists()
+    /**
+     * @test
+     */
+    public function createThrowsCorrectErrorWhenUserAlreadyExists()
     {
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel = Mockery::mock(Sentinel::class);
@@ -156,7 +183,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $account->create('mail@mail.mail', 'pass');
     }
 
-    public function testCreateReturnsCorrectUserWhenCreatingOne()
+    /**
+     * @test
+     */
+    public function createReturnsCorrectUserWhenCreatingOne()
     {
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel = Mockery::mock(Sentinel::class);
@@ -166,7 +196,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(SentinelUser::class, $account->create('mail@mail.mail', 'pass'));
     }
 
-    public function testCreateDefaultsToThrowingError()
+    /**
+     * @test
+     */
+    public function createDefaultsToThrowingError()
     {
         $sentinel = Mockery::mock(Sentinel::class);
         $sentinel->shouldReceive('getUserRepository->findByCredentials')->andReturn(null);
@@ -176,7 +209,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $account->create('mail@mail.mail', 'pass');
     }
 
-    public function testActivateActivatesUser()
+    /**
+     * @test
+     */
+    public function activateActivatesUser()
     {
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel = Mockery::mock(Sentinel::class);
@@ -188,7 +224,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         $account->activate('mail@mail');
     }
 
-    public function testPromoteToThrowsRoleNotFoundExceptionIfRoleWasNotFound()
+    /**
+     * @test
+     */
+    public function promoteToThrowsRoleNotFoundExceptionIfRoleWasNotFound()
     {
         $faker = $this->faker();
 
@@ -222,7 +261,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testPromoteToAttachesUserToUserCollection()
+    /**
+     * @test
+     */
+    public function promoteToAttachesUserToUserCollection()
     {
         $faker = $this->faker();
 
@@ -282,7 +324,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDemoteFromThrowsRoleNotFoundExceptionIfRoleWasNotFound()
+    /**
+     * @test
+     */
+    public function demoteFromThrowsRoleNotFoundExceptionIfRoleWasNotFound()
     {
         $faker = $this->faker();
 
@@ -316,7 +361,10 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDemoteFromDetachesUserFromUserCollection()
+    /**
+     * @test
+     */
+    public function demoteFromDetachesUserFromUserCollection()
     {
         $faker = $this->faker();
 

--- a/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -32,17 +32,26 @@ final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
     use Helper;
     use MockeryPHPUnitIntegration;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(SentinelAuthentication::class);
     }
 
-    public function testIsInstanceOfAuthentication()
+    /**
+     * @test
+     */
+    public function isInstanceOfAuthentication()
     {
         $this->assertClassImplementsInterface(Authentication::class, SentinelAuthentication::class);
     }
 
-    public function testAuthenticateWillThrowCorrectError()
+    /**
+     * @test
+     */
+    public function authenticateWillThrowCorrectError()
     {
         $sentinel = Mockery::mock(Sentinel::class);
         $account  = Mockery::mock(AccountManagement::class);
@@ -65,7 +74,10 @@ final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
         $auth->authenticate('mail', 'pass');
     }
 
-    public function testAuthenticateWillThrowErrorWhenWrongPassword()
+    /**
+     * @test
+     */
+    public function authenticateWillThrowErrorWhenWrongPassword()
     {
         $user = Mockery::mock(UserInterface::class);
         $user->shouldReceive('checkPassword')->andReturn(false);
@@ -77,7 +89,10 @@ final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
         $auth->authenticate('mail', 'pass');
     }
 
-    public function testAuthenticateIsVoidWhenSuccessFull()
+    /**
+     * @test
+     */
+    public function authenticateIsVoidWhenSuccessFull()
     {
         $sentinelUser = Mockery::mock(SentinelUserInterface::class);
         $user         = Mockery::mock(UserInterface::class);
@@ -91,7 +106,10 @@ final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
         $auth->authenticate('mail', 'pass');
     }
 
-    public function testUserReturnsCorrectUser()
+    /**
+     * @test
+     */
+    public function userReturnsCorrectUser()
     {
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel = Mockery::mock(Sentinel::class);
@@ -101,7 +119,10 @@ final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(SentinelUser::class, $auth->user());
     }
 
-    public function testUserThrowsCorrectErrorWhenNotFound()
+    /**
+     * @test
+     */
+    public function userThrowsCorrectErrorWhenNotFound()
     {
         $sentinel = Mockery::mock(Sentinel::class);
         $sentinel->shouldReceive('getUser')->andReturn(false);
@@ -111,7 +132,10 @@ final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
         $auth->user();
     }
 
-    public function testCheckReturnsBool()
+    /**
+     * @test
+     */
+    public function checkReturnsBool()
     {
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel = Mockery::mock(Sentinel::class);
@@ -121,7 +145,10 @@ final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($auth->isAuthenticated());
     }
 
-    public function testCheckReturnsFalseWhenNotLoggedIn()
+    /**
+     * @test
+     */
+    public function checkReturnsFalseWhenNotLoggedIn()
     {
         $sentinel = Mockery::mock(Sentinel::class);
         $account  = Mockery::mock(AccountManagement::class);
@@ -130,7 +157,10 @@ final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($auth->isAuthenticated());
     }
 
-    public function testLogoutReturnsBool()
+    /**
+     * @test
+     */
+    public function logoutReturnsBool()
     {
         $user     = Mockery::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel = Mockery::mock(Sentinel::class);

--- a/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
@@ -25,17 +25,26 @@ final class SentinelIdentityProviderTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(SentinelIdentityProvider::class);
     }
 
-    public function testImplementsIdentityProvider()
+    /**
+     * @test
+     */
+    public function implementsIdentityProvider()
     {
         $this->assertClassImplementsInterface(IdentityProvider::class, SentinelIdentityProvider::class);
     }
 
-    public function testGetCurrentUserThrowsNotAuthenticatedExceptionWhenNotAuthenticated()
+    /**
+     * @test
+     */
+    public function getCurrentUserThrowsNotAuthenticatedExceptionWhenNotAuthenticated()
     {
         $sentinel = $this->createSentinelMock();
 
@@ -60,7 +69,10 @@ final class SentinelIdentityProviderTest extends Framework\TestCase
         $provider->getCurrentUser();
     }
 
-    public function testGetCurrentUserReturnsUserWhenAuthenticated()
+    /**
+     * @test
+     */
+    public function getCurrentUserReturnsUserWhenAuthenticated()
     {
         $id = $this->faker()->randomNumber();
 

--- a/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
@@ -22,17 +22,26 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(SentinelUser::class);
     }
 
-    public function testWeHaveTheRightUser()
+    /**
+     * @test
+     */
+    public function weHaveTheRightUser()
     {
         $this->assertClassImplementsInterface(\OpenCFP\Infrastructure\Auth\UserInterface::class, SentinelUser::class);
     }
 
-    public function testGetIdWorks()
+    /**
+     * @test
+     */
+    public function getIdWorks()
     {
         $innerUser = m::mock(\Cartalyst\Sentinel\Users\UserInterface::class)->makePartial();
         $innerUser->shouldReceive('getUserId')->andReturn(2);
@@ -40,7 +49,10 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(2, $sentinelUser->getId());
     }
 
-    public function testGetLoginWorks()
+    /**
+     * @test
+     */
+    public function getLoginWorks()
     {
         $innerUser = m::mock(\Cartalyst\Sentinel\Users\UserInterface::class)->makePartial();
         $innerUser->shouldReceive('getUserLogin')->andReturn('test@example.com');
@@ -48,14 +60,20 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('test@example.com', $sentinelUser->getLogin());
     }
 
-    public function testGtUserWorks()
+    /**
+     * @test
+     */
+    public function gtUserWorks()
     {
         $user      = new SentinelUser(m::mock(\Cartalyst\Sentinel\Users\UserInterface::class), $this->getSentinel());
         $innerUser = $user->getUser();
         $this->assertInstanceOf(\Cartalyst\Sentinel\Users\UserInterface::class, $innerUser);
     }
 
-    public function testHasAccessReturnsFalseWhenUserDoesNotHaveAccess()
+    /**
+     * @test
+     */
+    public function hasAccessReturnsFalseWhenUserDoesNotHaveAccess()
     {
         $innerUser     = m::mock(\Cartalyst\Sentinel\Users\UserInterface::class)->makePartial();
         $innerUser->id = 2;
@@ -64,7 +82,10 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($user->hasAccess('role'));
     }
 
-    public function testHasAccessReturnsTrueIfWeHaveAccess()
+    /**
+     * @test
+     */
+    public function hasAccessReturnsTrueIfWeHaveAccess()
     {
         $toReturn      = [(object) ['id' => 2], (object) ['id' => 3], (object) ['id' => 4]];
         $innerUser     = m::mock(\Cartalyst\Sentinel\Users\UserInterface::class)->makePartial();
@@ -77,7 +98,10 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($user->hasAccess('role'));
     }
 
-    public function testHasAccessReturnsFalseWhenAnErrorOcuurs()
+    /**
+     * @test
+     */
+    public function hasAccessReturnsFalseWhenAnErrorOcuurs()
     {
         $sentinelMock = m::mock(Sentinel::class);
         $sentinelMock->shouldReceive('getRoleRepository')->andThrow(new \ErrorException());
@@ -86,7 +110,10 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($user->hasAccess('role'));
     }
 
-    public function testCheckMasswrodReturnsTrueWhenItMatches()
+    /**
+     * @test
+     */
+    public function checkMasswrodReturnsTrueWhenItMatches()
     {
         $innerUser = m::mock(\Cartalyst\Sentinel\Users\UserInterface::class)->makePartial();
         $sentinel  = m::mock(Sentinel::class);
@@ -95,7 +122,10 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($user->checkPassword('hello'));
     }
 
-    public function testCheckResetPasswordCodeReturnsABool()
+    /**
+     * @test
+     */
+    public function checkResetPasswordCodeReturnsABool()
     {
         $innerUser = m::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel  = m::mock(Sentinel::class);
@@ -106,7 +136,10 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($user->checkResetPasswordCode('asdfasdf'));
     }
 
-    public function testCheckResetPasswordCodeReturnsFalseWhenItIsFalse()
+    /**
+     * @test
+     */
+    public function checkResetPasswordCodeReturnsFalseWhenItIsFalse()
     {
         $innerUser = m::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel  = m::mock(Sentinel::class);
@@ -117,7 +150,10 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($user->checkResetPasswordCode('asdfasdf'));
     }
 
-    public function testGetResetPasswordCodeReturnsCorrect()
+    /**
+     * @test
+     */
+    public function getResetPasswordCodeReturnsCorrect()
     {
         $innerUser = m::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel  = m::mock(Sentinel::class);
@@ -126,7 +162,10 @@ final class SentinelUserTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('blabla', $user->getResetPasswordCode());
     }
 
-    public function testAttemptResetPasswordReturnsCorrectBool()
+    /**
+     * @test
+     */
+    public function attemptResetPasswordReturnsCorrectBool()
     {
         $innerUser = m::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
         $sentinel  = m::mock(Sentinel::class);

--- a/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
@@ -20,7 +20,10 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 
 final class SpeakerAccessTest extends \PHPUnit\Framework\TestCase
 {
-    public function testReturnsRedirectResponseIfCheckFailed()
+    /**
+     * @test
+     */
+    public function returnsRedirectResponseIfCheckFailed()
     {
         $auth = Mockery::mock(Authentication::class);
         $auth->shouldReceive('isAuthenticated')->andReturn(false);
@@ -28,7 +31,10 @@ final class SpeakerAccessTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(RedirectResponse::class, SpeakerAccess::userHasAccess($auth));
     }
 
-    public function testReturnsNothingIfCheckSucceeded()
+    /**
+     * @test
+     */
+    public function returnsNothingIfCheckSucceeded()
     {
         $auth = Mockery::mock(Authentication::class);
         $auth->shouldReceive('isAuthenticated')->andReturn(true);

--- a/tests/Unit/Infrastructure/Auth/SymfonySentinelSessionTest.php
+++ b/tests/Unit/Infrastructure/Auth/SymfonySentinelSessionTest.php
@@ -22,12 +22,18 @@ final class SymfonySentinelSessionTest extends \PHPUnit\Framework\TestCase
     use Helper;
     use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-    public function testImplementsSessionInterface()
+    /**
+     * @test
+     */
+    public function implementsSessionInterface()
     {
         $this->assertClassImplementsInterface(\Cartalyst\Sentinel\Sessions\SessionInterface::class, SymfonySentinelSession::class);
     }
 
-    public function testPutSetsValue()
+    /**
+     * @test
+     */
+    public function putSetsValue()
     {
         $key   = 'foo';
         $value = 'bar';
@@ -50,7 +56,10 @@ final class SymfonySentinelSessionTest extends \PHPUnit\Framework\TestCase
         $sentinelSession->put($value);
     }
 
-    public function testGetReturnsValue()
+    /**
+     * @test
+     */
+    public function getReturnsValue()
     {
         $key   = 'foo';
         $value = 'bar';
@@ -71,7 +80,10 @@ final class SymfonySentinelSessionTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($value, $sentinelSession->get());
     }
 
-    public function testForgetRemovesKey()
+    /**
+     * @test
+     */
+    public function forgetRemovesKey()
     {
         $key = 'foo';
 

--- a/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
@@ -20,12 +20,18 @@ final class UserExistsExceptionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 
-    public function testItIsTheCorrectTypeOfException()
+    /**
+     * @test
+     */
+    public function itIsTheCorrectTypeOfException()
     {
         $this->assertClassExtends(\UnexpectedValueException::class, UserExistsException::class);
     }
 
-    public function testFromEmailReturnsException()
+    /**
+     * @test
+     */
+    public function fromEmailReturnsException()
     {
         $email = $this->faker()->email;
 

--- a/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
@@ -20,7 +20,10 @@ final class UserNotFoundExceptionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(UserNotFoundException::class);
     }
@@ -33,7 +36,10 @@ final class UserNotFoundExceptionTest extends \PHPUnit\Framework\TestCase
         $this->assertClassExtends(\RuntimeException::class, UserNotFoundException::class);
     }
 
-    public function testFromEmailReturnsException()
+    /**
+     * @test
+     */
+    public function fromEmailReturnsException()
     {
         $email = $this->faker()->email;
 
@@ -50,7 +56,10 @@ final class UserNotFoundExceptionTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(0, $exception->getCode());
     }
 
-    public function testFromIdReturnsException()
+    /**
+     * @test
+     */
+    public function fromIdReturnsException()
     {
         $id = $this->faker()->numberBetween(1);
 

--- a/tests/Unit/Infrastructure/CacheWarmer/HtmlPurifierWarmerTest.php
+++ b/tests/Unit/Infrastructure/CacheWarmer/HtmlPurifierWarmerTest.php
@@ -23,17 +23,26 @@ final class HtmlPurifierWarmerTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(HtmlPurifierWarmer::class);
     }
 
-    public function testImplementsCacheWarmerInterface()
+    /**
+     * @test
+     */
+    public function implementsCacheWarmerInterface()
     {
         $this->assertClassImplementsInterface(HttpKernel\CacheWarmer\CacheWarmerInterface::class, HtmlPurifierWarmer::class);
     }
 
-    public function testIsRequired()
+    /**
+     * @test
+     */
+    public function isRequired()
     {
         $filesystem = $this->createFilesystemMock();
 
@@ -42,7 +51,10 @@ final class HtmlPurifierWarmerTest extends Framework\TestCase
         $this->assertFalse($cacheWarmer->isOptional());
     }
 
-    public function testWarmUpCreatesCacheDirectory()
+    /**
+     * @test
+     */
+    public function warmUpCreatesCacheDirectory()
     {
         $cacheDirectory = $this->faker()->slug;
 

--- a/tests/Unit/Infrastructure/Repository/IlluminateUserRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Repository/IlluminateUserRepositoryTest.php
@@ -25,12 +25,18 @@ final class IlluminateUserRepositoryTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsUserRepository()
+    /**
+     * @test
+     */
+    public function implementsUserRepository()
     {
         $this->assertClassImplementsInterface(UserRepository::class, IlluminateUserRepository::class);
     }
 
-    public function testFindByIdThrowsEntityNotFoundExceptionIfUserNotFound()
+    /**
+     * @test
+     */
+    public function findByIdThrowsEntityNotFoundExceptionIfUserNotFound()
     {
         $id = $this->faker()->numberBetween(1);
 
@@ -51,7 +57,10 @@ final class IlluminateUserRepositoryTest extends Framework\TestCase
         $repository->findById($id);
     }
 
-    public function testFindByIdReturnsUserIfUserFound()
+    /**
+     * @test
+     */
+    public function findByIdReturnsUserIfUserFound()
     {
         $id = $this->faker()->numberBetween(1);
 
@@ -72,7 +81,10 @@ final class IlluminateUserRepositoryTest extends Framework\TestCase
         $this->assertSame($user, $repository->findById($id));
     }
 
-    public function testPersistSavesUser()
+    /**
+     * @test
+     */
+    public function persistSavesUser()
     {
         $user = $this->createUserMock([
             'save',

--- a/tests/Unit/PathTest.php
+++ b/tests/Unit/PathTest.php
@@ -21,12 +21,18 @@ final class PathTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(Path::class);
     }
 
-    public function testImplementsPathInterface()
+    /**
+     * @test
+     */
+    public function implementsPathInterface()
     {
         $this->assertClassImplementsInterface(PathInterface::class, Path::class);
     }

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -26,7 +26,10 @@ final class ProjectCodeTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testProductionClassesHaveUnitTests()
+    /**
+     * @test
+     */
+    public function productionClassesHaveUnitTests()
     {
         $this->assertClassesHaveTests(
             __DIR__ . '/../../classes',
@@ -70,7 +73,10 @@ final class ProjectCodeTest extends Framework\TestCase
         );
     }
 
-    public function testControllerActionsUseResponseReturnType()
+    /**
+     * @test
+     */
+    public function controllerActionsUseResponseReturnType()
     {
         $actionsWithoutReturnTypes = $this->methodNames(\array_filter($this->controllerActions(), function (\ReflectionMethod $method) {
             $returnType = (string) $method->getReturnType();
@@ -85,7 +91,10 @@ final class ProjectCodeTest extends Framework\TestCase
         ));
     }
 
-    public function testControllerActionsUseActionSuffix()
+    /**
+     * @test
+     */
+    public function controllerActionsUseActionSuffix()
     {
         $actionsWithoutSuffix = $this->methodNames(\array_filter($this->controllerActions(), function (\ReflectionMethod $method) {
             return \preg_match('/Action$/', $method->getName()) === 0;
@@ -145,7 +154,10 @@ final class ProjectCodeTest extends Framework\TestCase
         return $methodNames;
     }
 
-    public function testTestClassesAreAbstractOrFinal()
+    /**
+     * @test
+     */
+    public function classesAreAbstractOrFinal()
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..');
     }
@@ -154,8 +166,10 @@ final class ProjectCodeTest extends Framework\TestCase
      * @dataProvider providerProductionClassesAreAbstractOrFinal
      *
      * @param string $directory
+     *
+     * @test
      */
-    public function testProductionClassesAreAbstractOrFinal(string $directory)
+    public function productionClassesAreAbstractOrFinal(string $directory)
     {
         $this->assertClassesAreAbstractOrFinal($directory);
     }

--- a/tests/Unit/WebPathTest.php
+++ b/tests/Unit/WebPathTest.php
@@ -21,12 +21,18 @@ final class WebPathTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
 
-    public function testIsFinal()
+    /**
+     * @test
+     */
+    public function isFinal()
     {
         $this->assertClassIsFinal(WebPath::class);
     }
 
-    public function testImplementsPathInterface()
+    /**
+     * @test
+     */
+    public function implementsPathInterface()
     {
         $this->assertClassImplementsInterface(PathInterface::class, WebPath::class);
     }


### PR DESCRIPTION
 This PR

* [x] enables and configures the `php_unit_test_annotation` fixer
* [x] runs `make cs`

Follows #903.
Replaces #884.
Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3312.
Follows #905.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

>**php_unit_test_annotation**
>
>Adds or removes `@test` annotations from tests, following configuration.
>
>*Risky rule: this fixer may change the name of your tests, and could cause incompatibility with abstract classes or interfaces.*
>
>Configuration options:
>
>* `case` (`'camel'`, `'snake'`): whether to camel or snake case when adding the test prefix; defaults to `'camel'`
>* `style` (`'annotation'`, `'prefix'`): whether to use the `@test` annotation or not; defaults to `'prefix'`