### PR TITLE
Quote strings starting with percent character in YAML files.

### DIFF
--- a/phinx.yml.dist
+++ b/phinx.yml.dist
@@ -1,5 +1,5 @@
 paths:
-    migrations: %%PHINX_CONFIG_DIR%%/migrations
+    migrations: '%%PHINX_CONFIG_DIR%%/migrations'
 
 environments:
     default_migration_table: phinxlog


### PR DESCRIPTION
This PR adds quote to a YAML string starting with a `%` character. This establishes forward compatibility with the stricter parsing rules in Symfony YAML 4.0.

Related to #618.

Reference: https://github.com/symfony/symfony/blob/4.0/src/Symfony/Component/Yaml/CHANGELOG.md#400