### PR TITLE
Don't swap the speakers service

### DIFF
--- a/classes/Provider/TestingServiceProvider.php
+++ b/classes/Provider/TestingServiceProvider.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace OpenCFP\Provider;
 
 use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Test\Helper\MockableAuthenticator;
+use OpenCFP\Test\Helper\MockableIdentityProvider;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
@@ -24,6 +26,9 @@ final class TestingServiceProvider implements ServiceProviderInterface
     {
         $app->extend(Authentication::class, function (Authentication $authentication) {
             return new MockableAuthenticator($authentication);
+        });
+        $app->extend(IdentityProvider::class, function (IdentityProvider $identityProvider) {
+            return new MockableIdentityProvider($identityProvider);
         });
     }
 }

--- a/tests/Helper/MockableIdentityProvider.php
+++ b/tests/Helper/MockableIdentityProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Helper;
+
+use OpenCFP\Domain\Model\User;
+use OpenCFP\Domain\Services\IdentityProvider;
+
+final class MockableIdentityProvider implements IdentityProvider
+{
+    private $wrapped;
+
+    private $currentUser;
+
+    public function __construct(IdentityProvider $wrapped)
+    {
+        $this->wrapped = $wrapped;
+    }
+
+    public function overrideCurrentUser(User $user = null)
+    {
+        $this->currentUser = $user;
+    }
+
+    public function reset()
+    {
+        $this->currentUser = null;
+    }
+
+    public function getCurrentUser(): User
+    {
+        return $this->currentUser ?: $this->wrapped->getCurrentUser();
+    }
+}

--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -15,10 +15,13 @@ namespace OpenCFP\Test\Integration;
 
 use Mockery;
 use OpenCFP\Domain\CallForPapers;
+use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\Authentication;
+use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Test\BaseTestCase;
 use OpenCFP\Test\Helper\MockableAuthenticator;
+use OpenCFP\Test\Helper\MockableIdentityProvider;
 use OpenCFP\Test\Helper\ResponseHelper;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Response;
@@ -134,6 +137,10 @@ abstract class WebTestCase extends BaseTestCase
         $authentication = $this->container->get(Authentication::class);
         $authentication->overrideUser($user);
 
+        /** @var MockableIdentityProvider $identityProvider */
+        $identityProvider = $this->container->get(IdentityProvider::class);
+        $identityProvider->overrideCurrentUser(new User(['id' => $id]));
+
         return $this;
     }
 
@@ -151,6 +158,10 @@ abstract class WebTestCase extends BaseTestCase
         $authentication = $this->container->get(Authentication::class);
         $authentication->overrideUser($user);
 
+        /** @var MockableIdentityProvider $identityProvider */
+        $identityProvider = $this->container->get(IdentityProvider::class);
+        $identityProvider->overrideCurrentUser(new User(['id' => $id]));
+
         return $this;
     }
 
@@ -167,6 +178,10 @@ abstract class WebTestCase extends BaseTestCase
         /** @var MockableAuthenticator $authentication */
         $authentication = $this->container->get(Authentication::class);
         $authentication->overrideUser($user);
+
+        /** @var MockableIdentityProvider $identityProvider */
+        $identityProvider = $this->container->get(IdentityProvider::class);
+        $identityProvider->overrideCurrentUser(new User(['id' => $id]));
 
         return $this;
     }


### PR DESCRIPTION
This PR removes all swapping of the `application.speakers` service.

Related to #618.
