### PR TITLE
Fix: Adjust covers annotation

### DIFF
--- a/tests/Unit/Http/Action/DashboardActionTest.php
+++ b/tests/Unit/Http/Action/DashboardActionTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Routing;
 use Twig_Environment;
 
 /**
- * @coversNothing
+ * @covers \OpenCFP\Http\Action\DashboardAction
  */
 final class DashboardActionTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] adjusts a `@covers` annotation

Follows #912.
