### PR TITLE
Upgrade aptoma/twig-markdown to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": ">=7",
-        "aptoma/twig-markdown": "0.2.*",
+        "aptoma/twig-markdown": "^2",
         "cartalyst/sentinel": "^2.0.17",
         "ezyang/htmlpurifier": "dev-master",
         "guzzlehttp/guzzle": "~6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,31 +4,36 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf8fe6c0503235cfcf17d26ce1ca612e",
+    "content-hash": "6c0a08fd997527f8beafda77bda4f498",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
-            "version": "0.2.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aptoma/twig-markdown.git",
-                "reference": "2c0972ecdaf5c94a0dec01b7c9af7919f2c6498d"
+                "reference": "64a9c5c7418c08faf91c4410b34bdb65fb25c23d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aptoma/twig-markdown/zipball/2c0972ecdaf5c94a0dec01b7c9af7919f2c6498d",
-                "reference": "2c0972ecdaf5c94a0dec01b7c9af7919f2c6498d",
+                "url": "https://api.github.com/repos/aptoma/twig-markdown/zipball/64a9c5c7418c08faf91c4410b34bdb65fb25c23d",
+                "reference": "64a9c5c7418c08faf91c4410b34bdb65fb25c23d",
                 "shasum": ""
             },
             "require": {
-                "twig/twig": "~1"
+                "twig/twig": "~1.12"
             },
             "require-dev": {
-                "dflydev/markdown": "~1",
-                "michelf/php-markdown": "~1"
+                "codeclimate/php-test-reporter": "dev-master",
+                "erusev/parsedown": "^1.6",
+                "knplabs/github-api": "~1.2",
+                "league/commonmark": "~0.5",
+                "michelf/php-markdown": "~1",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "~0.6"
             },
             "suggest": {
-                "dflydev/markdown": "Markdown engine based on the simple michelf/php-markdown engine.",
+                "knplabs/github-api": "Needed for using GitHub's Markdown engine provided through their API.",
                 "michelf/php-markdown": "Original Markdown engine with MarkdownExtra."
             },
             "type": "library",
@@ -43,14 +48,12 @@
             ],
             "authors": [
                 {
-                    "name": "Gunnar Lium",
-                    "email": "gunnar@aptoma.com",
-                    "homepage": "https://github.com/gunnarlium",
-                    "role": "Developer"
-                },
-                {
                     "name": "Joris Berthelot",
                     "email": "joris@berthelot.tel"
+                },
+                {
+                    "name": "Gunnar Lium",
+                    "email": "gunnar@aptoma.com"
                 }
             ],
             "description": "Twig extension to work with Markdown content",
@@ -58,7 +61,7 @@
                 "markdown",
                 "twig"
             ],
-            "time": "2013-09-26T15:14:08+00:00"
+            "time": "2015-10-23T20:27:08+00:00"
         },
         {
             "name": "cartalyst/sentinel",

--- a/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
@@ -15,7 +15,6 @@ namespace OpenCFP\Test\Unit\Infrastructure\Auth;
 
 use Cartalyst\Sentinel\Sentinel;
 use Localheinz\Test\Util\Helper;
-use Mockery as m;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Domain\Repository\UserRepository;
 use OpenCFP\Domain\Services\IdentityProvider;
@@ -41,16 +40,18 @@ final class SentinelIdentityProviderTest extends Framework\TestCase
 
     public function testGetCurrentUserThrowsNotAuthenticatedExceptionWhenNotAuthenticated()
     {
-        $sentinel = $this->getSentinel();
+        $sentinel = $this->createSentinelMock();
 
         $sentinel
-            ->shouldReceive('getUser')
-            ->once()
-            ->andReturnNull();
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn(null);
 
         $userRepository = $this->createUserRepositoryMock();
 
-        $userRepository->shouldNotReceive(m::any());
+        $userRepository
+            ->expects($this->never())
+            ->method($this->anything());
 
         $provider = new SentinelIdentityProvider(
             $sentinel,
@@ -66,29 +67,29 @@ final class SentinelIdentityProviderTest extends Framework\TestCase
     {
         $id = $this->faker()->randomNumber();
 
-        $sentinelUser = $this->getSentinelUserMock();
+        $sentinelUser = $this->createSentinelUserMock();
 
         $sentinelUser
-            ->shouldReceive('getUserId')
-            ->once()
-            ->andReturn($id);
+            ->expects($this->once())
+            ->method('getUserId')
+            ->willReturn($id);
 
-        $sentinel = $this->getSentinel();
+        $sentinel = $this->createSentinelMock();
 
         $sentinel
-            ->shouldReceive('getUser')
-            ->once()
-            ->andReturn($sentinelUser);
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($sentinelUser);
 
-        $user = $this->getUserMock();
+        $user = $this->createUserMock();
 
         $userRepository = $this->createUserRepositoryMock();
 
         $userRepository
-            ->shouldReceive('findById')
-            ->once()
-            ->with($id)
-            ->andReturn($user);
+            ->expects($this->once())
+            ->method('findById')
+            ->with($this->identicalTo($id))
+            ->willReturn($user);
 
         $provider = new SentinelIdentityProvider(
             $sentinel,
@@ -98,39 +99,35 @@ final class SentinelIdentityProviderTest extends Framework\TestCase
         $this->assertSame($user, $provider->getCurrentUser());
     }
 
-    //
-    // Factory Methods
-    //
-
     /**
-     * @return m\MockInterface|Sentinel
+     * @return Framework\MockObject\MockObject|Sentinel
      */
-    private function getSentinel()
+    private function createSentinelMock(): Sentinel
     {
-        return m::mock(Sentinel::class);
+        return $this->createMock(Sentinel::class);
     }
 
     /**
-     * @return \Cartalyst\Sentinel\Users\UserInterface|m\MockInterface
+     * @return \Cartalyst\Sentinel\Users\UserInterface|Framework\MockObject\MockObject
      */
-    private function getSentinelUserMock()
+    private function createSentinelUserMock(): \Cartalyst\Sentinel\Users\UserInterface
     {
-        return m::mock(\Cartalyst\Sentinel\Users\UserInterface::class);
+        return $this->createMock(\Cartalyst\Sentinel\Users\UserInterface::class);
     }
 
     /**
-     * @return m\MockInterface|UserRepository
+     * @return Framework\MockObject\MockObject|UserRepository
      */
-    private function createUserRepositoryMock()
+    private function createUserRepositoryMock(): UserRepository
     {
-        return m::mock(UserRepository::class);
+        return $this->createMock(UserRepository::class);
     }
 
     /**
-     * @return m\MockInterface|User
+     * @return Framework\MockObject\MockObject|User
      */
-    private function getUserMock()
+    private function createUserMock(): User
     {
-        return m::mock(User::class);
+        return $this->createMock(User::class);
     }
 }


### PR DESCRIPTION
This PR upgrades the `aptoma/twig-markdown` library to 2.0. The currently used version of that library accesses deprecated Twig functionality.