### PR TITLE
Fix broken build from forgotten mock factory

### DIFF
--- a/tests/Unit/Http/Action/AbstractActionTestCase.php
+++ b/tests/Unit/Http/Action/AbstractActionTestCase.php
@@ -18,10 +18,19 @@ use OpenCFP\Domain\Services;
 use PHPUnit\Framework;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
+use Twig_Environment;
 
 abstract class AbstractActionTestCase extends Framework\TestCase
 {
     use Helper;
+
+    /**
+     * @return Framework\MockObject\MockObject|Twig_Environment
+     */
+    final protected function createTwigMock(): Twig_Environment
+    {
+        return $this->createMock(Twig_Environment::class);
+    }
 
     /**
      * @return Framework\MockObject\MockObject|HttpFoundation\Request


### PR DESCRIPTION
See: https://travis-ci.org/opencfp/opencfp/builds/318070759

`createTwigMock` doesn't exist and tests fail. This PR adds `createTwigMock` to `AbstractActionTestCase`.

This is my bad as I didn't realize the rebase from https://github.com/opencfp/opencfp/pull/955 was broken. 