### PR TITLE
Removed remaining calls to WebTestCase::swap()

### DIFF
--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -112,21 +112,6 @@ abstract class WebTestCase extends \Silex\WebTestCase
         }
     }
 
-    /**
-     * Swap implementations of a service in the container.
-     *
-     * @param string $service
-     * @param object $instance
-     *
-     * @return object
-     */
-    protected function swap($service, $instance)
-    {
-        $this->app[$service] = $instance;
-
-        return $instance;
-    }
-
     public function call(string $method, string $uri, array $parameters = [], array $cookies = [], array $files = [], array $server = [], string $content = null): Response
     {
         $client = $this->createClient();
@@ -188,7 +173,6 @@ abstract class WebTestCase extends \Silex\WebTestCase
     {
         $config                                     = $this->container->get('config');
         $config['application']['online_conference'] = true;
-        $this->swap('config', $config);
         $this->container->get('twig')->addGlobal('site', $config['application']);
 
         return $this;


### PR DESCRIPTION
This PR removes the remaining calls to the `WebTestCase::swap()` method. That means that our integration tests do not modify the container anymore, which is very helpful for the Symfony migration.

Unfortunately, I had to kill one test case for this. I don't see a good way to simulate inside an integration test that the reset email could not be sent. It would probably be better to cover this with unit tests.

Follows #618.
Prepares #895.
