### PR TITLE
Add Symfony Profiler to development environment

### DIFF
--- a/classes/Kernel.php
+++ b/classes/Kernel.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
@@ -46,6 +47,10 @@ final class Kernel extends SymfonyKernel
 
         if ($this->getEnvironment() !== Environment::TYPE_PRODUCTION) {
             $bundles[] = new DebugBundle();
+        }
+
+        if ($this->getEnvironment() === Environment::TYPE_DEVELOPMENT) {
+            $bundles[] = new WebProfilerBundle();
         }
 
         return $bundles;

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "phpunit/phpunit": "^6.5.1",
         "symfony/browser-kit": "^3.4",
         "symfony/debug-bundle": "^3.4",
-        "symfony/phpunit-bridge": "^3.4"
+        "symfony/phpunit-bridge": "^3.4",
+        "symfony/web-profiler-bundle": "^3.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca0fe191fb22f85ad8bc6203b3b1341b",
+    "content-hash": "1041f8d78dc8d5ba7fc609e7f2c16d28",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -7069,6 +7069,73 @@
                 "debug",
                 "dump"
             ],
+            "time": "2017-12-11T22:06:16+00:00"
+        },
+        {
+            "name": "symfony/web-profiler-bundle",
+            "version": "v3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/web-profiler-bundle.git",
+                "reference": "94b6b48893781c7489398eb97837f02bdb7cd0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/94b6b48893781c7489398eb97837f02bdb7cd0bc",
+                "reference": "94b6b48893781c7489398eb97837f02bdb7cd0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/http-kernel": "~3.3|~4.0",
+                "symfony/polyfill-php70": "~1.0",
+                "symfony/routing": "~2.8|~3.0|~4.0",
+                "symfony/twig-bridge": "~2.8|~3.0|~4.0",
+                "symfony/var-dumper": "~3.3|~4.0",
+                "twig/twig": "~1.34|~2.4"
+            },
+            "conflict": {
+                "symfony/config": "<3.4",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<3.3.1",
+                "symfony/var-dumper": "<3.3"
+            },
+            "require-dev": {
+                "symfony/config": "~3.4|~4.0",
+                "symfony/console": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\WebProfilerBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony WebProfilerBundle",
+            "homepage": "https://symfony.com",
             "time": "2017-12-11T22:06:16+00:00"
         },
         {

--- a/resources/config/config_development.yml
+++ b/resources/config/config_development.yml
@@ -4,3 +4,7 @@ imports:
 framework:
   router:
     resource: '%kernel.project_dir%/resources/config/routing_development.yml'
+  profiler: ~
+
+web_profiler:
+  toolbar: true

--- a/resources/config/routing_development.yml
+++ b/resources/config/routing_development.yml
@@ -1,3 +1,11 @@
+_wdt:
+  resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+  prefix: /_wdt
+
+_profiler:
+  resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+  prefix: /_profiler
+
 _errors:
   resource: '@TwigBundle/Resources/config/routing/errors.xml'
   prefix: /_error


### PR DESCRIPTION
This PR enables the Symfony developer toolbar and the profiler in development environment. It the application runs in production environment, the profiler remains inaccessible.

~~The PR includes #895 in its full glory, please only look at the last commit of the branch.~~

Screenshots:

<img width="1222" alt="bildschirmfoto 2017-12-17 um 15 03 42" src="https://user-images.githubusercontent.com/1506493/34080293-da57a034-e33b-11e7-9763-6f17fa0b665e.png">

<img width="1222" alt="bildschirmfoto 2017-12-17 um 15 04 01" src="https://user-images.githubusercontent.com/1506493/34080294-dd9de834-e33b-11e7-93db-f3869d501075.png">