### PR TITLE
Fix: Use appropriate route when redirecting

### DIFF
--- a/classes/Http/Controller/Reviewer/TalksController.php
+++ b/classes/Http/Controller/Reviewer/TalksController.php
@@ -46,7 +46,7 @@ class TalksController extends BaseController
                 'ext'   => 'Could not find requested talk',
             ]);
 
-            return $this->redirectTo('admin_talks');
+            return $this->redirectTo('reviewer_talks');
         }
 
         return $this->render('reviewer/talks/view.twig', [


### PR DESCRIPTION
This PR

* [x] uses the proper route name when redirecting

Blocks #1002.