### PR TITLE
Don't swap the CSRF token validator

### DIFF
--- a/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
@@ -83,11 +83,16 @@ final class SpeakersControllerTest extends WebTestCase
      */
     public function promoteActionFailsOnUserNotFound()
     {
+        $csrfToken = $this->container->get('csrf.token_manager')
+            ->getToken('admin_speaker_promote')
+            ->getValue();
+
         $response = $this
             ->asAdmin()
-            ->passCsrfValidator()
             ->get('/admin/speakers/7679/promote', [
-                'role' => 'Admin',
+                'role'     => 'Admin',
+                'token'    => $csrfToken,
+                'token_id' => 'admin_speaker_promote',
             ]);
 
         $this->assertResponseIsRedirect($response);

--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -16,8 +16,6 @@ namespace OpenCFP\Test\Integration;
 use Mockery;
 use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Services\Authentication;
-use OpenCFP\Domain\Services\RequestValidator;
-use OpenCFP\Infrastructure\Auth\CsrfValidator;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\MockableAuthenticator;
@@ -217,15 +215,6 @@ abstract class WebTestCase extends BaseTestCase
         /** @var MockableAuthenticator $authentication */
         $authentication = $this->container->get(Authentication::class);
         $authentication->overrideUser($user);
-
-        return $this;
-    }
-
-    public function passCsrfValidator(): self
-    {
-        $csrf = Mockery::mock(RequestValidator::class);
-        $csrf->shouldReceive('isValid')->andReturn(true);
-        $this->swap(CsrfValidator::class, $csrf);
 
         return $this;
     }


### PR DESCRIPTION
This PR eliminates more service swapping on the container by using actual CSRF tokens in integration tests instead of mocking the CSRF validator.

Related to #618.
