### PR TITLE
Add html coverage to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ composer:
 	composer install
 
 coverage: composer
-	vendor/bin/phpunit --testsuite unit --coverage-text
+	if [ $(type) = "html" ]; then vendor/bin/phpunit --testsuite unit --coverage-html coverage; else vendor/bin/phpunit --testsuite unit --coverage-text; fi;
 
 cs: composer
 	vendor/bin/php-cs-fixer fix --verbose --diff


### PR DESCRIPTION
This PR

* [x] Adds to option to create html coverage from the makefile

Run ```make coverage type=html``` to build the phpunit coverage report

It currently goes to the coverage folder, this was already in the gitignore, so it seemed like a logical place