### PR TITLE
Fix: Only use RefreshDatabase when needed

### DIFF
--- a/tests/Integration/Domain/Model/AirportTest.php
+++ b/tests/Integration/Domain/Model/AirportTest.php
@@ -15,13 +15,10 @@ namespace OpenCFP\Test\Integration\Domain\Model;
 
 use OpenCFP\Domain\EntityNotFoundException;
 use OpenCFP\Domain\Model\Airport;
-use OpenCFP\Test\Helper\RefreshDatabase;
 use OpenCFP\Test\Integration\WebTestCase;
 
 final class AirportTest extends WebTestCase
 {
-    use RefreshDatabase;
-
     /**
      * @var Airport
      */


### PR DESCRIPTION
This PR

* [x] removes `RefreshDatabase` from a test that doesn't need it