### PR TITLE
Fix: Deprecate abstract Form class

### DIFF
--- a/classes/Http/Form/Form.php
+++ b/classes/Http/Form/Form.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Form;
 
+/**
+ * @deprecated
+ */
 abstract class Form
 {
     /**


### PR DESCRIPTION
This PR

* [x] marks the `abstract` `Form` class as deprecated

💁‍♂️ We should probably use Symfony forms instead.
