### PR TITLE
Fix: Dont copy phinx.yml if it is not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ cs: composer
 database: composer
 	mysql -uroot -e "DROP DATABASE IF EXISTS cfp_test"
 	mysql -uroot -e "CREATE DATABASE cfp_test"
-	cp phinx.yml.dist phinx.yml
+	if [ ! -f "phinx.yml" ]; then cp phinx.yml.dist phinx.yml; fi
 	vendor/bin/phinx migrate -e testing
 	mysqldump -uroot cfp_test > tests/dump.sql
 


### PR DESCRIPTION
This PR

* [x] Changes the ```make database``` command to only copy ```phinx.yml``` if it doesnt exist already.