### PR TITLE
Fix: Add test-env to phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: asset composer coverage cs database infection integration it test unit
+.PHONY: asset composer coverage cs database infection integration it test test-env unit
 
 it: cs test
 


### PR DESCRIPTION
This PR

* [x] adds `test-env` as a phony target

Follows #1024.