### PR TITLE
Fix: Inject defaults in service provider

### DIFF
--- a/classes/Http/View/TalkHelper.php
+++ b/classes/Http/View/TalkHelper.php
@@ -31,47 +31,26 @@ class TalkHelper
     private $types;
 
     /**
-     * @param $categories
-     * @param $levels
-     * @param $types
+     * @param string[] $categories
+     * @param string[] $levels
+     * @param string[] $types
      */
-    public function __construct($categories, $levels, $types)
+    public function __construct(array $categories, array $levels, array $types)
     {
         $this->categories = $categories;
         $this->levels     = $levels;
         $this->types      = $types;
     }
     
-    public function getTalkCategories()
+    /**
+     * @return string[]
+     */
+    public function getTalkCategories(): array
     {
-        $categories = $this->categories;
-
-        if ($categories === null) {
-            $categories = [
-                'api'                => 'APIs (REST, SOAP, etc.)',
-                'continuousdelivery' => 'Continuous Delivery',
-                'database'           => 'Database',
-                'development'        => 'Development',
-                'devops'             => 'Devops',
-                'framework'          => 'Framework',
-                'ibmi'               => 'IBMi',
-                'javascript'         => 'JavaScript',
-                'security'           => 'Security',
-                'testing'            => 'Testing',
-                'uiux'               => 'UI/UX',
-                'other'              => 'Other',
-            ];
-        }
-
-        return $categories;
+        return $this->categories;
     }
 
-    /**
-     * @param $category
-     *
-     * @return mixed
-     */
-    public function getCategoryDisplayName($category)
+    public function getCategoryDisplayName(string $category): string
     {
         if (isset($this->categories[$category])) {
             return $this->categories[$category];
@@ -80,26 +59,15 @@ class TalkHelper
         return $category;
     }
 
-    public function getTalkTypes()
+    /**
+     * @return string[]
+     */
+    public function getTalkTypes(): array
     {
-        $types = $this->types;
-
-        if ($types === null) {
-            $types = [
-                'regular'  => 'Regular',
-                'tutorial' => 'Tutorial',
-            ];
-        }
-
-        return $types;
+        return $this->types;
     }
 
-    /**
-     * @param $type
-     *
-     * @return mixed
-     */
-    public function getTypeDisplayName($type)
+    public function getTypeDisplayName(string $type): string
     {
         if (isset($this->types[$type])) {
             return $this->types[$type];
@@ -108,27 +76,15 @@ class TalkHelper
         return $type;
     }
 
-    public function getTalkLevels()
+    /**
+     * @return string[]
+     */
+    public function getTalkLevels(): array
     {
-        $levels = $this->levels;
-
-        if ($levels === null) {
-            $levels = [
-                'entry'    => 'Entry level',
-                'mid'      => 'Mid-level',
-                'advanced' => 'Advanced',
-            ];
-        }
-
-        return $levels;
+        return $this->levels;
     }
 
-    /**
-     * @param $level
-     *
-     * @return mixed
-     */
-    public function getLevelDisplayName($level)
+    public function getLevelDisplayName(string $level): string
     {
         if (isset($this->levels[$level])) {
             return $this->levels[$level];

--- a/classes/Provider/TalkHelperProvider.php
+++ b/classes/Provider/TalkHelperProvider.php
@@ -22,10 +22,48 @@ final class TalkHelperProvider implements ServiceProviderInterface
     public function register(Container $app)
     {
         $app[TalkHelper::class] = function ($app) {
+            $categories = $app->config('talk.categories');
+
+            if ($categories === null) {
+                $categories = [
+                    'api'                => 'APIs (REST, SOAP, etc.)',
+                    'continuousdelivery' => 'Continuous Delivery',
+                    'database'           => 'Database',
+                    'development'        => 'Development',
+                    'devops'             => 'Devops',
+                    'framework'          => 'Framework',
+                    'ibmi'               => 'IBMi',
+                    'javascript'         => 'JavaScript',
+                    'security'           => 'Security',
+                    'testing'            => 'Testing',
+                    'uiux'               => 'UI/UX',
+                    'other'              => 'Other',
+                ];
+            }
+
+            $levels = $app->config('talk.levels');
+
+            if ($levels === null) {
+                $levels = [
+                    'entry'    => 'Entry level',
+                    'mid'      => 'Mid-level',
+                    'advanced' => 'Advanced',
+                ];
+            }
+
+            $types = $app->config('talk.types');
+
+            if ($types === null) {
+                $types = [
+                    'regular'  => 'Regular',
+                    'tutorial' => 'Tutorial',
+                ];
+            }
+
             return new TalkHelper(
-                $app->config('talk.categories'),
-                $app->config('talk.levels'),
-                $app->config('talk.types')
+                $categories,
+                $levels,
+                $types
             );
         };
     }

--- a/tests/Integration/Provider/TalkHelperProviderTest.php
+++ b/tests/Integration/Provider/TalkHelperProviderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Integration\Provider;
+
+use OpenCfp\Application;
+use OpenCFP\Http\View\TalkHelper;
+use OpenCFP\Provider\TalkHelperProvider;
+use PHPUnit\Framework;
+
+final class TalkHelperProviderTest extends Framework\TestCase
+{
+    public function testInjectsDefaultCategoriesIfNoneConfigured()
+    {
+        $app = $this->createApplicationWithEmptyConfiguration();
+
+        $app->register(new TalkHelperProvider());
+
+        /** @var TalkHelper $helper */
+        $helper = $app[TalkHelper::class];
+
+        $this->assertInstanceOf(TalkHelper::class, $helper);
+
+        $defaultCategories = [
+            'api'                => 'APIs (REST, SOAP, etc.)',
+            'continuousdelivery' => 'Continuous Delivery',
+            'database'           => 'Database',
+            'development'        => 'Development',
+            'devops'             => 'Devops',
+            'framework'          => 'Framework',
+            'ibmi'               => 'IBMi',
+            'javascript'         => 'JavaScript',
+            'security'           => 'Security',
+            'testing'            => 'Testing',
+            'uiux'               => 'UI/UX',
+            'other'              => 'Other',
+        ];
+
+        $this->assertSame($defaultCategories, $helper->getTalkCategories());
+    }
+    
+    public function testInjectsDefaultLevelsIfNoneConfigured()
+    {
+        $app = $this->createApplicationWithEmptyConfiguration();
+
+        $app->register(new TalkHelperProvider());
+
+        /** @var TalkHelper $helper */
+        $helper = $app[TalkHelper::class];
+
+        $this->assertInstanceOf(TalkHelper::class, $helper);
+
+        $defaultLevels = [
+            'entry'    => 'Entry level',
+            'mid'      => 'Mid-level',
+            'advanced' => 'Advanced',
+        ];
+
+        $this->assertSame($defaultLevels, $helper->getTalkLevels());
+    }
+
+    public function testInjectsDefaultTypesIfNoneConfigured()
+    {
+        $app = $this->createApplicationWithEmptyConfiguration();
+
+        $app->register(new TalkHelperProvider());
+
+        /** @var TalkHelper $helper */
+        $helper = $app[TalkHelper::class];
+
+        $this->assertInstanceOf(TalkHelper::class, $helper);
+
+        $defaultTypes = [
+            'regular'  => 'Regular',
+            'tutorial' => 'Tutorial',
+        ];
+
+        $this->assertSame($defaultTypes, $helper->getTalkTypes());
+    }
+
+    private function createApplicationWithEmptyConfiguration(): Application
+    {
+        $reflection = new \ReflectionClass(Application::class);
+
+        $application = $reflection->newInstanceWithoutConstructor();
+
+        $application['config'] = [];
+
+        return $application;
+    }
+}

--- a/tests/Unit/Http/View/TalkHelperTest.php
+++ b/tests/Unit/Http/View/TalkHelperTest.php
@@ -21,32 +21,6 @@ final class TalkHelperTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testGetTalkCategoriesReturnsDefaultCategoriesIfNoneHaveBeenInjected()
-    {
-        $helper = new TalkHelper(
-            null,
-            null,
-            null
-        );
-
-        $defaultCategories = [
-            'api'                => 'APIs (REST, SOAP, etc.)',
-            'continuousdelivery' => 'Continuous Delivery',
-            'database'           => 'Database',
-            'development'        => 'Development',
-            'devops'             => 'Devops',
-            'framework'          => 'Framework',
-            'ibmi'               => 'IBMi',
-            'javascript'         => 'JavaScript',
-            'security'           => 'Security',
-            'testing'            => 'Testing',
-            'uiux'               => 'UI/UX',
-            'other'              => 'Other',
-        ];
-
-        $this->assertSame($defaultCategories, $helper->getTalkCategories());
-    }
-
     public function testGetTalkCategoriesReturnsInjectedCategories()
     {
         $faker = $this->faker();
@@ -100,22 +74,6 @@ final class TalkHelperTest extends Framework\TestCase
         $this->assertSame($categoryDisplayName, $helper->getCategoryDisplayName($category));
     }
 
-    public function testGetTalkTypesReturnsDefaultTypesIfNoneHaveBeenInjected()
-    {
-        $helper = new TalkHelper(
-            null,
-            null,
-            null
-        );
-
-        $defaultTypes = [
-            'regular'  => 'Regular',
-            'tutorial' => 'Tutorial',
-        ];
-
-        $this->assertSame($defaultTypes, $helper->getTalkTypes());
-    }
-
     public function testGetTalkTypesReturnsInjectedTypes()
     {
         $faker = $this->faker();
@@ -167,23 +125,6 @@ final class TalkHelperTest extends Framework\TestCase
         );
 
         $this->assertSame($typeDisplayName, $helper->getTypeDisplayName($type));
-    }
-
-    public function testGetTalkLevelsReturnsDefaultTypesIfNoneHaveBeenInjected()
-    {
-        $helper = new TalkHelper(
-            null,
-            null,
-            null
-        );
-
-        $defaultLevels = [
-            'entry'    => 'Entry level',
-            'mid'      => 'Mid-level',
-            'advanced' => 'Advanced',
-        ];
-
-        $this->assertSame($defaultLevels, $helper->getTalkLevels());
     }
 
     public function testGetTalkLevelsReturnsInjectedLevels()


### PR DESCRIPTION
This PR

* [x] injects default categories, levels, and types in the service provider, rather than letting the `TalkHelper` handle defaults
* [ ] fixes a test