### PR TITLE
Don't swap the CallForPapers service

### DIFF
--- a/classes/Domain/CallForPapers.php
+++ b/classes/Domain/CallForPapers.php
@@ -28,10 +28,7 @@ class CallForPapers
 
     public function __construct(\DateTimeImmutable $end)
     {
-        if ($end->format('H:i:s') === '00:00:00') {
-            $end = $end->add(new \DateInterval('P1D'));
-        }
-        $this->endDate = $end;
+        $this->setEndDate($end);
     }
 
     /**
@@ -46,5 +43,14 @@ class CallForPapers
         }
 
         return $currentTime < $this->endDate;
+    }
+
+    private function setEndDate(\DateTimeImmutable $end)
+    {
+        if ($end->format('H:i:s') === '00:00:00') {
+            $end = $end->add(new \DateInterval('P1D'));
+        }
+
+        $this->endDate = $end;
     }
 }

--- a/tests/Integration/Http/Controller/TalkControllerTest.php
+++ b/tests/Integration/Http/Controller/TalkControllerTest.php
@@ -85,7 +85,13 @@ final class TalkControllerTest extends WebTestCase
         // Previously, this fails because it checked midnight
         // for the current date. `isCfpOpen` now uses 11:59pm current date.
         $now = new \DateTime();
-        $this->swap(CallForPapers::class, new CallForPapers(new \DateTimeImmutable($now->format('M. jS, Y'))));
+
+        $cfp    = $this->container->get(CallForPapers::class);
+        $method = new \ReflectionMethod(CallForPapers::class, 'setEndDate');
+        $method->setAccessible(true);
+        $method->invoke($cfp, new \DateTimeImmutable($now->format('M. jS, Y')));
+
+        $this->container->get('twig')->addGlobal('cfp_open', $cfp->isOpen());
 
         /*
          * This should not have a flash message. The fact that this

--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -139,20 +139,24 @@ abstract class WebTestCase extends BaseTestCase
 
     public function callForPapersIsOpen(): self
     {
-        $cfp = Mockery::mock(CallForPapers::class);
-        $cfp->shouldReceive('isOpen')->andReturn(true);
-        $this->swap(CallForPapers::class, $cfp);
-        $this->container->get('twig')->addGlobal('cfp_open', true);
+        $cfp    = $this->container->get(CallForPapers::class);
+        $method = new \ReflectionMethod(CallForPapers::class, 'setEndDate');
+        $method->setAccessible(true);
+        $method->invoke($cfp, new \DateTimeImmutable('+1 week'));
+
+        $this->container->get('twig')->addGlobal('cfp_open', $cfp->isOpen());
 
         return $this;
     }
 
     public function callForPapersIsClosed(): self
     {
-        $cfp = Mockery::mock(CallForPapers::class);
-        $cfp->shouldReceive('isOpen')->andReturn(false);
-        $this->swap(CallForPapers::class, $cfp);
-        $this->container->get('twig')->addGlobal('cfp_open', false);
+        $cfp    = $this->container->get(CallForPapers::class);
+        $method = new \ReflectionMethod(CallForPapers::class, 'setEndDate');
+        $method->setAccessible(true);
+        $method->invoke($cfp, new \DateTimeImmutable('-1 week'));
+
+        $this->container->get('twig')->addGlobal('cfp_open', $cfp->isOpen());
 
         return $this;
     }


### PR DESCRIPTION
This PR uses reflection calls in integration tests to modify the `CallForPapers` service instead of swapping the whole service with a mocked one.

Related to #618.
