### PR TITLE
Enhancement: remove hardcoded references to uploads folder

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -124,7 +124,7 @@ class Application extends SilexApplication
 
     private function getConfigSlugs()
     {
-        return ['config', 'upload', 'templates', 'public', 'assets', 'cache.twig', 'cache.purifier'];
+        return ['config', 'uploadTo', 'downloadFrom', 'templates', 'public', 'assets', 'cache.twig', 'cache.purifier'];
     }
 
     /**

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -167,6 +167,7 @@ class SpeakersController extends BaseController
             'departure'  => \date('Y-m-d', $this->applicationDeparture),
             'speaker'    => new SpeakerProfile($speakerDetails),
             'talks'      => $talks,
+            //TODO: use Path downloadFrom function function
             'photo_path' => '/uploads/',
             'page'       => $request->get('page'),
         ]);

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -170,13 +170,12 @@ class SpeakersController extends BaseController
 
         // Build and render the template
         return $this->render('admin/speaker/view.twig', [
-            'airport'    => $this->applicationAirport,
-            'arrival'    => \date('Y-m-d', $this->applicationArrival),
-            'departure'  => \date('Y-m-d', $this->applicationDeparture),
-            'speaker'    => new SpeakerProfile($speakerDetails),
-            'talks'      => $talks,
-            'photo_path' => $this->path->downloadFromPath(),
-            'page'       => $request->get('page'),
+            'airport'   => $this->applicationAirport,
+            'arrival'   => \date('Y-m-d', $this->applicationArrival),
+            'departure' => \date('Y-m-d', $this->applicationDeparture),
+            'speaker'   => new SpeakerProfile($speakerDetails),
+            'talks'     => $talks,
+            'page'      => $request->get('page'),
         ]);
     }
 

--- a/classes/Http/Controller/Admin/SpeakersController.php
+++ b/classes/Http/Controller/Admin/SpeakersController.php
@@ -22,6 +22,7 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Http\Controller\BaseController;
+use OpenCFP\PathInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -64,6 +65,11 @@ class SpeakersController extends BaseController
      */
     private $applicationAirport;
 
+    /**
+     * @var PathInterface
+     */
+    private $path;
+
     public function __construct(
         Authentication $authentication,
         AccountManagement $accounts,
@@ -73,7 +79,8 @@ class SpeakersController extends BaseController
         UrlGeneratorInterface $urlGenerator,
         string $applicationAirport,
         int $applicationArrival,
-        int $applicationDeparture
+        int $applicationDeparture,
+        PathInterface $path
     ) {
         $this->authentication       = $authentication;
         $this->accounts             = $accounts;
@@ -82,6 +89,7 @@ class SpeakersController extends BaseController
         $this->applicationAirport   = $applicationAirport;
         $this->applicationArrival   = $applicationArrival;
         $this->applicationDeparture = $applicationDeparture;
+        $this->path                 = $path;
 
         parent::__construct($twig, $urlGenerator);
     }
@@ -167,8 +175,7 @@ class SpeakersController extends BaseController
             'departure'  => \date('Y-m-d', $this->applicationDeparture),
             'speaker'    => new SpeakerProfile($speakerDetails),
             'talks'      => $talks,
-            //TODO: use Path downloadFrom function function
-            'photo_path' => '/uploads/',
+            'photo_path' => $this->path->downloadFromPath(),
             'page'       => $request->get('page'),
         ]);
     }

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -46,16 +46,6 @@ class ProfileController extends BaseController
      */
     private $path;
 
-    /**
-     * ProfileController constructor.
-     *
-     * @param Authentication        $authentication
-     * @param HTMLPurifier          $purifier
-     * @param ProfileImageProcessor $profileImageProcessor
-     * @param Twig_Environment      $twig
-     * @param UrlGeneratorInterface $urlGenerator
-     * @param PathInterface         $path
-     */
     public function __construct(
         Authentication $authentication,
         HTMLPurifier $purifier,

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -80,6 +80,7 @@ class ProfileController extends BaseController
             'speaker_info'   => $speakerData['info'],
             'speaker_bio'    => $speakerData['bio'],
             'speaker_photo'  => $speakerData['photo_path'],
+            //TODO: use Path downloadFrom function function
             'preview_photo'  => '/uploads/' . $speakerData['photo_path'],
             'airport'        => $speakerData['airport'],
             'transportation' => $speakerData['transportation'],

--- a/classes/Http/Controller/ProfileController.php
+++ b/classes/Http/Controller/ProfileController.php
@@ -18,6 +18,7 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\ProfileImageProcessor;
 use OpenCFP\Http\Form\SignupForm;
+use OpenCFP\PathInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -40,16 +41,33 @@ class ProfileController extends BaseController
      */
     private $profileImageProcessor;
 
+    /**
+     * @var PathInterface
+     */
+    private $path;
+
+    /**
+     * ProfileController constructor.
+     *
+     * @param Authentication        $authentication
+     * @param HTMLPurifier          $purifier
+     * @param ProfileImageProcessor $profileImageProcessor
+     * @param Twig_Environment      $twig
+     * @param UrlGeneratorInterface $urlGenerator
+     * @param PathInterface         $path
+     */
     public function __construct(
         Authentication $authentication,
         HTMLPurifier $purifier,
         ProfileImageProcessor $profileImageProcessor,
         Twig_Environment $twig,
-        UrlGeneratorInterface $urlGenerator
+        UrlGeneratorInterface $urlGenerator,
+        PathInterface $path
     ) {
         $this->authentication        = $authentication;
         $this->purifier              = $purifier;
         $this->profileImageProcessor = $profileImageProcessor;
+        $this->path                  = $path;
 
         parent::__construct($twig, $urlGenerator);
     }
@@ -80,8 +98,7 @@ class ProfileController extends BaseController
             'speaker_info'   => $speakerData['info'],
             'speaker_bio'    => $speakerData['bio'],
             'speaker_photo'  => $speakerData['photo_path'],
-            //TODO: use Path downloadFrom function function
-            'preview_photo'  => '/uploads/' . $speakerData['photo_path'],
+            'preview_photo'  => $this->path->downloadFromPath() . $speakerData['photo_path'],
             'airport'        => $speakerData['airport'],
             'transportation' => $speakerData['transportation'],
             'hotel'          => $speakerData['hotel'],

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -17,6 +17,7 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Pagination;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Http\Controller\BaseController;
+use OpenCFP\PathInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -29,9 +30,16 @@ class SpeakersController extends BaseController
      */
     private $reviewerUsers;
 
-    public function __construct(Twig_Environment $twig, UrlGeneratorInterface $urlGenerator, array $reviewerUsers)
-    {
+    private $path;
+
+    public function __construct(
+        Twig_Environment $twig,
+        UrlGeneratorInterface $urlGenerator,
+        array $reviewerUsers,
+        PathInterface $path
+    ) {
         $this->reviewerUsers = $reviewerUsers;
+        $this->path          = $path;
 
         parent::__construct($twig, $urlGenerator);
     }
@@ -72,8 +80,7 @@ class SpeakersController extends BaseController
         return $this->render('reviewer/speaker/view.twig', [
             'speaker'    => new SpeakerProfile($speakerDetails, $this->reviewerUsers),
             'talks'      => $talks,
-            //TODO: use Path downloadFrom function function
-            'photo_path' => '/uploads/',
+            'photo_path' => $this->path->downloadFromPath(),
             'page'       => $request->get('page'),
         ]);
     }

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -78,10 +78,9 @@ class SpeakersController extends BaseController
         $talks = $speakerDetails->talks()->get()->toArray();
 
         return $this->render('reviewer/speaker/view.twig', [
-            'speaker'    => new SpeakerProfile($speakerDetails, $this->reviewerUsers),
-            'talks'      => $talks,
-            'photo_path' => $this->path->downloadFromPath(),
-            'page'       => $request->get('page'),
+            'speaker' => new SpeakerProfile($speakerDetails, $this->reviewerUsers),
+            'talks'   => $talks,
+            'page'    => $request->get('page'),
         ]);
     }
 }

--- a/classes/Http/Controller/Reviewer/SpeakersController.php
+++ b/classes/Http/Controller/Reviewer/SpeakersController.php
@@ -72,6 +72,7 @@ class SpeakersController extends BaseController
         return $this->render('reviewer/speaker/view.twig', [
             'speaker'    => new SpeakerProfile($speakerDetails, $this->reviewerUsers),
             'talks'      => $talks,
+            //TODO: use Path downloadFrom function function
             'photo_path' => '/uploads/',
             'page'       => $request->get('page'),
         ]);

--- a/classes/Infrastructure/Templating/TwigExtension.php
+++ b/classes/Infrastructure/Templating/TwigExtension.php
@@ -40,6 +40,7 @@ class TwigExtension extends Twig_Extension
     {
         return [
             new Twig_SimpleFunction('uploads', function ($path) {
+                //TODO: use Path downloadFrom function function
                 return '/uploads/' . $path;
             }),
             new Twig_SimpleFunction('assets', function ($path) {

--- a/classes/Infrastructure/Templating/TwigExtension.php
+++ b/classes/Infrastructure/Templating/TwigExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Infrastructure\Templating;
 
+use OpenCFP\PathInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig_Extension;
@@ -30,18 +31,23 @@ class TwigExtension extends Twig_Extension
      */
     private $urlGenerator;
 
-    public function __construct(RequestStack $requestStack, UrlGeneratorInterface $urlGenerator)
+    /**
+     * @var PathInterface
+     */
+    private $path;
+
+    public function __construct(RequestStack $requestStack, UrlGeneratorInterface $urlGenerator, PathInterface $path)
     {
         $this->requestStack = $requestStack;
         $this->urlGenerator = $urlGenerator;
+        $this->path         = $path;
     }
 
     public function getFunctions()
     {
         return [
             new Twig_SimpleFunction('uploads', function ($path) {
-                //TODO: use Path downloadFrom function function
-                return '/uploads/' . $path;
+                return $this->path->downloadFromPath() . $path;
             }),
             new Twig_SimpleFunction('assets', function ($path) {
                 return '/assets/' . $path;

--- a/classes/Path.php
+++ b/classes/Path.php
@@ -48,7 +48,7 @@ final class Path implements PathInterface
 
     public function downloadFromPath(): string
     {
-        return '/uploads';
+        return '/uploads/';
     }
 
     public function templatesPath(): string

--- a/classes/Path.php
+++ b/classes/Path.php
@@ -41,9 +41,14 @@ final class Path implements PathInterface
         return $this->path . "/config/{$this->env}.yml";
     }
 
-    public function uploadPath(): string
+    public function uploadToPath(): string
     {
         return $this->path . '/web/uploads';
+    }
+
+    public function downloadFromPath(): string
+    {
+        return '/uploads';
     }
 
     public function templatesPath(): string

--- a/classes/PathInterface.php
+++ b/classes/PathInterface.php
@@ -19,7 +19,9 @@ interface PathInterface
 
     public function configPath(): string;
 
-    public function uploadPath(): string;
+    public function uploadToPath(): string;
+
+    public function downloadFromPath(): string;
 
     public function templatesPath(): string;
 

--- a/classes/Provider/Gateways/WebGatewayProvider.php
+++ b/classes/Provider/Gateways/WebGatewayProvider.php
@@ -77,7 +77,8 @@ final class WebGatewayProvider implements
                 $app['purifier'],
                 $app['profile_image_processor'],
                 $app['twig'],
-                $app['url_generator']
+                $app['url_generator'],
+                $app['path']
             );
         };
 
@@ -138,7 +139,8 @@ final class WebGatewayProvider implements
                 $app['url_generator'],
                 $app->config('application.airport'),
                 $app->config('application.arrival'),
-                $app->config('application.departure')
+                $app->config('application.departure'),
+                $app['path']
             );
         };
 
@@ -165,7 +167,8 @@ final class WebGatewayProvider implements
             return new Reviewer\SpeakersController(
                 $app['twig'],
                 $app['url_generator'],
-                $app->config('reviewer.users') ?: []
+                $app->config('reviewer.users') ?: [],
+                $app['path']
             );
         };
 

--- a/classes/Provider/ImageProcessorProvider.php
+++ b/classes/Provider/ImageProcessorProvider.php
@@ -25,7 +25,7 @@ final class ImageProcessorProvider implements ServiceProviderInterface
     public function register(Container $app)
     {
         $app['profile_image_processor'] = function ($app) {
-            return new ProfileImageProcessor($app['path']->uploadPath(), $app['security.random']);
+            return new ProfileImageProcessor($app['path']->uploadToPath(), $app['security.random']);
         };
     }
 }

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -52,7 +52,8 @@ final class TwigServiceProvider implements ServiceProviderInterface, EventListen
 
             $twig->addExtension(new TwigExtension(
                 $app['request_stack'],
-                $app['url_generator']
+                $app['url_generator'],
+                $app['path']
             ));
 
             $twig->addGlobal('site', $app->config('application'));

--- a/resources/views/admin/speaker/index.twig
+++ b/resources/views/admin/speaker/index.twig
@@ -19,8 +19,7 @@
     {% for speaker in speakers %}
         <div class="flex justify-between items-center mb-8">
             <div class="flex">
-                {# //TODO: use twig uploads function function #}
-                <img class="w-10 h-10 mr-3 rounded-full" src="{{ speaker.photo_path ? '/uploads/' ~ speaker.photo_path : '/assets/img/dummyphoto.jpg' }}">
+                <img class="w-10 h-10 mr-3 rounded-full" src="{{ speaker.photo_path ? uploads(speaker.photo_path) : '/assets/img/dummyphoto.jpg' }}">
                 <div>
                     <h2 class="-mt-2">
                         <a href="{{ url('admin_speaker_view', { id: speaker.id }) }}">{{ speaker.first_name }} {{ speaker.last_name }}</a>

--- a/resources/views/admin/speaker/index.twig
+++ b/resources/views/admin/speaker/index.twig
@@ -19,6 +19,7 @@
     {% for speaker in speakers %}
         <div class="flex justify-between items-center mb-8">
             <div class="flex">
+                {# //TODO: use twig uploads function function #}
                 <img class="w-10 h-10 mr-3 rounded-full" src="{{ speaker.photo_path ? '/uploads/' ~ speaker.photo_path : '/assets/img/dummyphoto.jpg' }}">
                 <div>
                     <h2 class="-mt-2">

--- a/resources/views/admin/speaker/view.twig
+++ b/resources/views/admin/speaker/view.twig
@@ -2,8 +2,7 @@
 {% block content %}
 
     <div class="flex mb-8">
-        {# //TODO: use twig uploads function function #}
-        <img class="w-16 h-16 mr-4 rounded-full" src="{{ speaker.photo ? '/uploads/' ~ speaker.photo : '/assets/img/dummyphoto.jpg' }}">
+        <img class="w-16 h-16 mr-4 rounded-full" src="{{ speaker.photo ? uploads(speaker.photo) : '/assets/img/dummyphoto.jpg' }}">
         <div>
             <h1 class="-mt-2">
                 {{ speaker.name }}

--- a/resources/views/admin/speaker/view.twig
+++ b/resources/views/admin/speaker/view.twig
@@ -2,6 +2,7 @@
 {% block content %}
 
     <div class="flex mb-8">
+        {# //TODO: use twig uploads function function #}
         <img class="w-16 h-16 mr-4 rounded-full" src="{{ speaker.photo ? '/uploads/' ~ speaker.photo : '/assets/img/dummyphoto.jpg' }}">
         <div>
             <h1 class="-mt-2">

--- a/resources/views/admin/talks/view.twig
+++ b/resources/views/admin/talks/view.twig
@@ -52,6 +52,7 @@
             {% set user = comment.user.toArray %}
             <div class="flex text-sm mt-4">
                 <div>
+                    {# //TODO: use twig uploads function function #}
                     <img class="w-16 mr-4 rounded" src="{{ user.photo_path ? '/uploads/' ~ user.photo_path : '/assets/img/dummyphoto.jpg' }}">
                 </div>
                 <div class="border border-grey rounded-sm w-full">

--- a/resources/views/admin/talks/view.twig
+++ b/resources/views/admin/talks/view.twig
@@ -52,8 +52,7 @@
             {% set user = comment.user.toArray %}
             <div class="flex text-sm mt-4">
                 <div>
-                    {# //TODO: use twig uploads function function #}
-                    <img class="w-16 mr-4 rounded" src="{{ user.photo_path ? '/uploads/' ~ user.photo_path : '/assets/img/dummyphoto.jpg' }}">
+                    <img class="w-16 mr-4 rounded" src="{{ user.photo_path ? uploads(user.photo_path) : '/assets/img/dummyphoto.jpg' }}">
                 </div>
                 <div class="border border-grey rounded-sm w-full">
                     <div class="p-3 border-b border-grey bg-blue-lightest flex justify-between">

--- a/resources/views/reviewer/speaker/index.twig
+++ b/resources/views/reviewer/speaker/index.twig
@@ -19,8 +19,7 @@
     {% for speaker in speakers %}
         <div class="flex justify-between items-center mb-8">
             <div class="flex">
-                {# //TODO: use twig uploads function function #}
-                <img class="w-10 h-10 mr-3 rounded-full" src="{{ speaker.photo_path ? '/uploads/' ~ speaker.photo_path : '/assets/img/dummyphoto.jpg' }}">
+                <img class="w-10 h-10 mr-3 rounded-full" src="{{ speaker.photo_path ? uploads(speaker.photo_path) : '/assets/img/dummyphoto.jpg' }}">
                 <div>
                     <h2 class="-mt-2">
                         <a href="{{ url('reviewer_speaker_view', { id: speaker.id }) }}">{{ speaker.first_name }} {{ speaker.last_name }}</a>

--- a/resources/views/reviewer/speaker/index.twig
+++ b/resources/views/reviewer/speaker/index.twig
@@ -19,6 +19,7 @@
     {% for speaker in speakers %}
         <div class="flex justify-between items-center mb-8">
             <div class="flex">
+                {# //TODO: use twig uploads function function #}
                 <img class="w-10 h-10 mr-3 rounded-full" src="{{ speaker.photo_path ? '/uploads/' ~ speaker.photo_path : '/assets/img/dummyphoto.jpg' }}">
                 <div>
                     <h2 class="-mt-2">

--- a/resources/views/reviewer/speaker/view.twig
+++ b/resources/views/reviewer/speaker/view.twig
@@ -2,8 +2,7 @@
 {% block content %}
 
     <div class="flex mb-8">
-        {# //TODO: use twig uploads function function #}
-        <img class="w-16 h-16 mr-4 rounded-full" src="{{ speaker.photo ? '/uploads/' ~ speaker.photo : '/assets/img/dummyphoto.jpg' }}">
+        <img class="w-16 h-16 mr-4 rounded-full" src="{{ speaker.photo ? uploads(speaker.photo) : '/assets/img/dummyphoto.jpg' }}">
         <div>
             <h1 class="-mt-2">
                 {% if speaker.isAllowedToSee('name') %}{{ speaker.name }}{% else %}Unknown Speaker{% endif %}

--- a/resources/views/reviewer/speaker/view.twig
+++ b/resources/views/reviewer/speaker/view.twig
@@ -2,6 +2,7 @@
 {% block content %}
 
     <div class="flex mb-8">
+        {# //TODO: use twig uploads function function #}
         <img class="w-16 h-16 mr-4 rounded-full" src="{{ speaker.photo ? '/uploads/' ~ speaker.photo : '/assets/img/dummyphoto.jpg' }}">
         <div>
             <h1 class="-mt-2">

--- a/resources/views/reviewer/talks/view.twig
+++ b/resources/views/reviewer/talks/view.twig
@@ -52,6 +52,7 @@
 
             <div class="flex text-sm mt-4">
                 <div>
+                    {# //TODO: use twig uploads function function #}
                     <img class="w-16 mr-4 rounded" src="{{ comment.user.photo_path ? '/uploads/' ~ comment.user.photo_path : '/assets/img/dummyphoto.jpg' }}">
                 </div>
                 <div class="border border-grey rounded-sm w-full">

--- a/resources/views/reviewer/talks/view.twig
+++ b/resources/views/reviewer/talks/view.twig
@@ -52,8 +52,7 @@
 
             <div class="flex text-sm mt-4">
                 <div>
-                    {# //TODO: use twig uploads function function #}
-                    <img class="w-16 mr-4 rounded" src="{{ comment.user.photo_path ? '/uploads/' ~ comment.user.photo_path : '/assets/img/dummyphoto.jpg' }}">
+                    <img class="w-16 mr-4 rounded" src="{{ comment.user.photo_path ? uploads(comment.user.photo_path) : '/assets/img/dummyphoto.jpg' }}">
                 </div>
                 <div class="border border-grey rounded-sm w-full">
                     <div class="p-3 border-b border-grey bg-blue-lightest flex justify-between">

--- a/tests/Integration/Infrastructure/Templating/TwigExtensionTest.php
+++ b/tests/Integration/Infrastructure/Templating/TwigExtensionTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace OpenCFP\Test\Integration\Infrastructure\Templating;
 
+use OpenCFP\Environment;
 use OpenCFP\Infrastructure\Templating\TwigExtension;
+use OpenCFP\Path;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -32,6 +34,8 @@ final class TwigExtensionTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push(Request::create('/dashboard'));
 
+        $path = new Path('', Environment::testing());
+
         $routes = new RouteCollection();
         $routes->add('admin', new Route('/admin'));
         $routes->add('dashboard', new Route('/dashboard'));
@@ -40,7 +44,8 @@ final class TwigExtensionTest extends TestCase
         $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__ . '/Fixtures'));
         $twig->addExtension(new TwigExtension(
             $requestStack,
-            $urlGenerator
+            $urlGenerator,
+            $path
         ));
 
         $this->assertStringEqualsFile(__DIR__ . '/Fixtures/functions.txt', $twig->render('functions.txt.twig'));

--- a/tests/Unit/PathTest.php
+++ b/tests/Unit/PathTest.php
@@ -99,11 +99,10 @@ final class PathTest extends \PHPUnit\Framework\TestCase
     {
         $path = new Path('/home/folder/base', Environment::testing());
         $this->assertSame(
-            '/uploads',
+            '/uploads/',
             $path->downloadFromPath()
         );
     }
-
 
     /**
      * @test

--- a/tests/Unit/PathTest.php
+++ b/tests/Unit/PathTest.php
@@ -83,14 +83,27 @@ final class PathTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function uploadPathReturnsUploadPath()
+    public function uploadToPathReturnsUploadPath()
     {
         $path = new Path('/home/folder/base', Environment::testing());
         $this->assertSame(
             '/home/folder/base/web/uploads',
-            $path->uploadPath()
+            $path->uploadToPath()
         );
     }
+
+    /**
+     * @test
+     */
+    public function downloadFromPathReturnsDownloadFromPath()
+    {
+        $path = new Path('/home/folder/base', Environment::testing());
+        $this->assertSame(
+            '/uploads',
+            $path->downloadFromPath()
+        );
+    }
+
 
     /**
      * @test


### PR DESCRIPTION
This PR

* [x] Changes the Path and PathInterface to split up the uploads function 
* [x] Removes all references to 'uploads' in php classes and use the path function instead
* [x] Removes all references to 'uploads' in twig templates and uses the twig function instead

Related to #894.

This is a first step to making the uploading of profile pictures a bit more manageable on production environments where we can't, or don't want to, write to our own file system. If this gets merged, the only thing that needs to be changed in order to use another storage is the reference in the Path functions.

