### PR TITLE
Enhancement: Wrap tests in transactions

### DIFF
--- a/tests/Integration/Domain/Model/Interaction/TalkTest.php
+++ b/tests/Integration/Domain/Model/Interaction/TalkTest.php
@@ -17,10 +17,10 @@ use OpenCFP\Domain\Model\Favorite;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkComment;
 use OpenCFP\Domain\Model\TalkMeta;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class TalkTest extends WebTestCase implements RequiresDatabaseReset
+final class TalkTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @test

--- a/tests/Integration/Domain/Model/Interaction/UserTest.php
+++ b/tests/Integration/Domain/Model/Interaction/UserTest.php
@@ -15,10 +15,10 @@ namespace OpenCFP\Test\Integration\Domain\Model\Interaction;
 
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\User;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class UserTest extends WebTestCase implements RequiresDatabaseReset
+final class UserTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @test

--- a/tests/Integration/Http/Action/Admin/DashboardActionTest.php
+++ b/tests/Integration/Http/Action/Admin/DashboardActionTest.php
@@ -15,10 +15,10 @@ namespace OpenCFP\Test\Integration\Http\Action\Admin;
 
 use Illuminate\Database\Eloquent;
 use OpenCFP\Domain\Model;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class DashboardActionTest extends WebTestCase implements RequiresDatabaseReset
+final class DashboardActionTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @test

--- a/tests/Integration/Http/Action/Admin/Talk/IndexActionTest.php
+++ b/tests/Integration/Http/Action/Admin/Talk/IndexActionTest.php
@@ -15,10 +15,10 @@ namespace OpenCFP\Test\Integration\Http\Action\Admin\Talk;
 
 use Illuminate\Database\Eloquent;
 use OpenCFP\Domain\Model;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class IndexActionTest extends WebTestCase implements RequiresDatabaseReset
+final class IndexActionTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @test

--- a/tests/Integration/Http/Action/Reviewer/DashboardActionTest.php
+++ b/tests/Integration/Http/Action/Reviewer/DashboardActionTest.php
@@ -15,10 +15,10 @@ namespace OpenCFP\Test\Integration\Http\Action\Reviewer;
 
 use Illuminate\Database\Eloquent;
 use OpenCFP\Domain\Model;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class DashboardActionTest extends WebTestCase implements RequiresDatabaseReset
+final class DashboardActionTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @test

--- a/tests/Integration/Http/Action/Reviewer/Talk/IndexActionTest.php
+++ b/tests/Integration/Http/Action/Reviewer/Talk/IndexActionTest.php
@@ -15,10 +15,10 @@ namespace OpenCFP\Test\Integration\Http\Action\Reviewer\Talk;
 
 use Cartalyst\Support\Collection;
 use OpenCFP\Domain\Model;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class IndexActionTest extends WebTestCase implements RequiresDatabaseReset
+final class IndexActionTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @test

--- a/tests/Integration/Http/Action/Talk/CreateActionTest.php
+++ b/tests/Integration/Http/Action/Talk/CreateActionTest.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Integration\Http\Action\Talk;
 
 use OpenCFP\Domain\CallForPapers;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class CreateActionTest extends WebTestCase implements RequiresDatabaseReset
+final class CreateActionTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @test

--- a/tests/Integration/Http/Controller/ForgotControllerTest.php
+++ b/tests/Integration/Http/Controller/ForgotControllerTest.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Integration\Http\Controller;
 
 use OpenCFP\Domain\Services\AccountManagement;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class ForgotControllerTest extends WebTestCase implements RequiresDatabaseReset
+final class ForgotControllerTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @test

--- a/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAccountManagementTest.php
@@ -17,10 +17,10 @@ use Cartalyst\Sentinel\Native\Facades\Sentinel;
 use OpenCFP\Domain\Model\User;
 use OpenCFP\Infrastructure\Auth\SentinelAccountManagement;
 use OpenCFP\Infrastructure\Auth\UserExistsException;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class SentinelAccountManagementTest extends WebTestCase implements RequiresDatabaseReset
+final class SentinelAccountManagementTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @var SentinelAccountManagement

--- a/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -17,10 +17,10 @@ use Cartalyst\Sentinel\Native\Facades\Sentinel;
 use OpenCFP\Domain\Services\AuthenticationException;
 use OpenCFP\Infrastructure\Auth\SentinelAccountManagement;
 use OpenCFP\Infrastructure\Auth\SentinelAuthentication;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class SentinelAuthenticationTest extends WebTestCase implements RequiresDatabaseReset
+final class SentinelAuthenticationTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @var SentinelAuthentication

--- a/tests/Integration/TransactionalTestCase.php
+++ b/tests/Integration/TransactionalTestCase.php
@@ -13,6 +13,6 @@ declare(strict_types=1);
 
 namespace OpenCFP\Test\Integration;
 
-interface RequiresDatabaseReset
+interface TransactionalTestCase
 {
 }


### PR DESCRIPTION
This PR

* [x] renames the marker interface `RequiresDatabaseReset` to `TransactionalTestCase` and wraps tests in transactions

Follows https://github.com/opencfp/opencfp/pull/991#issuecomment-352565555.


### Before

```
$ make integration

vendor/bin/phpunit --testsuite integration
PHPUnit 6.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.0.25
Configuration: /Users/am/Sites/opencfp/opencfp/phpunit.xml.dist

.................................................................................................................................................................                                                                                                                                             161 / 161 (100%)

Time: 42.77 seconds, Memory: 354.00MB

OK (161 tests, 935 assertions)
```

### After

```
$ make integration

vendor/bin/phpunit --testsuite integration
PHPUnit 6.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.0.25
Configuration: /Users/am/Sites/opencfp/opencfp/phpunit.xml.dist

.................................................................................................................................................................                                                                                                                                             161 / 161 (100%)

Time: 21.78 seconds, Memory: 354.00MB

OK (161 tests, 935 assertions)
```