### PR TITLE
Type-hint for the interface instead of the implementation.

### DIFF
--- a/classes/Infrastructure/Auth/CsrfValidator.php
+++ b/classes/Infrastructure/Auth/CsrfValidator.php
@@ -16,16 +16,16 @@ namespace OpenCFP\Infrastructure\Auth;
 use OpenCFP\Domain\Services\RequestValidator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfToken;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 final class CsrfValidator implements RequestValidator
 {
     /**
-     * @var CsrfTokenManager
+     * @var CsrfTokenManagerInterface
      */
     private $manager;
 
-    public function __construct(CsrfTokenManager $manager)
+    public function __construct(CsrfTokenManagerInterface $manager)
     {
         $this->manager = $manager;
     }

--- a/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
+++ b/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
@@ -19,7 +19,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenCFP\Domain\Services\RequestValidator;
 use OpenCFP\Infrastructure\Auth\CsrfValidator;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * @covers \OpenCFP\Infrastructure\Auth\CsrfValidator
@@ -41,7 +41,7 @@ final class CsrfValidatorTest extends \PHPUnit\Framework\TestCase
 
     public function testReturnsTrueWhenTokenMangerReturnsTrue()
     {
-        $manager = Mockery::mock(CsrfTokenManager::class);
+        $manager = Mockery::mock(CsrfTokenManagerInterface::class);
         $manager->shouldReceive('isTokenValid')->andReturn(true);
         $request = Mockery::mock(Request::class);
         $request->shouldReceive('get')->once()->with('token_id');
@@ -53,7 +53,7 @@ final class CsrfValidatorTest extends \PHPUnit\Framework\TestCase
 
     public function testReturnsFalseWhenTokenManagersReturnsFalse()
     {
-        $manager = Mockery::mock(CsrfTokenManager::class);
+        $manager = Mockery::mock(CsrfTokenManagerInterface::class);
         $manager->shouldReceive('isTokenValid')->andReturn(false);
         $request = Mockery::mock(Request::class);
 


### PR DESCRIPTION
This PR replaces `CsrfTokenManager` with `CsrfTokenManagerInterface`in type-hints.