### PR TITLE
Use Silex' test client for integration tests

### DIFF
--- a/classes/Infrastructure/Event/TwigGlobalsListener.php
+++ b/classes/Infrastructure/Event/TwigGlobalsListener.php
@@ -59,7 +59,7 @@ class TwigGlobalsListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::REQUEST => ['onKernelRequest', 256],
+            KernelEvents::REQUEST => ['onKernelRequest', 128],
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "localheinz/test-util": "~0.5.0",
         "mikey179/vfsStream": "^1.6.5",
         "mockery/mockery": "^1.0.0",
-        "phpunit/phpunit": "^6.5.1"
+        "phpunit/phpunit": "^6.5.1",
+        "symfony/browser-kit": "^3.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d113ed82c88d1508fb7fe42374c8581",
+    "content-hash": "70e2a7b25af7bcc508866145f326437b",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -5790,6 +5790,119 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/browser-kit",
+            "version": "v3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/browser-kit.git",
+                "reference": "f761b4ecdd23a451c2cae6fba704d8b207cbb045"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/f761b4ecdd23a451c2cae6fba704d8b207cbb045",
+                "reference": "f761b4ecdd23a451c2cae6fba704d8b207cbb045",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/dom-crawler": "~2.8|~3.0|~4.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "~2.8|~3.0|~4.0",
+                "symfony/process": "~2.8|~3.0|~4.0"
+            },
+            "suggest": {
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\BrowserKit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony BrowserKit Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-12-11T22:06:16+00:00"
+        },
+        {
+            "name": "symfony/dom-crawler",
+            "version": "v3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dom-crawler.git",
+                "reference": "dc847845c66fa68ad4522ed27e62b9b9dd12ab3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/dc847845c66fa68ad4522ed27e62b9b9dd12ab3b",
+                "reference": "dc847845c66fa68ad4522ed27e62b9b9dd12ab3b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "~2.8|~3.0|~4.0"
+            },
+            "suggest": {
+                "symfony/css-selector": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DomCrawler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DomCrawler Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-12-14T19:40:10+00:00"
         },
         {
             "name": "symfony/polyfill-php72",

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -21,8 +21,9 @@ use OpenCFP\Test\Helper\DataBaseInteraction;
 use OpenCFP\Test\Helper\RefreshDatabase;
 use Pimple\Psr11\Container;
 use Psr\Container\ContainerInterface;
+use Silex\WebTestCase;
 
-abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
+abstract class BaseTestCase extends WebTestCase
 {
     use Helper;
     use MockeryPHPUnitIntegration;
@@ -44,29 +45,19 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        if (!$this->app) {
-            $this->refreshApplication();
-        }
+        parent::setUp();
+
+        $this->refreshContainer();
         $this->runBeforeTestTraits();
     }
 
-    protected function tearDown()
-    {
-        if ($this->app) {
-            $this->app->flush();
-            $this->app       = null;
-            $this->container = null;
-        }
-    }
-
-    private function createApplication(): Application
+    public function createApplication()
     {
         return new Application(__DIR__ . '/..', Environment::testing());
     }
 
-    private function refreshApplication()
+    private function refreshContainer()
     {
-        $this->app       = $this->createApplication();
         $this->container = new Container($this->app);
     }
 

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -51,7 +51,9 @@ final class ForgotControllerTest extends WebTestCase
     public function sendResetDisplaysCorrectMessage()
     {
         $accounts = m::mock(AccountManagement::class);
-        $accounts->shouldReceive('findByLogin')->andReturn($this->createUser());
+        $accounts->shouldReceive('findByLogin')
+            ->withArgs(['someone@example.com'])
+            ->andReturn($this->createUser());
         $this->swap(AccountManagement::class, $accounts);
 
         // Override our reset_emailer service
@@ -59,18 +61,20 @@ final class ForgotControllerTest extends WebTestCase
         $resetEmailer->shouldReceive('send')->andReturn(true);
         $this->swap('reset_emailer', $resetEmailer);
 
-        // We need to create a replacement form.factory to return a form we control
-        $formFactory = m::mock(\Symfony\Component\Form\FormFactoryInterface::class);
-        $formFactory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('valid'));
-        $this->swap('form.factory', $formFactory);
+        $client = $this->createClient();
 
-        $this->post('/forgot');
+        $form = $client->request('GET', '/forgot')
+            ->selectButton('Reset Password')
+            ->form();
 
-        // As long as the email validates as being a potential email, the flash message should indicate success
-        $flashMessage = $this->container->get('session')->get('flash');
+        $form->setValues(['forgot_form' => ['email' => 'someone@example.com']]);
+
+        $client->followRedirects();
+        $client->submit($form);
+
         $this->assertContains(
             'If your email was valid, we sent a link to reset your password to',
-            $flashMessage['ext']
+            $client->getResponse()->getContent()
         );
     }
 
@@ -79,16 +83,20 @@ final class ForgotControllerTest extends WebTestCase
      */
     public function invalidResetFormTriggersErrorMessage()
     {
-        $formFactory = m::mock(\Symfony\Component\Form\FormFactoryInterface::class);
-        $formFactory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('not valid'));
-        $this->swap('form.factory', $formFactory);
+        $client = $this->createClient();
 
-        $this->post('/forgot');
+        $form = $client->request('GET', '/forgot')
+            ->selectButton('Reset Password')
+            ->form();
 
-        $flashMessage = $this->container->get('session')->get('flash');
+        $form->setValues(['forgot_form' => ['email' => 'INVALID']]);
+
+        $client->followRedirects();
+        $client->submit($form);
+
         $this->assertContains(
             'Please enter a properly formatted email address',
-            $flashMessage['ext']
+            $client->getResponse()->getContent()
         );
     }
 
@@ -97,16 +105,20 @@ final class ForgotControllerTest extends WebTestCase
      */
     public function resetPasswordNotFindingUserCorrectlyDisplaysMessage()
     {
-        $formFactory = m::mock(\Symfony\Component\Form\FormFactoryInterface::class);
-        $formFactory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('valid'));
-        $this->swap('form.factory', $formFactory);
+        $client = $this->createClient();
 
-        $this->post('/forgot');
+        $form = $client->request('GET', '/forgot')
+            ->selectButton('Reset Password')
+            ->form();
 
-        $flashMessage = $this->container->get('session')->get('flash');
+        $form->setValues(['forgot_form' => ['email' => 'someone@example.com']]);
+
+        $client->followRedirects();
+        $client->submit($form);
+
         $this->assertContains(
             'If your email was valid, we sent a link to reset your password to',
-            $flashMessage['ext']
+            $client->getResponse()->getContent()
         );
     }
 
@@ -124,18 +136,21 @@ final class ForgotControllerTest extends WebTestCase
         $resetEmailer->shouldReceive('send')->andReturn(false);
         $this->swap('reset_emailer', $resetEmailer);
 
-        // We need to create a replacement form.factory to return a form we control
-        $formFactory = m::mock(\Symfony\Component\Form\FormFactoryInterface::class);
-        $formFactory->shouldReceive('createBuilder->getForm')->andReturn($this->createForm('valid'));
-        $this->swap('form.factory', $formFactory);
+        $client = $this->createClient();
 
-        $this->post('/forgot');
+        $form = $client->request('GET', '/forgot')
+            ->selectButton('Reset Password')
+            ->form();
+
+        $form->setValues(['forgot_form' => ['email' => 'someone@example.com']]);
+
+        $client->followRedirects();
+        $client->submit($form);
 
         // As long as the email validates as being a potential email, the flash message should indicate success
-        $flashMessage = $this->container->get('session')->get('flash');
         $this->assertContains(
             'We were unable to send your password reset request. Please try again',
-            $flashMessage['ext']
+            $client->getResponse()->getContent()
         );
     }
 
@@ -146,17 +161,5 @@ final class ForgotControllerTest extends WebTestCase
         $user->shouldReceive('getId');
 
         return $user;
-    }
-
-    private function createForm($validStatus): \OpenCFP\Http\Form\ForgotForm
-    {
-        $isValid = ($validStatus == 'valid');
-        $form    = m::mock(\OpenCFP\Http\Form\ForgotForm::class);
-        $form->shouldReceive('handleRequest');
-        $form->shouldReceive('isValid')->andReturn($isValid);
-        $data = ['email' => 'test@opencfp.org'];
-        $form->shouldReceive('getData')->andReturn($data);
-
-        return $form;
     }
 }

--- a/tests/Integration/Infrastructure/Event/ExceptionListenerTest.php
+++ b/tests/Integration/Infrastructure/Event/ExceptionListenerTest.php
@@ -20,10 +20,7 @@ final class ExceptionListenerTest extends WebTestCase
 {
     public function testJsonOn404()
     {
-        $request = HttpFoundation\Request::create('/invalid/uri');
-        $request->headers->set('Accept', 'application/json');
-
-        $response = $this->app->handle($request);
+        $response = $this->get('/invalid/uri', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
 
         $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_NOT_FOUND, $response);
         $this->assertResponseHeader('application/json', 'Content-Type', $response);

--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -20,7 +20,7 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\MockableAuthenticator;
 use OpenCFP\Test\Helper\ResponseHelper;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class WebTestCase extends BaseTestCase
@@ -56,65 +56,17 @@ abstract class WebTestCase extends BaseTestCase
         return $instance;
     }
 
-    /**
-     * Define additional headers to be sent with the request.
-     *
-     * @param array $headers
-     *
-     * @return $this
-     */
-    public function withHeaders(array $headers): self
-    {
-        $this->headers = \array_merge($this->headers, $headers);
-
-        return $this;
-    }
-
-    /**
-     * Add a header to be sent with the request.
-     *
-     * @param string $name
-     * @param string $value
-     *
-     * @return $this
-     */
-    public function withHeader(string $name, string $value): self
-    {
-        $this->headers[$name] = $value;
-
-        return $this;
-    }
-
-    public function withNoHeaders()
-    {
-        $this->headers = [];
-
-        return $this;
-    }
-
-    public function withServerVariables(array $server): self
-    {
-        $this->server = $server;
-
-        return $this;
-    }
-
     public function call(string $method, string $uri, array $parameters = [], array $cookies = [], array $files = [], array $server = [], string $content = null): Response
     {
-        $request = Request::create(
-            $uri,
-            $method,
-            $parameters,
-            $cookies,
-            $files,
-            \array_replace($this->server, $server),
-            $content
-        );
+        $client = $this->createClient();
 
-        $response = $this->app->handle($request);
-        $this->app->terminate($request, $response);
+        foreach ($cookies as $key => $value) {
+            $client->getCookieJar()->set(new Cookie($key, $value));
+        }
 
-        return $response;
+        $client->request($method, $uri, $parameters, $files, $server, $content);
+
+        return $client->getResponse();
     }
 
     public function get(string $uri, array $parameters = [], array $cookies = [], array $files = [], array $server = [], string $content = null): Response


### PR DESCRIPTION
This PR integrates Silex' test client into the integration test suite. This allows us to emulate user interaction better and with less mocking.

The PR also contains a better `ResetControllerTest` that covers the issue fixed by PR #933.

Follows #933.
Related to #618.
