### PR TITLE
Fix: Assert that flash is not null

### DIFF
--- a/tests/Helper/ResponseHelper.php
+++ b/tests/Helper/ResponseHelper.php
@@ -149,7 +149,10 @@ trait ResponseHelper
 
     final protected function assertSessionHasFlashMessage(string $message, HttpFoundation\Session\SessionInterface $session)
     {
-        $this->assertContains($message, $session->get('flash'), \sprintf(
+        $flash = $session->get('flash');
+
+        $this->assertNotNull($flash, 'Failed asserting that the session has flash messages.');
+        $this->assertContains($message, $flash, \sprintf(
             'Failed asserting that the session has a flash message "%s".',
             $message
         ));


### PR DESCRIPTION
This PR

* [x] asserts that flash pulled from session is not `null`
