### PR TITLE
Fix: Move integration test into appropriate namespace

### DIFF
--- a/tests/Integration/Provider/SentinelServiceProviderTest.php
+++ b/tests/Integration/Provider/SentinelServiceProviderTest.php
@@ -11,14 +11,11 @@ declare(strict_types=1);
  * @see https://github.com/opencfp/opencfp
  */
 
-namespace OpenCFP\Test\Unit\Provider;
+namespace OpenCFP\Test\Integration\Provider;
 
 use Cartalyst\Sentinel\Sentinel;
 use OpenCFP\Test\BaseTestCase;
 
-/**
- * @covers \OpenCFP\Provider\SentinelServiceProvider
- */
 final class SentinelServiceProviderTest extends BaseTestCase
 {
     public function testAllRepositoriesAreSet()

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -76,6 +76,7 @@ final class ProjectCodeTest extends Framework\TestCase
                 Provider\HtmlPurifierServiceProvider::class,
                 Provider\ImageProcessorProvider::class,
                 Provider\ResetEmailerServiceProvider::class,
+                Provider\SentinelServiceProvider::class,
                 Provider\TalkFilterProvider::class,
                 Provider\TalkHandlerProvider::class,
                 Provider\TalkHelperProvider::class,


### PR DESCRIPTION
This PR

* [x] moves an integration test into the appropriate namespace

Blocks #936.

/cc @derrabus