### PR TITLE
Removed switch to disable the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ $ bin/opencfp user:create --first_name="Admin" --last_name="Name" --email="admin
 
 ### [Clear Caches](#clear-caches)
 
-OpenCFP uses Twig as a templating engine and HTML Purifier for input filtering. Both of these packages maintain a cache,
-if enabled. If you need to clear all application caches:
+OpenCFP uses Twig as a templating engine and HTML Purifier for input filtering. Both of these packages maintain a cache.
+If you need to clear all application caches:
 
 ```
 $ bin/opencfp cache:clear
@@ -383,4 +383,4 @@ The default phpunit.xml.dist file is in the root directory for the project.
 **I'm getting weird permissions-related errors to do with HTML Purifier.**
 
 You may need to edit directory permissions for some vendor packages such as HTML Purifier. Check the `/cache` directory's
-permissions first (if you have `cache.enabled` set to `true`).
+permissions first.

--- a/classes/Provider/HtmlPurifierServiceProvider.php
+++ b/classes/Provider/HtmlPurifierServiceProvider.php
@@ -28,17 +28,15 @@ final class HtmlPurifierServiceProvider implements ServiceProviderInterface
         $app['purifier'] = function ($app) {
             $config = HTMLPurifier_Config::createDefault();
 
-            if ($app->config('cache.enabled')) {
-                $cachePermissions = 0755;
-                $config->set('Cache.SerializerPermissions', $cachePermissions);
-                $cacheDirectory = $app['path']->cachePurifierPath();
+            $cachePermissions = 0755;
+            $config->set('Cache.SerializerPermissions', $cachePermissions);
+            $cacheDirectory = $app['path']->cachePurifierPath();
 
-                if (!\is_dir($cacheDirectory)) {
-                    \mkdir($cacheDirectory, $cachePermissions, true);
-                }
-
-                $config->set('Cache.SerializerPath', $cacheDirectory);
+            if (!\is_dir($cacheDirectory)) {
+                \mkdir($cacheDirectory, $cachePermissions, true);
             }
+
+            $config->set('Cache.SerializerPath', $cacheDirectory);
 
             return new HTMLPurifier($config);
         };

--- a/classes/Provider/TwigServiceProvider.php
+++ b/classes/Provider/TwigServiceProvider.php
@@ -41,7 +41,7 @@ final class TwigServiceProvider implements ServiceProviderInterface, EventListen
             'twig.path'    => $app['path']->templatesPath(),
             'twig.options' => [
                 'debug' => !$app['env']->isProduction(),
-                'cache' => $app->config('cache.enabled') ? $app['path']->cacheTwigPath() : false,
+                'cache' => $app['path']->cacheTwigPath(),
             ],
         ]);
 

--- a/config/development.dist.yml
+++ b/config/development.dist.yml
@@ -17,9 +17,6 @@ application:
   show_contrib_banner: true
   venue_image_path: /assets/img/venue.jpg
 
-cache:
-  enabled: false
-
 database:
   host: 127.0.0.1
   database: cfp

--- a/config/production.dist.yml
+++ b/config/production.dist.yml
@@ -17,9 +17,6 @@ application:
   show_contrib_banner: true
   venue_image_path: /assets/img/venue.jpg
 
-cache:
-  enabled: false
-
 database:
   host: 127.0.0.1
   database: cfp

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -16,9 +16,6 @@ application:
   show_contrib_banner: true
   venue_image_path: /assets/img/venue.jpg
 
-cache:
-  enabled: false
-
 database:
   host: 127.0.0.1
   database: cfp_test


### PR DESCRIPTION
This PR removes the switch to disable the cache. Once we switch to Symfony, we don't have a choice but to maintain a cache directory, because Symfony operates on a compiled container and router and therefore requires a cache.

Related to #618.
Preparation for #895.
