### PR TITLE
Fix: Do not use stdClass to mock something different

### DIFF
--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -15,6 +15,7 @@ namespace OpenCFP\Test\Unit\Http\Form;
 
 use Mockery as m;
 use OpenCFP\Http\Form\SignupForm;
+use Symfony\Component\HttpFoundation;
 
 /**
  * @covers \OpenCFP\Http\Form\SignupForm
@@ -34,7 +35,7 @@ final class SignupFormTest extends \PHPUnit\Framework\TestCase
     public function formRejectsValidationOnInvalidSpeakerPhoto()
     {
         // Mock speaker photo.
-        $photo = m::mock(\stdClass::class);
+        $photo = m::mock(HttpFoundation\File\UploadedFile::class);
         $photo->shouldReceive('isValid')->andReturn(false);
         $photo->shouldReceive('getErrorMessage')->andReturn('stubbed error message');
 


### PR DESCRIPTION
This PR

* [x] uses a concrete class when mocking instead of `stdClass`

💁‍♂️ There are other places where `stdClass` is used to mock something different, but it appears to be a lot of work to fix these tests. Maybe someone else is interested in fixing them?

Running

```
$ git grep stdClass
```

yields

```
tests/Unit/Application/SpeakersTest.php:154:    private function getSpeakerWithNoTalks(): \stdClass
tests/Unit/Application/SpeakersTest.php:157:        $stub = m::mock(\stdClass::class);
tests/Unit/Application/SpeakersTest.php:164:    private function getSpeakerFromMisbehavingRelation(): \stdClass
tests/Unit/Application/SpeakersTest.php:167:        $stub     = m::mock(\stdClass::class);
tests/Unit/Application/SpeakersTest.php:171:        $talk = m::mock(\stdClass::class);
tests/Unit/Application/SpeakersTest.php:184:    private function getSpeakerWithOneTalk(): \stdClass
tests/Unit/Application/SpeakersTest.php:187:        $stub     = m::mock(\stdClass::class);
tests/Unit/Application/SpeakersTest.php:191:        $talk = m::mock(\stdClass::class);
tests/Unit/Application/SpeakersTest.php:204:    private function getSpeakerWithManyTalks(): \stdClass
tests/Unit/Application/SpeakersTest.php:207:        $stub     = m::mock(\stdClass::class);
```