### PR TITLE
Fix: Remove unused method

### DIFF
--- a/classes/Domain/Services/TalkFormat.php
+++ b/classes/Domain/Services/TalkFormat.php
@@ -18,6 +18,4 @@ use Illuminate\Support\Collection;
 interface TalkFormat
 {
     public function formatList(Collection $talkCollection, int $adminUserId): Collection;
-
-    public function createdFormattedOutput($talk, int $adminUserId);
 }

--- a/classes/Domain/Talk/TalkFormatter.php
+++ b/classes/Domain/Talk/TalkFormatter.php
@@ -32,17 +32,4 @@ class TalkFormatter implements TalkFormat
             return new TalkProfile($talk, $adminUserId);
         });
     }
-
-    /**
-     * Iterates over DBAL objects and returns a formatted result set
-     *
-     * @param mixed $talk
-     * @param int   $adminUserId
-     *
-     * @return TalkProfile
-     */
-    public function createdFormattedOutput($talk, int $adminUserId)
-    {
-        return new TalkProfile($talk, $adminUserId);
-    }
 }

--- a/tests/Integration/Domain/Services/TalkFormatterTest.php
+++ b/tests/Integration/Domain/Services/TalkFormatterTest.php
@@ -37,37 +37,6 @@ final class TalkFormatterTest extends BaseTestCase
     /**
      * @test
      */
-    public function createFormattedOutputWorksWithNoMeta()
-    {
-        $talk      = new Talk();
-        $formatter = new TalkFormatter();
-
-        $format = $formatter->createdFormattedOutput($talk->first(), 1);
-
-        $this->assertSame('One talk to rule them all', $format->getTitle());
-        $this->assertSame('api', $format->getCategory());
-        $this->assertSame(0, $format->getRating());
-        $this->assertFalse($format->isViewedByMe());
-    }
-
-    /**
-     * @test
-     */
-    public function createFormattedOutputWorksWithMeta()
-    {
-        $formatter = new TalkFormatter();
-        $talk      = new Talk();
-
-        // Now to see if the meta gets put in correctly
-        $secondFormat = $formatter->createdFormattedOutput($talk->first(), 2);
-
-        $this->assertSame(1, $secondFormat->getRating());
-        $this->assertTrue($secondFormat->isViewedByMe());
-    }
-
-    /**
-     * @test
-     */
     public function formatListReturnsAllTalksAsCollection()
     {
         $formatter = new TalkFormatter();


### PR DESCRIPTION
This PR

* [x] removes an unused method

Related to #908.

💁‍♂️ Running

```
$ git grep -i createdFormattedOutput
```

yields no results other than in tests, the interface, and the single implementation.