### PR TITLE
Moved SymfonySentinelSession out of the Provider namespace

### DIFF
--- a/classes/Infrastructure/Auth/SymfonySentinelSession.php
+++ b/classes/Infrastructure/Auth/SymfonySentinelSession.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/opencfp/opencfp
  */
 
-namespace OpenCFP\Provider;
+namespace OpenCFP\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sessions\SessionInterface as SentinelSessionInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface as SymfonySessionInterface;

--- a/classes/Provider/SentinelServiceProvider.php
+++ b/classes/Provider/SentinelServiceProvider.php
@@ -24,6 +24,7 @@ use Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository;
 use Cartalyst\Sentinel\Users\IlluminateUserRepository;
 use Cartalyst\Sentinel\Users\UserRepositoryInterface;
 use Illuminate\Contracts\Events\Dispatcher;
+use OpenCFP\Infrastructure\Auth\SymfonySentinelSession;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 

--- a/tests/Unit/Infrastructure/Auth/SymfonySentinelSessionTest.php
+++ b/tests/Unit/Infrastructure/Auth/SymfonySentinelSessionTest.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * @see https://github.com/opencfp/opencfp
  */
 
-namespace OpenCFP\Test\Unit\Provider;
+namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Localheinz\Test\Util\Helper;
 use Mockery;
-use OpenCFP\Provider\SymfonySentinelSession;
+use OpenCFP\Infrastructure\Auth\SymfonySentinelSession;
 
 /**
- * @covers \OpenCFP\Provider\SymfonySentinelSession
+ * @covers \OpenCFP\Infrastructure\Auth\SymfonySentinelSession
  */
 final class SymfonySentinelSessionTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
This PR moves the class `SymfonySentinelSession` out of the provider namespace as it is not really a service provider. Plus, when switching to Symfony, that class would be the only one left in that namespace.

Related to #618.
