### PR TITLE
Since adding flash before default content, we do not need doubles

### DIFF
--- a/resources/views/home.twig
+++ b/resources/views/home.twig
@@ -38,7 +38,5 @@
     </div>
 {% endblock %}
 {% block content %}
-    {% include "_flash.twig" %}
-
     {% include "_marketing.twig" %}
 {% endblock %}

--- a/resources/views/user/edit.twig
+++ b/resources/views/user/edit.twig
@@ -22,7 +22,6 @@
 {% endblock %}
 
 {% block content %}
-    {% include '_flash.twig' %}
     <h2 class="headline">My Profile</h2>
     {% include 'forms/_user.twig' %}
 {% endblock %}


### PR DESCRIPTION
This PR resolves this 🌶 

![image](https://user-images.githubusercontent.com/2453394/34240146-141f24fe-e5da-11e7-9451-a9b7c94e2cde.png)

We recently added an include for the flash template before content on all templates extending `default.twig`. There were a few forgotten usages of flash that caused issues like this. I `grep`-ed for occurrences of `_flash.twig` and removed what made sense.\

Follows #900.