### PR TITLE
Fix: Mark RefreshDatabase trait as deprecated

### DIFF
--- a/tests/Helper/RefreshDatabase.php
+++ b/tests/Helper/RefreshDatabase.php
@@ -15,6 +15,9 @@ namespace OpenCFP\Test\Helper;
 
 use Illuminate\Database\Capsule\Manager;
 
+/**
+ * @deprecated
+ */
 trait RefreshDatabase
 {
     final protected static function setUpDatabase()


### PR DESCRIPTION
This PR

* [x] marks the `RefreshDatabase` trait as deprecated

Related to https://github.com/opencfp/opencfp/issues/721.

💁‍♂️ I believe we are better of if we have a single means of resetting the database to a known state, and that should involve fetching the database connection from the container, rather than manually creating it.