### PR TITLE
Fix: Mark methods as final to prevent multiple imports

### DIFF
--- a/tests/Helper/DataBaseInteraction.php
+++ b/tests/Helper/DataBaseInteraction.php
@@ -17,12 +17,12 @@ use Illuminate\Database\Capsule\Manager;
 
 trait DataBaseInteraction
 {
-    protected function resetDatabase()
+    final protected function resetDatabase()
     {
         $this->getCapsule()->getConnection()->unprepared(\file_get_contents(__DIR__ . '/../dump.sql'));
     }
 
-    protected function getCapsule(): Manager
+    final protected function getCapsule(): Manager
     {
         return $this->container->get(Manager::class);
     }

--- a/tests/Helper/RefreshDatabase.php
+++ b/tests/Helper/RefreshDatabase.php
@@ -17,12 +17,12 @@ use Illuminate\Database\Capsule\Manager;
 
 trait RefreshDatabase
 {
-    protected static function setUpDatabase()
+    final protected static function setUpDatabase()
     {
         self::createCapsule()->getConnection()->unprepared(\file_get_contents(__DIR__ . '/../dump.sql'));
     }
 
-    protected static function createCapsule(): Manager
+    final protected static function createCapsule(): Manager
     {
         $capsule = new Manager();
 


### PR DESCRIPTION
This PR

* [x] marks methods provided by test helper traits as `final`

Related to #936.

💁‍♂️ This is useful to prevent multiple imports, as well as tests attempting to override these methods.