### PR TITLE
Render flash message on reset form and validate the form.

### DIFF
--- a/classes/Http/Form/ForgotForm.php
+++ b/classes/Http/Form/ForgotForm.php
@@ -17,12 +17,13 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ForgotForm extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('email', EmailType::class)
+        $builder->add('email', EmailType::class, ['constraints' => [new Assert\Email()]])
             ->add('send', SubmitType::class, ['label' => 'Reset my password']);
     }
 }

--- a/resources/views/security/forgot_password.twig
+++ b/resources/views/security/forgot_password.twig
@@ -5,6 +5,9 @@
             <img class="w-10 mr-2" src="/assets/img/logo.svg" alt="OpenCFP">
             <h1 class="font-normal text-white m-0">Open<span class="text-brand font-bold">CFP</span></h1>
         </a>
+
+        {% include "_flash.twig" %}
+
         <form id="forgot" class="form-horizontal" action="{{ url('forgot_password_create') }}" method="POST">
             {{ form_widget(form._token) }}
 


### PR DESCRIPTION
This PR adds validation to the reset form and makes sure that flash messages are displayed on that form.

Unfortunately, `ResetControllerTest` does not catch either of those issues because the form validation is mocked and the flash bag is accessed directly. I'm currently checking how to improve tests like that one.