### PR TITLE
Use template annotation on actions

### DIFF
--- a/classes/Http/Action/DashboardAction.php
+++ b/classes/Http/Action/DashboardAction.php
@@ -15,9 +15,9 @@ namespace OpenCFP\Http\Action;
 
 use OpenCFP\Application\Speakers;
 use OpenCFP\Domain\Services;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
 
 final class DashboardAction
 {
@@ -27,33 +27,27 @@ final class DashboardAction
     private $speakers;
 
     /**
-     * @var Twig_Environment
-     */
-    private $twig;
-
-    /**
      * @var Routing\Generator\UrlGeneratorInterface
      */
     private $urlGenerator;
 
     public function __construct(
         Speakers $speakers,
-        Twig_Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->speakers     = $speakers;
-        $this->twig         = $twig;
         $this->urlGenerator = $urlGenerator;
     }
 
-    public function __invoke(): HttpFoundation\Response
+    /**
+     * @Template("dashboard.twig")
+     */
+    public function __invoke()
     {
         try {
-            $content = $this->twig->render('dashboard.twig', [
+            return [
                 'profile' => $this->speakers->findProfile(),
-            ]);
-
-            return new HttpFoundation\Response($content);
+            ];
         } catch (Services\NotAuthenticatedException $exception) {
             $url = $this->urlGenerator->generate('login');
 

--- a/classes/Http/Action/Page/HomePageAction.php
+++ b/classes/Http/Action/Page/HomePageAction.php
@@ -14,33 +14,27 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Action\Page;
 
 use OpenCFP\Domain\Model\Talk;
-use Symfony\Component\HttpFoundation;
-use Twig_Environment;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 final class HomePageAction
 {
-    /**
-     * @var Twig_Environment
-     */
-    private $twig;
-
     /**
      * @var bool
      */
     private $showSubmissionCount;
 
-    public function __construct(Twig_Environment $twig, bool $showSubmissionCount)
+    public function __construct(bool $showSubmissionCount)
     {
-        $this->twig                = $twig;
         $this->showSubmissionCount = $showSubmissionCount;
     }
 
-    public function __invoke(): HttpFoundation\Response
+    /**
+     * @Template("home.twig")
+     */
+    public function __invoke(): array
     {
-        $content = $this->twig->render('home.twig', [
+        return [
             'number_of_talks' => $this->showSubmissionCount ? Talk::count() : '',
-        ]);
-
-        return new HttpFoundation\Response($content);
+        ];
     }
 }

--- a/classes/Http/Action/Page/SpeakerPackageAction.php
+++ b/classes/Http/Action/Page/SpeakerPackageAction.php
@@ -13,25 +13,15 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Action\Page;
 
-use Symfony\Component\HttpFoundation;
-use Twig_Environment;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 final class SpeakerPackageAction
 {
     /**
-     * @var Twig_Environment
+     * @Template("package.twig")
      */
-    private $twig;
-
-    public function __construct(Twig_Environment $twig)
+    public function __invoke(): array
     {
-        $this->twig = $twig;
-    }
-
-    public function __invoke(): HttpFoundation\Response
-    {
-        $content = $this->twig->render('package.twig');
-
-        return new HttpFoundation\Response($content);
+        return [];
     }
 }

--- a/classes/Http/Action/Page/TalkIdeasAction.php
+++ b/classes/Http/Action/Page/TalkIdeasAction.php
@@ -13,25 +13,15 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Action\Page;
 
-use Symfony\Component\HttpFoundation;
-use Twig_Environment;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 final class TalkIdeasAction
 {
     /**
-     * @var Twig_Environment
+     * @Template("ideas.twig")
      */
-    private $twig;
-
-    public function __construct(Twig_Environment $twig)
+    public function __invoke(): array
     {
-        $this->twig = $twig;
-    }
-
-    public function __invoke(): HttpFoundation\Response
-    {
-        $content = $this->twig->render('ideas.twig');
-
-        return new HttpFoundation\Response($content);
+        return [];
     }
 }

--- a/classes/Http/Action/Talk/EditAction.php
+++ b/classes/Http/Action/Talk/EditAction.php
@@ -17,9 +17,9 @@ use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Model;
 use OpenCFP\Domain\Services;
 use OpenCFP\Http\View;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
 
 final class EditAction
 {
@@ -39,11 +39,6 @@ final class EditAction
     private $callForPapers;
 
     /**
-     * @var Twig_Environment
-     */
-    private $twig;
-
-    /**
      * @var Routing\Generator\UrlGeneratorInterface
      */
     private $urlGenerator;
@@ -52,17 +47,18 @@ final class EditAction
         Services\Authentication $authentication,
         View\TalkHelper $talkHelper,
         CallForPapers $callForPapers,
-        Twig_Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->authentication = $authentication;
         $this->talkHelper     = $talkHelper;
         $this->callForPapers  = $callForPapers;
-        $this->twig           = $twig;
         $this->urlGenerator   = $urlGenerator;
     }
 
-    public function __invoke(HttpFoundation\Request $request): HttpFoundation\Response
+    /**
+     * @Template("talk/edit.twig")
+     */
+    public function __invoke(HttpFoundation\Request $request)
     {
         $talkId = (int) $request->get('id');
 
@@ -96,7 +92,7 @@ final class EditAction
             return new HttpFoundation\RedirectResponse($url);
         }
 
-        $content = $this->twig->render('talk/edit.twig', [
+        return [
             'formAction'     => $this->urlGenerator->generate('talk_update'),
             'talkCategories' => $this->talkHelper->getTalkCategories(),
             'talkTypes'      => $this->talkHelper->getTalkTypes(),
@@ -112,8 +108,6 @@ final class EditAction
             'other'          => $talk['other'],
             'sponsor'        => $talk['sponsor'],
             'buttonInfo'     => 'Update my talk!',
-        ]);
-
-        return new HttpFoundation\Response($content);
+        ];
     }
 }

--- a/classes/Http/Action/Talk/ViewAction.php
+++ b/classes/Http/Action/Talk/ViewAction.php
@@ -15,9 +15,9 @@ namespace OpenCFP\Http\Action\Talk;
 
 use OpenCFP\Application\NotAuthorizedException;
 use OpenCFP\Application\Speakers;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
 
 final class ViewAction
 {
@@ -27,26 +27,22 @@ final class ViewAction
     private $speakers;
 
     /**
-     * @var Twig_Environment
-     */
-    private $twig;
-
-    /**
      * @var Routing\Generator\UrlGeneratorInterface
      */
     private $urlGenerator;
 
     public function __construct(
         Speakers $speakers,
-        Twig_Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->speakers     = $speakers;
-        $this->twig         = $twig;
         $this->urlGenerator = $urlGenerator;
     }
 
-    public function __invoke(HttpFoundation\Request $request): HttpFoundation\Response
+    /**
+     * @Template("talk/view.twig")
+     */
+    public function __invoke(HttpFoundation\Request $request)
     {
         $talkId = (int) $request->get('id');
 
@@ -58,11 +54,9 @@ final class ViewAction
             return new HttpFoundation\RedirectResponse($url);
         }
 
-        $content = $this->twig->render('talk/view.twig', [
+        return [
             'talkId' => $talkId,
             'talk'   => $talk,
-        ]);
-
-        return new HttpFoundation\Response($content);
+        ];
     }
 }

--- a/classes/Kernel.php
+++ b/classes/Kernel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP;
 
 use OpenCFP\Infrastructure\DependencyInjection\TestingPass;
+use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\MonologBundle\MonologBundle;
@@ -39,6 +40,7 @@ final class Kernel extends SymfonyKernel
     {
         $bundles = [
             new FrameworkBundle(),
+            new SensioFrameworkExtraBundle(),
             new MonologBundle(),
             new TwigBundle(),
             new SwiftmailerBundle(),

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "monolog/monolog": "~1.22",
         "pagerfanta/pagerfanta": "1.0.*@dev",
         "robmorgan/phinx": "*",
+        "sensio/framework-extra-bundle": "^5.1.3",
         "symfony/config": "^3.4",
         "symfony/console": "^3.4",
         "symfony/css-selector": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1041f8d78dc8d5ba7fc609e7f2c16d28",
+    "content-hash": "3dd467bd30def29e1c652133a32e622f",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -199,6 +199,284 @@
                 "support"
             ],
             "time": "2017-02-23T12:05:30+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-02-24T16:22:25+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/eb152c5100571c7a45470ff2a35095ab3f3b900b",
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.5|~7.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|~5.0",
+                "predis/predis": "~1.0",
+                "satooshi/php-coveralls": "~0.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2017-07-22T12:49:21+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-01-03T10:49:41+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "4acb8f89626baafede6ee5475bc5844096eba8a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/4acb8f89626baafede6ee5475bc5844096eba8a9",
+                "reference": "4acb8f89626baafede6ee5475bc5844096eba8a9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~5.6|~7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2017-07-22T08:35:12+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1728,6 +2006,75 @@
                 "phinx"
             ],
             "time": "2017-09-09T13:54:33+00:00"
+        },
+        {
+            "name": "sensio/framework-extra-bundle",
+            "version": "v5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
+                "reference": "0696496cb3e2d23add645d424699e5c723238aad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/0696496cb3e2d23add645d424699e5c723238aad",
+                "reference": "0696496cb3e2d23add645d424699e5c723238aad",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "^2.2",
+                "symfony/config": "^3.3|^4.0",
+                "symfony/dependency-injection": "^3.3|^4.0",
+                "symfony/framework-bundle": "^3.3|^4.0",
+                "symfony/http-kernel": "^3.3|^4.0"
+            },
+            "require-dev": {
+                "doctrine/doctrine-bundle": "^1.6",
+                "doctrine/orm": "^2.5",
+                "symfony/browser-kit": "^3.3|^4.0",
+                "symfony/dom-crawler": "^3.3|^4.0",
+                "symfony/expression-language": "^3.3|^4.0",
+                "symfony/finder": "^3.3|^4.0",
+                "symfony/phpunit-bridge": "^3.3|^4.0",
+                "symfony/psr-http-message-bridge": "^0.3",
+                "symfony/security-bundle": "^3.3|^4.0",
+                "symfony/twig-bundle": "^3.3|^4.0",
+                "symfony/yaml": "^3.3|^4.0",
+                "twig/twig": "~1.12|~2.0",
+                "zendframework/zend-diactoros": "^1.3"
+            },
+            "suggest": {
+                "symfony/expression-language": "",
+                "symfony/psr-http-message-bridge": "To use the PSR-7 converters",
+                "symfony/security-bundle": ""
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sensio\\Bundle\\FrameworkExtraBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "This bundle provides a way to configure your controllers with annotations",
+            "keywords": [
+                "annotations",
+                "controllers"
+            ],
+            "time": "2017-12-04T18:33:55+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -4426,74 +4773,6 @@
                 "versioning"
             ],
             "time": "2016-08-30T16:08:34+00:00"
-        },
-        {
-            "name": "doctrine/annotations",
-            "version": "v1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
-                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "1.*",
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^5.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "http://www.doctrine-project.org",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
-            ],
-            "time": "2017-02-24T16:22:25+00:00"
         },
         {
             "name": "doctrine/instantiator",

--- a/tests/Unit/Http/Action/AbstractActionTestCase.php
+++ b/tests/Unit/Http/Action/AbstractActionTestCase.php
@@ -18,19 +18,10 @@ use OpenCFP\Domain\Services;
 use PHPUnit\Framework;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
 
 abstract class AbstractActionTestCase extends Framework\TestCase
 {
     use Helper;
-
-    /**
-     * @return Framework\MockObject\MockObject|Twig_Environment
-     */
-    final protected function createTwigMock(): Twig_Environment
-    {
-        return $this->createMock(Twig_Environment::class);
-    }
 
     /**
      * @return Framework\MockObject\MockObject|HttpFoundation\Request

--- a/tests/Unit/Http/Action/DashboardActionTest.php
+++ b/tests/Unit/Http/Action/DashboardActionTest.php
@@ -33,12 +33,6 @@ final class DashboardActionTest extends AbstractActionTestCase
             ->method('findProfile')
             ->willThrowException(new Services\NotAuthenticatedException());
 
-        $twig = $this->createTwigMock();
-
-        $twig
-            ->expects($this->never())
-            ->method($this->anything());
-
         $urlGenerator = $this->createUrlGeneratorMock();
 
         $urlGenerator
@@ -49,7 +43,6 @@ final class DashboardActionTest extends AbstractActionTestCase
 
         $action = new DashboardAction(
             $speakers,
-            $twig,
             $urlGenerator
         );
 
@@ -63,8 +56,6 @@ final class DashboardActionTest extends AbstractActionTestCase
 
     public function testRendersDashboardIfUserIsAuthenticated()
     {
-        $content = $this->faker()->text();
-
         $speakerProfile = $this->createSpeakerProfileMock();
 
         $speakers = $this->createSpeakersMock();
@@ -74,19 +65,6 @@ final class DashboardActionTest extends AbstractActionTestCase
             ->method('findProfile')
             ->willReturn($speakerProfile);
 
-        $twig = $this->createTwigMock();
-
-        $twig
-            ->expects($this->once())
-            ->method('render')
-            ->with(
-                $this->identicalTo('dashboard.twig'),
-                $this->identicalTo([
-                    'profile' => $speakerProfile,
-                ])
-            )
-            ->willReturn($content);
-
         $urlGenerator = $this->createUrlGeneratorMock();
 
         $urlGenerator
@@ -95,15 +73,14 @@ final class DashboardActionTest extends AbstractActionTestCase
 
         $action = new DashboardAction(
             $speakers,
-            $twig,
             $urlGenerator
         );
 
-        $response = $action();
+        $expected = [
+            'profile' => $speakerProfile,
+        ];
 
-        $this->assertInstanceOf(HttpFoundation\Response::class, $response);
-        $this->assertSame(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame($content, $response->getContent());
+        $this->assertSame($expected, $action());
     }
 
     /**

--- a/tests/Unit/Http/Action/Page/HomePageActionTest.php
+++ b/tests/Unit/Http/Action/Page/HomePageActionTest.php
@@ -14,35 +14,18 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Unit\Http\Action\Page;
 
 use OpenCFP\Http\Action\Page\HomePageAction;
-use OpenCFP\Test\Unit\Http\Action\AbstractActionTestCase;
-use Symfony\Component\HttpFoundation;
+use PHPUnit\Framework\TestCase;
 
-final class HomePageActionTest extends AbstractActionTestCase
+final class HomePageActionTest extends TestCase
 {
     public function testItReturnsTheCorrectContentIfNoSubmissionCountNeedsToBeShown()
     {
-        $content = $this->faker()->text();
+        $action = new HomePageAction(false);
 
-        $twig = $this->createTwigMock();
+        $expected = [
+            'number_of_talks' => '',
+        ];
 
-        $twig
-            ->expects($this->once())
-            ->method('render')
-            ->with(
-                $this->identicalTo('home.twig'),
-                $this->identicalTo(['number_of_talks' => ''])
-            )
-            ->willReturn($content);
-
-        $action = new HomePageAction(
-            $twig,
-            false
-        );
-
-        $response = $action();
-
-        $this->assertInstanceOf(HttpFoundation\Response::class, $response);
-        $this->assertSame($content, $response->getContent());
-        $this->assertSame(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame($expected, $action());
     }
 }

--- a/tests/Unit/Http/Action/Page/SpeakerPackageActionTest.php
+++ b/tests/Unit/Http/Action/Page/SpeakerPackageActionTest.php
@@ -14,31 +14,14 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Unit\Http\Action\Page;
 
 use OpenCFP\Http\Action\Page\SpeakerPackageAction;
-use OpenCFP\Test\Unit\Http\Action\AbstractActionTestCase;
-use Symfony\Component\HttpFoundation;
+use PHPUnit\Framework\TestCase;
 
-final class SpeakerPackageActionTest extends AbstractActionTestCase
+final class SpeakerPackageActionTest extends TestCase
 {
-    public function testItReturnsTheContentOfTheTwigInAResponseObject()
+    public function testAction()
     {
-        $content = $this->faker()->text();
+        $action = new SpeakerPackageAction();
 
-        $twig = $this->createTwigMock();
-
-        $twig
-            ->expects($this->once())
-            ->method('render')
-            ->with(
-                $this->identicalTo('package.twig')
-            )
-            ->willReturn($content);
-
-        $action = new SpeakerPackageAction($twig);
-
-        $response = $action();
-
-        $this->assertInstanceOf(HttpFoundation\Response::class, $response);
-        $this->assertSame($content, $response->getContent());
-        $this->assertSame(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([], $action());
     }
 }

--- a/tests/Unit/Http/Action/Page/TalkIdeasActionTest.php
+++ b/tests/Unit/Http/Action/Page/TalkIdeasActionTest.php
@@ -14,29 +14,14 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Unit\Http\Action\Page;
 
 use OpenCFP\Http\Action\Page\TalkIdeasAction;
-use OpenCFP\Test\Unit\Http\Action\AbstractActionTestCase;
-use Symfony\Component\HttpFoundation;
+use PHPUnit\Framework\TestCase;
 
-final class TalkIdeasActionTest extends AbstractActionTestCase
+final class TalkIdeasActionTest extends TestCase
 {
-    public function testItReturnsTheContentOfTheTwigInAResponseObject()
+    public function testAction()
     {
-        $content = $this->faker()->text();
+        $action = new TalkIdeasAction();
 
-        $twig = $this->createTwigMock();
-
-        $twig
-            ->expects($this->once())
-            ->method('render')
-            ->with($this->identicalTo('ideas.twig'))
-            ->willReturn($content);
-
-        $action = new TalkIdeasAction($twig);
-
-        $response = $action();
-
-        $this->assertInstanceOf(HttpFoundation\Response::class, $response);
-        $this->assertSame($content, $response->getContent());
-        $this->assertSame(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([], $action());
     }
 }

--- a/tests/Unit/Http/Action/Talk/EditActionTest.php
+++ b/tests/Unit/Http/Action/Talk/EditActionTest.php
@@ -78,12 +78,6 @@ final class EditActionTest extends AbstractActionTestCase
             ->method('isOpen')
             ->willReturn(false);
 
-        $twig = $this->createTwigMock();
-
-        $twig
-            ->expects($this->never())
-            ->method($this->anything());
-
         $urlGenerator = $this->createUrlGeneratorMock();
 
         $urlGenerator
@@ -101,7 +95,6 @@ final class EditActionTest extends AbstractActionTestCase
             $authentication,
             $talkHelper,
             $callForPapers,
-            $twig,
             $urlGenerator
         );
 
@@ -151,12 +144,6 @@ final class EditActionTest extends AbstractActionTestCase
             ->method('isOpen')
             ->willReturn(true);
 
-        $twig = $this->createTwigMock();
-
-        $twig
-            ->expects($this->never())
-            ->method($this->anything());
-
         $urlGenerator = $this->createUrlGeneratorMock();
 
         $urlGenerator
@@ -169,7 +156,6 @@ final class EditActionTest extends AbstractActionTestCase
             $authentication,
             $talkHelper,
             $callForPapers,
-            $twig,
             $urlGenerator
         );
 

--- a/tests/Unit/Http/Action/Talk/ViewActionTest.php
+++ b/tests/Unit/Http/Action/Talk/ViewActionTest.php
@@ -46,12 +46,6 @@ final class ViewActionTest extends AbstractActionTestCase
             ->with($this->identicalTo($talkId))
             ->willThrowException(new NotAuthorizedException());
 
-        $twig = $this->createTwigMock();
-
-        $twig
-            ->expects($this->never())
-            ->method($this->anything());
-
         $urlGenerator = $this->createUrlGeneratorMock();
 
         $urlGenerator
@@ -62,7 +56,6 @@ final class ViewActionTest extends AbstractActionTestCase
 
         $action = new ViewAction(
             $speakers,
-            $twig,
             $urlGenerator
         );
 
@@ -78,8 +71,7 @@ final class ViewActionTest extends AbstractActionTestCase
     {
         $faker = $this->faker();
 
-        $talkId  = $faker->numberBetween(1);
-        $content = $faker->text();
+        $talkId = $faker->numberBetween(1);
 
         $request = $this->createRequestMock();
 
@@ -99,20 +91,6 @@ final class ViewActionTest extends AbstractActionTestCase
             ->with($this->identicalTo($talkId))
             ->willReturn($talk);
 
-        $twig = $this->createTwigMock();
-
-        $twig
-            ->expects($this->once())
-            ->method('render')
-            ->with(
-                $this->identicalTo('talk/view.twig'),
-                $this->identicalTo([
-                    'talkId' => $talkId,
-                    'talk'   => $talk,
-                ])
-            )
-            ->willReturn($content);
-
         $urlGenerator = $this->createUrlGeneratorMock();
 
         $urlGenerator
@@ -121,15 +99,15 @@ final class ViewActionTest extends AbstractActionTestCase
 
         $action = new ViewAction(
             $speakers,
-            $twig,
             $urlGenerator
         );
 
-        $response = $action($request);
+        $expected = [
+            'talkId' => $talkId,
+            'talk'   => $talk,
+        ];
 
-        $this->assertInstanceOf(HttpFoundation\Response::class, $response);
-        $this->assertSame(HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame($content, $response->getContent());
+        $this->assertSame($expected, $action($request));
     }
 
     /**


### PR DESCRIPTION
This PR enables SensioFrameworkExtraBundle which allows us to configure controllers with annotations. It also adds `@Template` annotations to actions that render templates. This allows us to return an array with template variables instead of a `Response` object, so we do not need to interface with Twig directly anymore.

~~The PR includes #895 in its full glory, please only look at the last commit of the branch.~~