### PR TITLE
Fix: Remove covers annotations

### DIFF
--- a/tests/Integration/MigrationsTest.php
+++ b/tests/Integration/MigrationsTest.php
@@ -21,8 +21,6 @@ use Symfony\Component\Console\Output\BufferedOutput;
 /**
  * This test makes sure our migrations work correctly.
  * There is no test for migrating 'down' all the way, since that is known to be broken
- *
- * @coversNothing
  */
 final class MigrationsTest extends WebTestCase
 {

--- a/tests/Unit/Application/NotAuthorizedExceptionTest.php
+++ b/tests/Unit/Application/NotAuthorizedExceptionTest.php
@@ -17,9 +17,6 @@ use Localheinz\Test\Util\Helper;
 use OpenCFP\Application\NotAuthorizedException;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Application\NotAuthorizedException
- */
 final class NotAuthorizedExceptionTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -21,9 +21,6 @@ use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Services\IdentityProvider;
 
-/**
- * @covers \OpenCFP\Application\Speakers
- */
 final class SpeakersTest extends \PHPUnit\Framework\TestCase
 {
     use MockeryPHPUnitIntegration;

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -16,10 +16,6 @@ namespace OpenCFP\Test\Unit;
 use OpenCFP\Application;
 use OpenCFP\Environment;
 
-/**
- * @covers \OpenCFP\Application
- * @group db
- */
 final class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
     /** @var Application */

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -19,10 +19,6 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenCFP\Console\Application;
 use Symfony\Component\Console;
 
-/**
- * @group db
- * @covers \OpenCFP\Console\Application
- */
 final class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Console/Command/ClearCacheCommandTest.php
+++ b/tests/Unit/Console/Command/ClearCacheCommandTest.php
@@ -19,9 +19,6 @@ use org\bovigo\vfs;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
 
-/**
- * @covers \OpenCFP\Console\Command\ClearCacheCommand
- */
 final class ClearCacheCommandTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -20,9 +20,6 @@ use OpenCFP\Infrastructure\Auth;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
 
-/**
- * @covers \OpenCFP\Console\Command\UserCreateCommand
- */
 final class UserCreateCommandTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Console/Command/UserDemoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserDemoteCommandTest.php
@@ -20,9 +20,6 @@ use OpenCFP\Infrastructure\Auth;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
 
-/**
- * @covers \OpenCFP\Console\Command\UserDemoteCommand
- */
 final class UserDemoteCommandTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Console/Command/UserPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserPromoteCommandTest.php
@@ -20,9 +20,6 @@ use OpenCFP\Infrastructure\Auth;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
 
-/**
- * @covers \OpenCFP\Console\Command\UserPromoteCommand
- */
 final class UserPromoteCommandTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Domain/CallForPapersTest.php
+++ b/tests/Unit/Domain/CallForPapersTest.php
@@ -15,9 +15,6 @@ namespace OpenCFP\Test\Unit\Domain;
 
 use OpenCFP\Domain\CallForPapers;
 
-/**
- * @covers \OpenCFP\Domain\CallForPapers
- */
 final class CallForPapersTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Unit/Domain/EntityNotFoundExceptionTest.php
+++ b/tests/Unit/Domain/EntityNotFoundExceptionTest.php
@@ -17,9 +17,6 @@ use Localheinz\Test\Util\Helper;
 use OpenCFP\Domain\EntityNotFoundException;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Domain\EntityNotFoundException
- */
 final class EntityNotFoundExceptionTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
+++ b/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
@@ -17,9 +17,6 @@ use Localheinz\Test\Util\Helper;
 use OpenCFP\Domain\Services\AuthenticationException;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Domain\Services\AuthenticationException
- */
 final class AuthenticationExceptionTest extends Framework\TestCase
 {
     use Helper;
@@ -28,7 +25,7 @@ final class AuthenticationExceptionTest extends Framework\TestCase
     {
         $this->assertClassIsFinal(AuthenticationException::class);
     }
-    
+
     public function testIsRuntimeException()
     {
         $this->assertClassExtends(\RuntimeException::class, AuthenticationException::class);

--- a/tests/Unit/Domain/Services/NotAuthenticatedExceptionTest.php
+++ b/tests/Unit/Domain/Services/NotAuthenticatedExceptionTest.php
@@ -17,9 +17,6 @@ use Localheinz\Test\Util\Helper;
 use OpenCFP\Domain\Services\NotAuthenticatedException;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Domain\Services\NotAuthenticatedException
- */
 final class NotAuthenticatedExceptionTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Domain/Services/PaginationTest.php
+++ b/tests/Unit/Domain/Services/PaginationTest.php
@@ -17,9 +17,6 @@ use OpenCFP\Domain\Services\Pagination;
 use Pagerfanta\Pagerfanta;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Domain\Services\Pagination
- */
 final class PaginationTest extends Framework\TestCase
 {
     /**

--- a/tests/Unit/Domain/Services/ResetEmailerTest.php
+++ b/tests/Unit/Domain/Services/ResetEmailerTest.php
@@ -20,9 +20,6 @@ use Swift_Mailer;
 use Swift_Message;
 use Twig_Template;
 
-/**
- * @covers \OpenCFP\Domain\Services\ResetEmailer
- */
 final class ResetEmailerTest extends \PHPUnit\Framework\TestCase
 {
     use MockeryPHPUnitIntegration;

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingContextTest.php
@@ -20,9 +20,6 @@ use OpenCFP\Domain\Services\TalkRating\TalkRatingStrategy;
 use OpenCFP\Domain\Services\TalkRating\YesNoRating;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 
-/**
- * @covers \OpenCFP\Domain\Services\TalkRating\TalkRatingContext
- */
 final class TalkRatingContextTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingExceptionTest.php
@@ -17,9 +17,6 @@ use Localheinz\Test\Util\Helper;
 use OpenCFP\Domain\Services\TalkRating\TalkRatingException;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Domain\Services\TalkRating\TalkRatingException
- */
 final class TalkRatingExceptionTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/TalkRatingTest.php
@@ -22,8 +22,6 @@ use OpenCFP\Infrastructure\Auth\UserInterface;
 
 /**
  * We Use the YesNoRating class to test the base class, since we know exactly what values are allowed
- *
- * @covers \OpenCFP\Domain\Services\TalkRating\TalkRating
  */
 final class TalkRatingTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
+++ b/tests/Unit/Domain/Services/TalkRating/YesNoRatingTest.php
@@ -20,9 +20,6 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Domain\Services\TalkRating\YesNoRating;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 
-/**
- * @covers \OpenCFP\Domain\Services\TalkRating\YesNoRating
- */
 final class YesNoRatingTest extends \PHPUnit\Framework\TestCase
 {
     use MockeryPHPUnitIntegration;

--- a/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
+++ b/tests/Unit/Domain/Speaker/NotAllowedExceptionTest.php
@@ -17,9 +17,6 @@ use Localheinz\Test\Util\Helper;
 use OpenCFP\Domain\Speaker\NotAllowedException;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Domain\Speaker\NotAllowedException
- */
 final class NotAllowedExceptionTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -20,9 +20,6 @@ use OpenCFP\Domain\Speaker\NotAllowedException;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Domain\Speaker\SpeakerProfile
- */
 final class SpeakerProfileTest extends Framework\TestCase
 {
     use Helper;
@@ -83,7 +80,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'talks',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -117,7 +114,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'name',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -155,7 +152,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'email',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -183,7 +180,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'company',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -211,7 +208,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'twitter',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -239,7 +236,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'url',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -267,7 +264,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'info',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -295,7 +292,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'bio',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -317,13 +314,13 @@ final class SpeakerProfileTest extends Framework\TestCase
 
         $this->assertSame($bio, $profile->getBio());
     }
-    
+
     public function testGetTransportationThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'transportation',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);

--- a/tests/Unit/Domain/Talk/TalkFilterTest.php
+++ b/tests/Unit/Domain/Talk/TalkFilterTest.php
@@ -20,9 +20,6 @@ use OpenCFP\Domain\Talk\TalkFilter;
 use OpenCFP\Domain\Talk\TalkFormatter;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Domain\Talk\TalkFilter
- */
 final class TalkFilterTest extends Framework\TestCase
 {
     use MockeryPHPUnitIntegration;

--- a/tests/Unit/Domain/Talk/TalkProfileTest.php
+++ b/tests/Unit/Domain/Talk/TalkProfileTest.php
@@ -24,9 +24,6 @@ use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Domain\Talk\TalkProfile;
 
-/**
- * @covers \OpenCFP\Domain\Talk\TalkProfile
- */
 final class TalkProfileTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Domain/ValidationExceptionTest.php
+++ b/tests/Unit/Domain/ValidationExceptionTest.php
@@ -17,9 +17,6 @@ use Localheinz\Test\Util\Helper;
 use OpenCFP\Domain\ValidationException;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Domain\ValidationException
- */
 final class ValidationExceptionTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -15,9 +15,6 @@ namespace OpenCFP\Test\Unit;
 
 use OpenCFP\Environment;
 
-/**
- * @covers \OpenCFP\Environment
- */
 final class EnvironmentTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstants()
@@ -26,11 +23,11 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('development', Environment::TYPE_DEVELOPMENT);
         $this->assertSame('testing', Environment::TYPE_TESTING);
     }
-    
+
     public function testProductionReturnsEnvironment()
     {
         $environment = Environment::production();
-        
+
         $this->assertInstanceOf(Environment::class, $environment);
         $this->assertTrue($environment->isProduction());
         $this->assertFalse($environment->isDevelopment());

--- a/tests/Unit/Http/Action/DashboardActionTest.php
+++ b/tests/Unit/Http/Action/DashboardActionTest.php
@@ -20,9 +20,6 @@ use OpenCFP\Http\Action\DashboardAction;
 use PHPUnit\Framework;
 use Symfony\Component\HttpFoundation;
 
-/**
- * @covers \OpenCFP\Http\Action\DashboardAction
- */
 final class DashboardActionTest extends AbstractActionTestCase
 {
     public function testRedirectsToLoginIfUserIsNotAuthenticated()

--- a/tests/Unit/Http/Action/Page/HomePageActionTest.php
+++ b/tests/Unit/Http/Action/Page/HomePageActionTest.php
@@ -17,9 +17,6 @@ use OpenCFP\Http\Action\Page\HomePageAction;
 use OpenCFP\Test\Unit\Http\Action\AbstractActionTestCase;
 use Symfony\Component\HttpFoundation;
 
-/**
- * @covers \OpenCFP\Http\Action\Page\HomePageAction
- */
 final class HomePageActionTest extends AbstractActionTestCase
 {
     public function testItReturnsTheCorrectContentIfNoSubmissionCountNeedsToBeShown()

--- a/tests/Unit/Http/Action/Page/SpeakerPackageActionTest.php
+++ b/tests/Unit/Http/Action/Page/SpeakerPackageActionTest.php
@@ -17,9 +17,6 @@ use OpenCFP\Http\Action\Page\SpeakerPackageAction;
 use OpenCFP\Test\Unit\Http\Action\AbstractActionTestCase;
 use Symfony\Component\HttpFoundation;
 
-/**
- * @covers \OpenCFP\Http\Action\Page\SpeakerPackageAction
- */
 final class SpeakerPackageActionTest extends AbstractActionTestCase
 {
     public function testItReturnsTheContentOfTheTwigInAResponseObject()

--- a/tests/Unit/Http/Action/Page/TalkIdeasActionTest.php
+++ b/tests/Unit/Http/Action/Page/TalkIdeasActionTest.php
@@ -17,9 +17,6 @@ use OpenCFP\Http\Action\Page\TalkIdeasAction;
 use OpenCFP\Test\Unit\Http\Action\AbstractActionTestCase;
 use Symfony\Component\HttpFoundation;
 
-/**
- * @covers \OpenCFP\Http\Action\Page\TalkIdeasAction
- */
 final class TalkIdeasActionTest extends AbstractActionTestCase
 {
     public function testItReturnsTheContentOfTheTwigInAResponseObject()

--- a/tests/Unit/Http/Action/Talk/ViewActionTest.php
+++ b/tests/Unit/Http/Action/Talk/ViewActionTest.php
@@ -21,9 +21,6 @@ use OpenCFP\Test\Unit\Http\Action\AbstractActionTestCase;
 use PHPUnit\Framework;
 use Symfony\Component\HttpFoundation;
 
-/**
- * @covers \OpenCFP\Http\Action\Talk\ViewAction
- */
 final class ViewActionTest extends AbstractActionTestCase
 {
     public function testRedirectsToDashboardIfUserIsNotAuthorized()

--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -17,9 +17,6 @@ use Mockery as m;
 use OpenCFP\Http\Form\SignupForm;
 use Symfony\Component\HttpFoundation;
 
-/**
- * @covers \OpenCFP\Http\Form\SignupForm
- */
 final class SignupFormTest extends \PHPUnit\Framework\TestCase
 {
     private $purifier;

--- a/tests/Unit/Http/Form/TalkFormTest.php
+++ b/tests/Unit/Http/Form/TalkFormTest.php
@@ -15,9 +15,6 @@ namespace OpenCFP\Test\Unit\Http\Form;
 
 use Localheinz\Test\Util\Helper;
 
-/**
- * @covers \OpenCFP\Http\Form\TalkForm
- */
 final class TalkFormTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
+++ b/tests/Unit/Infrastructure/Auth/CsrfValidatorTest.php
@@ -21,9 +21,6 @@ use OpenCFP\Infrastructure\Auth\CsrfValidator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\CsrfValidator
- */
 final class CsrfValidatorTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleAccessTest.php
@@ -21,9 +21,6 @@ use OpenCFP\Infrastructure\Auth\RoleAccess;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\RoleAccess
- */
 final class RoleAccessTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Auth/RoleNotFoundExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/RoleNotFoundExceptionTest.php
@@ -16,9 +16,6 @@ namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 use Localheinz\Test\Util\Helper;
 use OpenCFP\Infrastructure\Auth\RoleNotFoundException;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\RoleNotFoundException
- */
 final class RoleNotFoundExceptionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -27,9 +27,6 @@ use OpenCFP\Infrastructure\Auth\SentinelUser;
 use OpenCFP\Infrastructure\Auth\UserExistsException;
 use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\SentinelAccountManagement
- */
 final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;
@@ -145,7 +142,7 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
             ->andReturn($roleRepository);
 
         $accounts = new SentinelAccountManagement($sentinel);
-        
+
         $this->assertSame($users, $accounts->findByRole($name));
     }
 

--- a/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -27,9 +27,6 @@ use OpenCFP\Infrastructure\Auth\SentinelUser;
 use OpenCFP\Infrastructure\Auth\UserInterface;
 use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\SentinelAuthentication
- */
 final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
@@ -22,9 +22,6 @@ use OpenCFP\Domain\Services\IdentityProvider;
 use OpenCFP\Infrastructure\Auth\SentinelIdentityProvider;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\SentinelIdentityProvider
- */
 final class SentinelIdentityProviderTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelUserTest.php
@@ -18,9 +18,6 @@ use Localheinz\Test\Util\Helper;
 use Mockery as m;
 use OpenCFP\Infrastructure\Auth\SentinelUser;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\SentinelUser
- */
 final class SentinelUserTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
+++ b/tests/Unit/Infrastructure/Auth/SpeakerAccessTest.php
@@ -18,9 +18,6 @@ use OpenCFP\Domain\Services\Authentication;
 use OpenCFP\Infrastructure\Auth\SpeakerAccess;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\SpeakerAccess
- */
 final class SpeakerAccessTest extends \PHPUnit\Framework\TestCase
 {
     public function testReturnsRedirectResponseIfCheckFailed()

--- a/tests/Unit/Infrastructure/Auth/SymfonySentinelSessionTest.php
+++ b/tests/Unit/Infrastructure/Auth/SymfonySentinelSessionTest.php
@@ -17,9 +17,6 @@ use Localheinz\Test\Util\Helper;
 use Mockery;
 use OpenCFP\Infrastructure\Auth\SymfonySentinelSession;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\SymfonySentinelSession
- */
 final class SymfonySentinelSessionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserExistsExceptionTest.php
@@ -16,9 +16,6 @@ namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 use Localheinz\Test\Util\Helper;
 use OpenCFP\Infrastructure\Auth\UserExistsException;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\UserExistsException
- */
 final class UserExistsExceptionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
+++ b/tests/Unit/Infrastructure/Auth/UserNotFoundExceptionTest.php
@@ -16,9 +16,6 @@ namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 use Localheinz\Test\Util\Helper;
 use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 
-/**
- * @covers \OpenCFP\Infrastructure\Auth\UserNotFoundException
- */
 final class UserNotFoundExceptionTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
+++ b/tests/Unit/Infrastructure/Crypto/PseudoRandomStringGeneratorTest.php
@@ -15,9 +15,6 @@ namespace OpenCFP\Test\Unit\Infrastructure\Crypto;
 
 use OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator;
 
-/**
- * @covers \OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator
- */
 final class PseudoRandomStringGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Unit/Infrastructure/Repository/IlluminateUserRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Repository/IlluminateUserRepositoryTest.php
@@ -21,9 +21,6 @@ use OpenCFP\Domain\Repository\UserRepository;
 use OpenCFP\Infrastructure\Repository\IlluminateUserRepository;
 use PHPUnit\Framework;
 
-/**
- * @covers \OpenCFP\Infrastructure\Repository\IlluminateUserRepository
- */
 final class IlluminateUserRepositoryTest extends Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/PathTest.php
+++ b/tests/Unit/PathTest.php
@@ -18,9 +18,6 @@ use OpenCFP\Environment;
 use OpenCFP\Path;
 use OpenCFP\PathInterface;
 
-/**
- * @covers \OpenCFP\Path
- */
 final class PathTest extends \PHPUnit\Framework\TestCase
 {
     use Helper;

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -22,9 +22,6 @@ use OpenCFP\Provider;
 use PHPUnit\Framework;
 use Symfony\Component\HttpFoundation;
 
-/**
- * @coversNothing
- */
 final class ProjectCodeTest extends Framework\TestCase
 {
     use Helper;


### PR DESCRIPTION
This PR

* [x] removes `@covers` annotations

Follows https://github.com/opencfp/opencfp/pull/917.