### PR TITLE
Fix: Pull up createAuthenticationMock()

### DIFF
--- a/tests/Unit/Http/Action/AbstractActionTestCase.php
+++ b/tests/Unit/Http/Action/AbstractActionTestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Unit\Http\Action;
 
 use Localheinz\Test\Util\Helper;
+use OpenCFP\Domain\Services;
 use PHPUnit\Framework;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
@@ -45,5 +46,13 @@ abstract class AbstractActionTestCase extends Framework\TestCase
     final protected function createRequestMock(): HttpFoundation\Request
     {
         return $this->createMock(HttpFoundation\Request::class);
+    }
+
+    /**
+     * @return Framework\MockObject\MockObject|Services\Authentication
+     */
+    final protected function createAuthenticationMock(): Services\Authentication
+    {
+        return $this->createMock(Services\Authentication::class);
     }
 }

--- a/tests/Unit/Http/Action/Talk/DeleteActionTest.php
+++ b/tests/Unit/Http/Action/Talk/DeleteActionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Unit\Http\Action\Talk;
 
 use OpenCFP\Domain\CallForPapers;
-use OpenCFP\Domain\Services;
 use OpenCFP\Http\Action\Talk\DeleteAction;
 use OpenCFP\Test\Unit\Http\Action\AbstractActionTestCase;
 use PHPUnit\Framework;
@@ -54,14 +53,6 @@ final class DeleteActionTest extends AbstractActionTestCase
         ]);
 
         $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
-    }
-
-    /**
-     * @return Framework\MockObject\MockObject|Services\Authentication
-     */
-    private function createAuthenticationMock(): Services\Authentication
-    {
-        return $this->createMock(Services\Authentication::class);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] pulls up `createAuthenticationMock()`

Follows #957.
Related to #925.
Related to #959.
Related to #962.
Related to #964.

💁‍♂️ Using it in all of the referenced PRs. While we could wait until any one of these gets merged, it's probably ok to pull this method up already (as I assume the open PRs will get merged eventually).