### PR TITLE
Fix: Increase memory limit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
     <php>
         <!-- https://github.com/symfony/console/blob/v3.3.12/Terminal.php#L24-L36 -->
         <env name="COLUMNS" value="120"/>
-        <ini name="memory_limit" value="512M"/>
+        <ini name="memory_limit" value="768M"/>
         <server name="CFP_ENV" value="testing"/>
     </php>
     <filter>


### PR DESCRIPTION
This PR

* [x] increases the memory limit for running tests

Blocks #1030.

💁‍♂️ Running tests fails there because the current memory limit of `512M` is exceeded a bit.
