### PR TITLE
Fix: Extract method that fetches session from container

### DIFF
--- a/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/DashboardControllerTest.php
@@ -40,6 +40,6 @@ final class DashboardControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful($response);
         $this->assertResponseBodyContains(self::$talks->first()->title, $response);
-        $this->assertSessionHasNoFlashMessage($this->container->get('session'));
+        $this->assertSessionHasNoFlashMessage($this->session());
     }
 }

--- a/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/ExportsControllerTest.php
@@ -46,7 +46,7 @@ final class ExportsControllerTest extends WebTestCase
         $this->assertResponseIsSuccessful($response);
         $this->assertResponseBodyContains(self::$talks->first()->title, $response);
         $this->assertResponseBodyNotContains($user->first_name, $response);
-        $this->assertSessionHasNoFlashMessage($this->container->get('session'));
+        $this->assertSessionHasNoFlashMessage($this->session());
     }
 
     /**
@@ -60,7 +60,7 @@ final class ExportsControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful($response);
         $this->assertResponseBodyContains(self::$talks->first()->title, $response);
-        $this->assertSessionHasNoFlashMessage($this->container->get('session'));
+        $this->assertSessionHasNoFlashMessage($this->session());
     }
 
     /**
@@ -77,7 +77,7 @@ final class ExportsControllerTest extends WebTestCase
         $this->assertResponseIsSuccessful($response);
         $this->assertResponseBodyContains(self::$talks->first()->title, $response);
         $this->assertResponseBodyContains($user->first_name, $response);
-        $this->assertSessionHasNoFlashMessage($this->container->get('session'));
+        $this->assertSessionHasNoFlashMessage($this->session());
     }
 
     /**
@@ -94,7 +94,7 @@ final class ExportsControllerTest extends WebTestCase
         $this->assertResponseBodyContains(self::$selectedTalk->title, $response);
         $this->assertResponseBodyNotContains(self::$talks->first()->title, $response);
         $this->assertResponseBodyNotContains($user->first_name, $response);
-        $this->assertSessionHasNoFlashMessage($this->container->get('session'));
+        $this->assertSessionHasNoFlashMessage($this->session());
     }
 
     /**

--- a/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
@@ -41,7 +41,7 @@ final class SpeakersControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful($response);
         $this->assertResponseBodyContains($this->users->first()->first_name, $response);
-        $this->assertSessionHasNoFlashMessage($this->container->get('session'));
+        $this->assertSessionHasNoFlashMessage($this->session());
     }
 
     /**
@@ -57,7 +57,7 @@ final class SpeakersControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful($response);
         $this->assertResponseBodyContains($user->first_name, $response);
-        $this->assertSessionHasNoFlashMessage($this->container->get('session'));
+        $this->assertSessionHasNoFlashMessage($this->session());
     }
 
     /**
@@ -73,7 +73,7 @@ final class SpeakersControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('admin/speakers', $response);
-        $this->assertSessionHasFlashMessage('Error', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('Error', $this->session());
     }
 
     /**
@@ -95,7 +95,7 @@ final class SpeakersControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('admin/speakers', $response);
-        $this->assertSessionHasFlashMessage('We were unable to promote the Admin. Please try again.', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('We were unable to promote the Admin. Please try again.', $this->session());
     }
 
     /**
@@ -122,7 +122,7 @@ final class SpeakersControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('admin/speakers', $response);
-        $this->assertSessionHasFlashMessage('User already is in the Admin group.', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('User already is in the Admin group.', $this->session());
     }
 
     /**
@@ -144,7 +144,7 @@ final class SpeakersControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('admin/speakers', $response);
-        $this->assertSessionHasFlashMessage('success', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('success', $this->session());
     }
 
     /**
@@ -183,7 +183,7 @@ final class SpeakersControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('/admin/speakers', $response);
-        $this->assertSessionHasFlashMessage('We were unable to remove the Admin. Please try again.', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('We were unable to remove the Admin. Please try again.', $this->session());
     }
 
     /**
@@ -206,7 +206,7 @@ final class SpeakersControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('/admin/speakers', $response);
-        $this->assertSessionHasFlashMessage('Sorry, you cannot remove yourself as Admin.', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('Sorry, you cannot remove yourself as Admin.', $this->session());
     }
 
     /**
@@ -233,7 +233,7 @@ final class SpeakersControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('/admin/speakers', $response);
-        $this->assertSessionHasFlashMessage('success', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('success', $this->session());
     }
 
     /**

--- a/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/DashboardControllerTest.php
@@ -40,6 +40,6 @@ final class DashboardControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful($response);
         $this->assertResponseBodyContains(self::$talks->first()->title, $response);
-        $this->assertSessionHasNoFlashMessage($this->container->get('session'));
+        $this->assertSessionHasNoFlashMessage($this->session());
     }
 }

--- a/tests/Integration/Http/Controller/SignupControllerTest.php
+++ b/tests/Integration/Http/Controller/SignupControllerTest.php
@@ -84,7 +84,7 @@ final class SignupControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('dashboard', $response);
-        $this->assertSessionHasFlashMessage("You've successfully created your account!", $this->container->get('session'));
+        $this->assertSessionHasFlashMessage("You've successfully created your account!", $this->session());
     }
 
     /**
@@ -110,7 +110,7 @@ final class SignupControllerTest extends WebTestCase
             'coc'            => 1,
         ]);
 
-        $this->assertSessionHasFlashMessage("You've successfully created your account!", $this->container->get('session'));
+        $this->assertSessionHasFlashMessage("You've successfully created your account!", $this->session());
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('dashboard', $response);
     }

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -113,8 +113,8 @@ final class TalkControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertResponseBodyNotContains('Edit Your Talk', $response);
-        $this->assertSessionHasFlashMessage('error', $this->container->get('session'));
-        $this->assertSessionHasFlashMessage('You cannot edit talks once the call for papers has ended', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('error', $this->session());
+        $this->assertSessionHasFlashMessage('You cannot edit talks once the call for papers has ended', $this->session());
     }
 
     /**
@@ -231,7 +231,7 @@ final class TalkControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertResponseBodyNotContains('Create Your Talk', $response);
-        $this->assertSessionHasFlashMessage('You cannot create talks once the call for papers has ended', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('You cannot create talks once the call for papers has ended', $this->session());
     }
 
     /**
@@ -253,7 +253,7 @@ final class TalkControllerTest extends WebTestCase
 
         $this->assertResponseIsRedirect($response);
         $this->assertResponseBodyNotContains('Create Your Talk', $response);
-        $this->assertSessionHasFlashMessage('You cannot create talks once the call for papers has ended', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('You cannot create talks once the call for papers has ended', $this->session());
     }
 
     /**
@@ -276,7 +276,7 @@ final class TalkControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful($response);
         $this->assertResponseBodyContains('Create Your Talk', $response);
-        $this->assertSessionHasFlashMessage('Error', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('Error', $this->session());
     }
 
     /**
@@ -316,7 +316,7 @@ final class TalkControllerTest extends WebTestCase
             ]);
 
         $this->assertResponseIsRedirect($response);
-        $this->assertSessionHasFlashMessage('Read Only', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('Read Only', $this->session());
     }
 
     /**
@@ -338,7 +338,7 @@ final class TalkControllerTest extends WebTestCase
             ]);
 
         $this->assertResponseIsSuccessful($response);
-        $this->assertSessionHasFlashMessage('Error', $this->container->get('session'));
+        $this->assertSessionHasFlashMessage('Error', $this->session());
     }
 
     /**

--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -32,6 +32,7 @@ use Pimple\Psr11\Container;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session;
 
 abstract class WebTestCase extends \Silex\WebTestCase
 {
@@ -240,5 +241,10 @@ abstract class WebTestCase extends \Silex\WebTestCase
         $identityProvider->overrideCurrentUser(new User(['id' => $id]));
 
         return $this;
+    }
+
+    final protected function session(): Session\SessionInterface
+    {
+        return $this->container->get('session');
     }
 }


### PR DESCRIPTION
This PR

* [x] extracts a method that fetches the session from the container

Follows #881.