### PR TITLE
Fix: Assert identity

### DIFF
--- a/tests/Unit/Http/Action/Page/HomePageActionTest.php
+++ b/tests/Unit/Http/Action/Page/HomePageActionTest.php
@@ -38,7 +38,7 @@ final class HomePageActionTest extends AbstractActionTestCase
         $action   = new HomePageAction($twig, false);
         $response = $action();
         $this->assertInstanceOf(HttpFoundation\Response::class, $response);
-        $this->assertContains($content, $response->getContent());
+        $this->assertSame($content, $response->getContent());
         $this->assertSame(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
     }
 }

--- a/tests/Unit/Http/Action/Page/SpeakerPackageActionTest.php
+++ b/tests/Unit/Http/Action/Page/SpeakerPackageActionTest.php
@@ -37,7 +37,7 @@ final class SpeakerPackageActionTest extends AbstractActionTestCase
         $action   = new SpeakerPackageAction($twig);
         $response = $action();
         $this->assertInstanceOf(HttpFoundation\Response::class, $response);
-        $this->assertContains($content, $response->getContent());
+        $this->assertSame($content, $response->getContent());
         $this->assertSame(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
     }
 }

--- a/tests/Unit/Http/Action/Page/TalkIdeasActionTest.php
+++ b/tests/Unit/Http/Action/Page/TalkIdeasActionTest.php
@@ -37,7 +37,7 @@ final class TalkIdeasActionTest extends AbstractActionTestCase
         $action   = new TalkIdeasAction($twig);
         $response = $action();
         $this->assertInstanceOf(HttpFoundation\Response::class, $response);
-        $this->assertContains($content, $response->getContent());
+        $this->assertSame($content, $response->getContent());
         $this->assertSame(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
This PR

* [x] uses `assertSame()` instead of `assertContains()`

Follows #926.