### PR TITLE
Fix: Suffix controller actions with Action

### DIFF
--- a/classes/Http/Controller/DashboardController.php
+++ b/classes/Http/Controller/DashboardController.php
@@ -36,7 +36,7 @@ class DashboardController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function showSpeakerProfile(): Response
+    public function indexAction(): Response
     {
         try {
             return $this->render('dashboard.twig', [

--- a/classes/Http/Controller/PagesController.php
+++ b/classes/Http/Controller/PagesController.php
@@ -18,19 +18,19 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PagesController extends BaseController
 {
-    public function showHomepage(): Response
+    public function homepageAction(): Response
     {
         return $this->render('home.twig', [
             'number_of_talks' => Talk::count(),
         ]);
     }
 
-    public function showSpeakerPackage(): Response
+    public function speakerPackageAction(): Response
     {
         return $this->render('package.twig');
     }
 
-    public function showTalkIdeas(): Response
+    public function talkIdeasAction(): Response
     {
         return $this->render('ideas.twig');
     }

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -190,15 +190,15 @@ final class WebGatewayProvider implements
             $app->requireHttps();
         }
 
-        $web->get('/', 'OpenCFP\Http\Controller\PagesController::showHomepage')
+        $web->get('/', 'OpenCFP\Http\Controller\PagesController::homepageAction')
             ->bind('homepage');
-        $web->get('/package', 'OpenCFP\Http\Controller\PagesController::showSpeakerPackage')
+        $web->get('/package', 'OpenCFP\Http\Controller\PagesController::speakerPackageAction')
             ->bind('speaker_package');
-        $web->get('/ideas', 'OpenCFP\Http\Controller\PagesController::showTalkIdeas')
+        $web->get('/ideas', 'OpenCFP\Http\Controller\PagesController::talkIdeasAction')
             ->bind('talk_ideas');
 
         // User Dashboard
-        $web->get('/dashboard', 'OpenCFP\Http\Controller\DashboardController::showSpeakerProfile')
+        $web->get('/dashboard', 'OpenCFP\Http\Controller\DashboardController::indexAction')
             ->bind('dashboard');
 
         // Talks

--- a/tests/Integration/Http/Controller/PagesControllerTest.php
+++ b/tests/Integration/Http/Controller/PagesControllerTest.php
@@ -24,7 +24,7 @@ final class PagesControllerTest extends WebTestCase
     /**
      * @test
      */
-    public function showHomePageWorks()
+    public function indexActionWorks()
     {
         $response = $this->get('/');
 
@@ -36,7 +36,7 @@ final class PagesControllerTest extends WebTestCase
     /**
      * @test
      */
-    public function showHomeWorksWhenCFPIsClosed()
+    public function indexActionWorksWhenCFPIsClosed()
     {
         $response = $this
             ->callForPapersIsClosed()
@@ -50,7 +50,7 @@ final class PagesControllerTest extends WebTestCase
     /**
      * @test
      */
-    public function showSpeakerPackageWorks()
+    public function speakerPackageActionWorks()
     {
         $response = $this->get('/package');
 
@@ -62,7 +62,7 @@ final class PagesControllerTest extends WebTestCase
     /**
      * @test
      */
-    public function showSpeakerPackageWorksWhenCFPIsClosed()
+    public function speakerPackageActionWorksWhenCFPIsClosed()
     {
         $response = $this
             ->callForPapersIsClosed()
@@ -76,7 +76,7 @@ final class PagesControllerTest extends WebTestCase
     /**
      * @test
      */
-    public function showTalkIdeasWorks()
+    public function talkIdeasActionWorks()
     {
         $response = $this->get('/ideas');
 
@@ -88,7 +88,7 @@ final class PagesControllerTest extends WebTestCase
     /**
      * @test
      */
-    public function showTalkIdeasWorksWhenCFPIsClosed()
+    public function talkIdeasActionWorksWhenCFPIsClosed()
     {
         $response = $this
             ->callForPapersIsClosed()


### PR DESCRIPTION
This PR

* [x] asserts that controller actions are suffixed with `Action`
* [x] renames controller actions
