### PR TITLE
Register a debug error handler for development

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -15,9 +15,14 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use OpenCFP\Application;
 use OpenCFP\Environment;
+use Symfony\Component\Debug\Debug;
 
 $basePath    = \realpath(\dirname(__DIR__));
 $environment = Environment::fromServer($_SERVER);
+
+if (!$environment->isProduction()) {
+    Debug::enable();
+}
 
 $app = new Application($basePath, $environment);
 


### PR DESCRIPTION
This PR adds Symfony's debug error handler to the development environment.

This is another small piece that I managed to cut out of #895. If something goes wrong during the application bootstrap (I simulated this by writing garbage into my development.yml), the error handler renders a nice error page with a stack trace.

**Before**

<img width="938" alt="bildschirmfoto 2017-12-17 um 11 32 37" src="https://user-images.githubusercontent.com/1506493/34078752-adce9c22-e320-11e7-8271-5dc257466348.png">

**After**

<img width="938" alt="bildschirmfoto 2017-12-17 um 11 33 19" src="https://user-images.githubusercontent.com/1506493/34078755-bb211c92-e320-11e7-87b8-83159d8d7653.png">

Note that exceptions that happen _during_ request processing are still caught and handled by your `ExceptionListener`.