### PR TITLE
Fix: Mark methods creating mocks as deprecated

### DIFF
--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -358,6 +358,8 @@ final class UserCreateCommandTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject|Services\AccountManagement
      */
     private function createAccountManagementMock(): Services\AccountManagement
@@ -366,6 +368,8 @@ final class UserCreateCommandTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Auth\UserInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private function createUserMock(): Auth\UserInterface

--- a/tests/Unit/Console/Command/UserDemoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserDemoteCommandTest.php
@@ -255,6 +255,8 @@ final class UserDemoteCommandTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject|Services\AccountManagement
      */
     private function createAccountManagementMock(): Services\AccountManagement

--- a/tests/Unit/Console/Command/UserPromoteCommandTest.php
+++ b/tests/Unit/Console/Command/UserPromoteCommandTest.php
@@ -255,6 +255,8 @@ final class UserPromoteCommandTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject|Services\AccountManagement
      */
     private function createAccountManagementMock(): Services\AccountManagement

--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -471,6 +471,8 @@ final class SpeakerProfileTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @param array $properties
      *
      * @return Model\User|\PHPUnit_Framework_MockObject_MockObject
@@ -492,6 +494,8 @@ final class SpeakerProfileTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Model\Talk|\PHPUnit_Framework_MockObject_MockObject
      */
     private function createTalkMock(): Model\Talk

--- a/tests/Unit/Http/Action/AbstractActionTestCase.php
+++ b/tests/Unit/Http/Action/AbstractActionTestCase.php
@@ -20,11 +20,16 @@ use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
 use Twig_Environment;
 
+/**
+ * @deprecated
+ */
 abstract class AbstractActionTestCase extends Framework\TestCase
 {
     use Helper;
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|Twig_Environment
      */
     final protected function createTwigMock(): Twig_Environment
@@ -33,6 +38,8 @@ abstract class AbstractActionTestCase extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|HttpFoundation\Request
      */
     final protected function createRequestMock(): HttpFoundation\Request
@@ -41,6 +48,8 @@ abstract class AbstractActionTestCase extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|HttpFoundation\Session\SessionInterface
      */
     final protected function createSessionMock(): HttpFoundation\Session\SessionInterface
@@ -49,6 +58,8 @@ abstract class AbstractActionTestCase extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|Routing\Generator\UrlGeneratorInterface
      */
     final protected function createUrlGeneratorMock(): Routing\Generator\UrlGeneratorInterface
@@ -57,6 +68,8 @@ abstract class AbstractActionTestCase extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|Services\Authentication
      */
     final protected function createAuthenticationMock(): Services\Authentication

--- a/tests/Unit/Http/Action/DashboardActionTest.php
+++ b/tests/Unit/Http/Action/DashboardActionTest.php
@@ -84,6 +84,8 @@ final class DashboardActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|Speakers
      */
     private function createSpeakersMock(): Speakers
@@ -92,6 +94,8 @@ final class DashboardActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|Speaker\SpeakerProfile
      */
     private function createSpeakerProfileMock(): Speaker\SpeakerProfile

--- a/tests/Unit/Http/Action/Signup/IndexActionTest.php
+++ b/tests/Unit/Http/Action/Signup/IndexActionTest.php
@@ -194,6 +194,8 @@ final class IndexActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return CallForPapers|Framework\MockObject\MockObject
      */
     private function createCallForPapersMock(): CallForPapers

--- a/tests/Unit/Http/Action/Talk/CreateActionTest.php
+++ b/tests/Unit/Http/Action/Talk/CreateActionTest.php
@@ -207,6 +207,8 @@ final class CreateActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|View\TalkHelper
      */
     private function createTalkHelperMock(): View\TalkHelper
@@ -215,6 +217,8 @@ final class CreateActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return CallForPapers|Framework\MockObject\MockObject
      */
     private function createCallForPapersMock(): CallForPapers

--- a/tests/Unit/Http/Action/Talk/DeleteActionTest.php
+++ b/tests/Unit/Http/Action/Talk/DeleteActionTest.php
@@ -56,6 +56,8 @@ final class DeleteActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return CallForPapers|Framework\MockObject\MockObject
      */
     private function createCallForPapersMock(): CallForPapers

--- a/tests/Unit/Http/Action/Talk/EditActionTest.php
+++ b/tests/Unit/Http/Action/Talk/EditActionTest.php
@@ -168,6 +168,8 @@ final class EditActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|View\TalkHelper
      */
     private function createTalkHelperMock(): View\TalkHelper
@@ -176,6 +178,8 @@ final class EditActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return CallForPapers|Framework\MockObject\MockObject
      */
     private function createCallForPapersMock(): CallForPapers

--- a/tests/Unit/Http/Action/Talk/ViewActionTest.php
+++ b/tests/Unit/Http/Action/Talk/ViewActionTest.php
@@ -111,6 +111,8 @@ final class ViewActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|Speakers
      */
     private function createSpeakersMock(): Speakers
@@ -119,6 +121,8 @@ final class ViewActionTest extends AbstractActionTestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|Model\Talk
      */
     private function createTalkMock(): Model\Talk

--- a/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelIdentityProviderTest.php
@@ -97,6 +97,8 @@ final class SentinelIdentityProviderTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|Sentinel
      */
     private function createSentinelMock(): Sentinel
@@ -105,6 +107,8 @@ final class SentinelIdentityProviderTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return \Cartalyst\Sentinel\Users\UserInterface|Framework\MockObject\MockObject
      */
     private function createSentinelUserMock(): \Cartalyst\Sentinel\Users\UserInterface
@@ -113,6 +117,8 @@ final class SentinelIdentityProviderTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|UserRepository
      */
     private function createUserRepositoryMock(): UserRepository
@@ -121,6 +127,8 @@ final class SentinelIdentityProviderTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Framework\MockObject\MockObject|User
      */
     private function createUserMock(): User

--- a/tests/Unit/Infrastructure/CacheWarmer/HtmlPurifierWarmerTest.php
+++ b/tests/Unit/Infrastructure/CacheWarmer/HtmlPurifierWarmerTest.php
@@ -62,6 +62,8 @@ final class HtmlPurifierWarmerTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @return Filesystem\Filesystem|Framework\MockObject\MockObject
      */
     private function createFilesystemMock(): Filesystem\Filesystem

--- a/tests/Unit/Infrastructure/Repository/IlluminateUserRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Repository/IlluminateUserRepositoryTest.php
@@ -88,6 +88,8 @@ final class IlluminateUserRepositoryTest extends Framework\TestCase
     }
 
     /**
+     * @deprecated
+     *
      * @param string[] $methods
      *
      * @return Model\User|\PHPUnit_Framework_MockObject_MockObject


### PR DESCRIPTION
This PR

* [x] marks methods creating mocks as `@deprecated`

Follows #985.
Related to #983.

💁‍♂️ Marking these methods as `@deprecated` emphasises` that - going forward - we don't want to use the internal mocking facilities of `phpunit/phpunit` anymore.
