### PR TITLE
Enhancement: Enable and configure general_phpdoc_annotation_remove fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -63,6 +63,12 @@ return PhpCsFixer\Config::create()
         'declare_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
+        'general_phpdoc_annotation_remove' => [
+            'annotations' => [
+                'covers',
+                'coversNothing',
+            ],
+        ],
         'header_comment' => [
             'commentType' => 'PHPDoc',
             'header' => $header,

--- a/tests/Unit/Http/Action/Talk/EditActionTest.php
+++ b/tests/Unit/Http/Action/Talk/EditActionTest.php
@@ -20,9 +20,6 @@ use OpenCFP\Test\Unit\Http\Action\AbstractActionTestCase;
 use PHPUnit\Framework;
 use Symfony\Component\HttpFoundation;
 
-/**
- * @covers \OpenCFP\Http\Action\Talk\EditAction
- */
 final class EditActionTest extends AbstractActionTestCase
 {
     public function testRedirectsToDashboardIfCallForPapersIsClosed()


### PR DESCRIPTION
This PR

* [x] enables and configures the `general_phpdoc_annotation_remove` fixer
* [x] runs `make cs`

Follows #958.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.9.0#usage:

>**general_phpdoc_annotation_remove**
>
>Configured annotations should be omitted from phpdocs.
>
>Configuration options:
>
>* `annotations` (`array`): list of annotations to remove, e.g. `["author"]`; defaults to `[]`