### PR TITLE
Enhancement: Enable no_whitespace_in_blank_line fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -88,6 +88,7 @@ return PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
+        'no_whitespace_in_blank_line' => true,
         'ordered_imports' => true,
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,

--- a/classes/Console/Command/UserPromoteCommand.php
+++ b/classes/Console/Command/UserPromoteCommand.php
@@ -70,7 +70,7 @@ EOF
             $email,
             $roleName
         ));
-        
+
         try {
             $this->accountManagement->promoteTo(
                 $email,

--- a/classes/Http/Controller/Admin/ExportsController.php
+++ b/classes/Http/Controller/Admin/ExportsController.php
@@ -99,7 +99,7 @@ class ExportsController extends BaseController
         if (!\is_string($info)) {
             return $info;
         }
-        
+
         if ($this->startsWith($info, '=')
                 || $this->startsWith($info, '+')
                 || $this->startsWith($info, '-')

--- a/classes/Http/Controller/ForgotController.php
+++ b/classes/Http/Controller/ForgotController.php
@@ -137,7 +137,7 @@ class ForgotController extends BaseController
                 'ext'   => $errorMessage,
             ]);
         }
-        
+
         // Build password form and display it to the user
         $formOptions = [
             'user_id'    => $request->get('user_id'),
@@ -162,7 +162,7 @@ class ForgotController extends BaseController
 
         $form = $this->formFactory->createBuilder(ResetForm::class)->getForm();
         $form->handleRequest($request);
-        
+
         if (!$form->isValid()) {
             $form->get('user_id')->setData($userId);
             $form->get('reset_code')->setData($resetCode);
@@ -171,7 +171,7 @@ class ForgotController extends BaseController
                 'form' => $form->createView(),
             ]);
         }
-             
+
         $errorMessage = 'The reset you have requested appears to be invalid, please try again.';
         $error        = 0;
 
@@ -200,7 +200,7 @@ class ForgotController extends BaseController
     {
         $form = $this->formFactory->createBuilder(ResetForm::class)->getForm();
         $form->handleRequest($request);
-        
+
         if (!$form->isValid()) {
             return $this->render('user/reset_password.twig', [
                 'form' => $form->createView(),

--- a/classes/Http/View/TalkHelper.php
+++ b/classes/Http/View/TalkHelper.php
@@ -41,7 +41,7 @@ class TalkHelper
         $this->levels     = $levels;
         $this->types      = $types;
     }
-    
+
     public function getTalkCategories()
     {
         $categories = $this->categories;

--- a/classes/Infrastructure/Auth/SentinelAuthentication.php
+++ b/classes/Infrastructure/Auth/SentinelAuthentication.php
@@ -66,7 +66,7 @@ final class SentinelAuthentication implements Authentication
 
         throw new NotAuthenticatedException();
     }
-    
+
     public function isAuthenticated(): bool
     {
         return $this->sentinel->check() !== false;

--- a/migrations/20140828144530_add_id_to_speaker_table.php
+++ b/migrations/20140828144530_add_id_to_speaker_table.php
@@ -20,7 +20,7 @@ class AddIdToSpeakerTable extends AbstractMigration
         //$this->execute('ALTER TABLE speakers DROP PRIMARY KEY');
         //$this->execute('ALTER TABLE speakers ADD COLUMN id INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST');
     }
-    
+
     /**
      * Migrate Up.
      */

--- a/migrations/20140828145029_add_hotel_and_transportation_cost_fields.php
+++ b/migrations/20140828145029_add_hotel_and_transportation_cost_fields.php
@@ -22,7 +22,7 @@ class AddHotelAndTransportationCostFields extends AbstractMigration
         $table->addColumn('hotel', 'integer');
         $table->save();
     }
-    
+
     /**
      * Migrate Up.
      */

--- a/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/TalksControllerTest.php
@@ -70,7 +70,7 @@ final class TalksControllerTest extends WebTestCase
             ->post('/admin/talks/' . $talk->id . '/comment', [
                 'comment' => 'Great Talk i rate 10/10',
             ]);
-        
+
         $this->assertResponseBodyNotContains('Server Error', $response);
         $this->assertResponseIsRedirect($response);
     }

--- a/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
+++ b/tests/Unit/Domain/Services/AuthenticationExceptionTest.php
@@ -28,7 +28,7 @@ final class AuthenticationExceptionTest extends Framework\TestCase
     {
         $this->assertClassIsFinal(AuthenticationException::class);
     }
-    
+
     public function testIsRuntimeException()
     {
         $this->assertClassExtends(\RuntimeException::class, AuthenticationException::class);

--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -83,7 +83,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'talks',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -117,7 +117,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'name',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -155,7 +155,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'email',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -183,7 +183,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'company',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -211,7 +211,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'twitter',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -239,7 +239,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'url',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -267,7 +267,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'info',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -295,7 +295,7 @@ final class SpeakerProfileTest extends Framework\TestCase
         $hiddenProperties = [
             'bio',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);
@@ -317,13 +317,13 @@ final class SpeakerProfileTest extends Framework\TestCase
 
         $this->assertSame($bio, $profile->getBio());
     }
-    
+
     public function testGetTransportationThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [
             'transportation',
         ];
-        
+
         $speaker = $this->createUserMock();
 
         $profile = new SpeakerProfile($speaker, $hiddenProperties);

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -26,11 +26,11 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('development', Environment::TYPE_DEVELOPMENT);
         $this->assertSame('testing', Environment::TYPE_TESTING);
     }
-    
+
     public function testProductionReturnsEnvironment()
     {
         $environment = Environment::production();
-        
+
         $this->assertInstanceOf(Environment::class, $environment);
         $this->assertTrue($environment->isProduction());
         $this->assertFalse($environment->isDevelopment());

--- a/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -145,7 +145,7 @@ final class SentinelAccountManagementTest extends \PHPUnit\Framework\TestCase
             ->andReturn($roleRepository);
 
         $accounts = new SentinelAccountManagement($sentinel);
-        
+
         $this->assertSame($users, $accounts->findByRole($name));
     }
 


### PR DESCRIPTION
This PR

* [x] enables the `no_whitespace_in_blank_line` fixer
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.9.0#usage:

>**no_whitespace_in_blank_line** [`@Symfony`]
>
>Remove trailing whitespace at the end of blank lines.

