### PR TITLE
Fix: Refresh database before and after class

### DIFF
--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -63,7 +63,12 @@ abstract class WebTestCase extends KernelTestCase
 
     public static function setUpBeforeClass()
     {
-        self::runBeforeClassTraits();
+        self::runBeforeAndAfterClassTraits();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::runBeforeAndAfterClassTraits();
     }
 
     protected function setUp()
@@ -104,9 +109,9 @@ abstract class WebTestCase extends KernelTestCase
     }
 
     /**
-     * Runs setups from Traits that are needed before the class is setup (as called from setUpBeforeClass)
+     * @deprecated
      */
-    private static function runBeforeClassTraits()
+    private static function runBeforeAndAfterClassTraits()
     {
         $uses = \array_flip(class_uses_recursive(static::class));
 


### PR DESCRIPTION
This PR

* [x] refreshes the database before **and** after the class

Blocks #1030.

💁‍♂️ I have been scratching my head because tests in #1030 are failing. Then it dawned on me that of course, when we have integration tests run from a test class that uses the `RefreshDatabase` trait, and the next test class does not use the `RefreshDatabase` trait, but instead implements the `TransactionalTestCase`, then the database won't be fresh in the latter, and tests might fail (as they currently do in #1030). So unfortunately, until we remove the `RefreshDatabase` trait (working on it), we'll have to refresh the database twice.
