### PR TITLE
Fix: Explicitly disable php_unit_test_class_requires_covers fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -93,6 +93,7 @@ return PhpCsFixer\Config::create()
         'php_unit_expectation' => true,
         'php_unit_no_expectation_annotation' => true,
         'php_unit_strict' => true,
+        'php_unit_test_class_requires_covers' => false,
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,


### PR DESCRIPTION
This PR

* [x] explicitly disables the `php_unit_test_class_requires_covers` fixer

Follows #917.

💁‍♂️ I believe explicitly disabling the fixer, rather than just removing it, sends the signal that a) we are aware of the fixer, and b) have decided not to use it (anymore).