### PR TITLE
Fix: Use TransactionalTestCase instead of removed RequiresDatabaseReset

### DIFF
--- a/tests/Integration/Http/Action/Admin/Talk/ViewActionTest.php
+++ b/tests/Integration/Http/Action/Admin/Talk/ViewActionTest.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Integration\Http\Action\Admin\Talk;
 
 use OpenCFP\Domain\Model;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class ViewActionTest extends WebTestCase implements RequiresDatabaseReset
+final class ViewActionTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * Verify that not found talk redirects

--- a/tests/Integration/Http/Action/Talk/UpdateActionTest.php
+++ b/tests/Integration/Http/Action/Talk/UpdateActionTest.php
@@ -13,11 +13,10 @@ declare(strict_types=1);
 
 namespace OpenCFP\Test\Integration\Http\Action\Talk;
 
-use OpenCFP\Domain\Model\Talk;
-use OpenCFP\Test\Integration\RequiresDatabaseReset;
+use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
-final class UpdateActionTest extends WebTestCase implements RequiresDatabaseReset
+final class UpdateActionTest extends WebTestCase implements TransactionalTestCase
 {
     /**
      * @test


### PR DESCRIPTION
This PR

* [x] uses `TransactionalTestCase` instead of `RequiresDatabaseReset`

Follows #959.
Follows #1001.
Follows #1004.

Blocks #996.
Blocks #1002.
Blocks #1003.

💁‍♂️ This should fix the broken build.

