### PR TITLE
Enhancement: Use TemplateController to render login

### DIFF
--- a/classes/Http/Controller/SecurityController.php
+++ b/classes/Http/Controller/SecurityController.php
@@ -36,13 +36,6 @@ class SecurityController extends BaseController
         parent::__construct($twig, $urlGenerator);
     }
 
-    public function indexAction(): Response
-    {
-        return $this->render('security/login.twig', [
-            'email' => null,
-        ]);
-    }
-
     public function processAction(Request $request): Response
     {
         try {

--- a/resources/config/routing.yml
+++ b/resources/config/routing.yml
@@ -172,7 +172,9 @@ talk_view:
 login:
   path: /login
   methods: [GET]
-  controller: 'OpenCFP\Http\Controller\SecurityController::indexAction'
+  controller: FrameworkBundle:Template:template
+  defaults:
+    template: security/login.twig
 
 login_check:
   path: /login

--- a/resources/views/security/login.twig
+++ b/resources/views/security/login.twig
@@ -10,7 +10,7 @@
 
     <form method="post" action="{{ url('login_check') }}">
       <label class="text-sm text-white">Email</label>
-      <input type="email" name="email" value="{{ email | escape }}" class="w-full" placeholder="you@example.com">
+      <input type="email" name="email" value="{% if email %}{{ email | escape }}{% endif %}" class="w-full" placeholder="you@example.com">
       <label class="text-sm text-white">Password</label>
       <input type="password" name="password" class="w-full" placeholder="•••••••">
       <p class="text-right my-4"><a href="{{ url('forgot_password') }}" class="text-white text-sm">Forgot password?</a></p>

--- a/tests/Integration/Http/Action/Security/IndexActionTest.php
+++ b/tests/Integration/Http/Action/Security/IndexActionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2017 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Integration\Http\Action\Security;
+
+use OpenCFP\Test\Integration\WebTestCase;
+
+final class IndexActionTest extends WebTestCase
+{
+    public function testIndexShowsLoginForm()
+    {
+        $this->callForPapersIsOpen();
+
+        $response = $this->get('/login');
+
+        $this->assertResponseIsSuccessful($response);
+        $this->assertResponseBodyContains('Email', $response);
+        $this->assertResponseBodyContains('Password', $response);
+        $this->assertResponseBodyContains('Login', $response);
+    }
+}


### PR DESCRIPTION
This PR

* [x] renders the login template using the `TemplateController`

Follows #976.