### PR TITLE
Enhancement: Configure memory limit in phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,7 @@
     <php>
         <!-- https://github.com/symfony/console/blob/v3.3.12/Terminal.php#L24-L36 -->
         <env name="COLUMNS" value="120"/>
+        <ini name="memory_limit" value="512M"/>
     </php>
     <filter>
         <whitelist>


### PR DESCRIPTION
This PR

* [x] configures the `memory_limit` in `phpunit.xml.dist` to `512M`

Fixes #978.
