### PR TITLE
Enhancement: Enable and configure class_attributes_separation fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -50,6 +50,12 @@ return PhpCsFixer\Config::create()
             ],
         ],
         'cast_spaces' => true,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method',
+                'property',
+            ],
+        ],
         'combine_consecutive_unsets' => true,
         'concat_space' => [
             'spacing' => 'one',

--- a/classes/Domain/Model/Airport.php
+++ b/classes/Domain/Model/Airport.php
@@ -18,7 +18,8 @@ use OpenCFP\Domain\Services\AirportInformationDatabase;
 
 class Airport extends Eloquent implements AirportInformationDatabase
 {
-    protected $table   = 'airports';
+    protected $table = 'airports';
+
     public $timestamps = false;
 
     /**

--- a/classes/Domain/Talk/TalkFilter.php
+++ b/classes/Domain/Talk/TalkFilter.php
@@ -33,6 +33,7 @@ class TalkFilter
      * @var Talk
      */
     private $talk;
+
     /**
      * @var TalkFormatter
      */

--- a/tests/Integration/Domain/Talk/TalkHandlerTest.php
+++ b/tests/Integration/Domain/Talk/TalkHandlerTest.php
@@ -35,6 +35,7 @@ final class TalkHandlerTest extends BaseTestCase
     private static $talk;
 
     private $authentication;
+
     private $ratingSystem;
 
     public static function setUpBeforeClass()

--- a/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
@@ -26,6 +26,7 @@ final class ExportsControllerTest extends WebTestCase
     use RefreshDatabase;
 
     private static $talks;
+
     private static $selectedTalk;
 
     public static function setUpBeforeClass()

--- a/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -26,6 +26,7 @@ use OpenCFP\Test\Helper\DataBaseInteraction;
 final class SentinelAuthenticationTest extends BaseTestCase
 {
     use DataBaseInteraction;
+
     /**
      * @var SentinelAuthentication
      */


### PR DESCRIPTION
This PR

* [x] enables and configures the `class_attributes_separation` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.9.0#usage:

>**class_attributes_separation** [`@Symfony`]
>
>Class, trait and interface elements must be separated with one blank line.
>
>Configuration options:
>
>* `elements` (`array`): list of classy elements; `'const'`, `'method'`, `'property'`; defaults to `['const', 'method', 'property']`