### PR TITLE
Fix: Don't assume a user identifier

### DIFF
--- a/tests/Integration/Http/Action/Admin/DashboardActionTest.php
+++ b/tests/Integration/Http/Action/Admin/DashboardActionTest.php
@@ -25,11 +25,14 @@ final class DashboardActionTest extends WebTestCase implements TransactionalTest
      */
     public function indexDisplaysListOfTalks()
     {
+        /** @var Model\User $admin */
+        $admin = factory(Model\User::class)->create()->first();
+
         /** @var Eloquent\Collection|Model\Talk[] $talks */
         $talks = factory(Model\Talk::class, 2)->create();
 
         $response = $this
-            ->asAdmin()
+            ->asAdmin($admin->id)
             ->get('/admin/');
 
         $this->assertResponseIsSuccessful($response);

--- a/tests/Integration/Http/Action/Admin/Talk/IndexActionTest.php
+++ b/tests/Integration/Http/Action/Admin/Talk/IndexActionTest.php
@@ -25,11 +25,14 @@ final class IndexActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function indexPageDisplaysTalksCorrectly()
     {
+        /** @var Model\User $admin */
+        $admin = factory(Model\User::class)->create()->first();
+
         /** @var Eloquent\Collection|Model\Talk[] $talks */
         $talks = factory(Model\Talk::class, 3)->create();
 
         $response = $this
-            ->asAdmin()
+            ->asAdmin($admin->id)
             ->get('/admin/talks');
 
         $this->assertResponseIsSuccessful($response);
@@ -46,8 +49,11 @@ final class IndexActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function indexPageWorkWithNoTalks()
     {
+        /** @var Model\User $admin */
+        $admin = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asAdmin()
+            ->asAdmin($admin->id)
             ->get('/admin/talks');
 
         $this->assertResponseIsSuccessful($response);

--- a/tests/Integration/Http/Action/Admin/Talk/ViewActionTest.php
+++ b/tests/Integration/Http/Action/Admin/Talk/ViewActionTest.php
@@ -39,11 +39,14 @@ final class ViewActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function talkWithNoMetaDisplaysCorrectly()
     {
+        /** @var Model\User $admin */
+        $admin = factory(Model\User::class)->create()->first();
+
         /** @var Model\Talk $talk */
         $talk = factory(Model\Talk::class)->create()->first();
 
         $response = $this
-            ->asAdmin()
+            ->asAdmin($admin->id)
             ->get('/admin/talks/' . $talk->id);
 
         $this->assertResponseIsSuccessful($response);

--- a/tests/Integration/Http/Action/Reviewer/DashboardActionTest.php
+++ b/tests/Integration/Http/Action/Reviewer/DashboardActionTest.php
@@ -25,11 +25,14 @@ final class DashboardActionTest extends WebTestCase implements TransactionalTest
      */
     public function indexDisplaysListOfTalks()
     {
+        /** @var Model\User[] $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
         /** @var Eloquent\Collection|Model\Talk[] $talks */
         $talks = factory(Model\Talk::class, 2)->create();
 
         $response = $this
-            ->asReviewer()
+            ->asReviewer($reviewer->id)
             ->get('/reviewer/');
 
         $this->assertResponseIsSuccessful($response);

--- a/tests/Integration/Http/Action/Reviewer/Speaker/ViewActionTest.php
+++ b/tests/Integration/Http/Action/Reviewer/Speaker/ViewActionTest.php
@@ -24,10 +24,13 @@ final class ViewActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function viewActionRedirectsWhenUserDoesntExist()
     {
-        $id = $this->faker()->numberBetween(1);
+        /** @var Model\User $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
+        $id = $this->faker()->numberBetween(100);
 
         $response = $this
-            ->asReviewer()
+            ->asReviewer($reviewer->id)
             ->get('/reviewer/speakers/' . $id);
 
         $this->assertResponseBodyNotContains('Speaker Bio', $response);
@@ -39,11 +42,14 @@ final class ViewActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function viewActionShowsSpeaker()
     {
+        /** @var Model\User $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
         /** @var Model\User $speaker */
         $speaker = factory(Model\User::class, 1)->create()->first();
 
         $response = $this
-            ->asReviewer()
+            ->asReviewer($reviewer->id)
             ->get('/reviewer/speakers/' . $speaker->id);
 
         $this->assertResponseIsSuccessful($response);

--- a/tests/Integration/Http/Action/Reviewer/Talk/IndexActionTest.php
+++ b/tests/Integration/Http/Action/Reviewer/Talk/IndexActionTest.php
@@ -25,11 +25,14 @@ final class IndexActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function indexActionWorksNormally()
     {
+        /** @var Model\User $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
         /** @var Collection|Model\Talk[] $talks */
         $talks = factory(Model\Talk::class, 3)->create();
 
         $response = $this
-            ->asReviewer()
+            ->asReviewer($reviewer->id)
             ->get('/reviewer/talks');
 
         $this->assertResponseIsSuccessful($response);

--- a/tests/Integration/Http/Action/Reviewer/Talk/ViewActionTest.php
+++ b/tests/Integration/Http/Action/Reviewer/Talk/ViewActionTest.php
@@ -24,10 +24,13 @@ final class ViewActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function viewActionWillRedirectWhenTalkNotFound()
     {
-        $id = $this->faker()->numberBetween(1);
+        /** @var Model\User $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
+        $id = $this->faker()->numberBetween(100);
 
         $response = $this
-            ->asReviewer()
+            ->asReviewer($reviewer->id)
             ->get('/reviewer/talks/' . $id);
 
         $this->assertResponseBodyNotContains('title="I want to see this talk"', $response);
@@ -39,11 +42,14 @@ final class ViewActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function viewActionWillShowTalk()
     {
+        /** @var Model\User $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
         /** @var Model\Talk $talk */
         $talk = factory(Model\Talk::class)->create()->first();
 
         $response = $this
-            ->asReviewer()
+            ->asReviewer($reviewer->id)
             ->get('/reviewer/talks/' . $talk->id);
 
         $this->assertResponseIsSuccessful($response);

--- a/tests/Integration/Http/Action/Signup/IndexActionTest.php
+++ b/tests/Integration/Http/Action/Signup/IndexActionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Test\Integration\Http\Action\Signup;
 
+use OpenCFP\Domain\Model;
 use OpenCFP\Test\Integration\WebTestCase;
 
 final class IndexActionTest extends WebTestCase
@@ -48,8 +49,11 @@ final class IndexActionTest extends WebTestCase
      */
     public function signUpRedirectsWhenLoggedIn()
     {
+        /** @var Model\User $admin */
+        $admin = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asAdmin()
+            ->asAdmin($admin->id)
             ->get('/signup');
 
         $this->assertResponseIsRedirect($response);

--- a/tests/Integration/Http/Action/Talk/CreateActionTest.php
+++ b/tests/Integration/Http/Action/Talk/CreateActionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Integration\Http\Action\Talk;
 
 use OpenCFP\Domain\CallForPapers;
+use OpenCFP\Domain\Model;
 use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
@@ -38,13 +39,16 @@ final class CreateActionTest extends WebTestCase implements TransactionalTestCas
 
         $this->container->get('twig')->addGlobal('cfp_open', $callForPapers->isOpen());
 
+        /** @var Model\User $speaker */
+        $speaker = factory(Model\User::class)->create()->first();
+
         /*
          * This should not have a flash message. The fact that this
          * is true means code is working as intended. Previously this fails
          * because the CFP incorrectly ended at 12:00am the day of, not 11:59pm.
          */
         $response = $this
-            ->asLoggedInSpeaker()
+            ->asLoggedInSpeaker($speaker->id)
             ->get('/talk/create');
 
         $this->assertResponseBodyContains('Create Your Talk', $response);
@@ -55,8 +59,11 @@ final class CreateActionTest extends WebTestCase implements TransactionalTestCas
      */
     public function cantCreateTalkAfterCFPIsClosed()
     {
+        /** @var Model\User $speaker */
+        $speaker = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asLoggedInSpeaker()
+            ->asLoggedInSpeaker($speaker->id)
             ->callForPapersIsClosed()
             ->get('/talk/create');
 

--- a/tests/Integration/Http/Action/Talk/CreateProcessActionTest.php
+++ b/tests/Integration/Http/Action/Talk/CreateProcessActionTest.php
@@ -104,8 +104,11 @@ final class CreateProcessActionTest extends WebTestCase implements Transactional
      */
     public function processCreateTalkFailsWithBadToken()
     {
+        /** @var Model\User $speaker */
+        $speaker = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asLoggedInSpeaker()
+            ->asLoggedInSpeaker($speaker->id)
             ->callForPapersIsOpen()
             ->post('/talk/create', [
                 'description' => 'Talk Description',

--- a/tests/Integration/Http/Action/Talk/EditActionTest.php
+++ b/tests/Integration/Http/Action/Talk/EditActionTest.php
@@ -65,11 +65,11 @@ final class EditActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function getRedirectedToDashboardWhenTalkIsNotYours()
     {
-        /** @var Talk $talk */
-        $talk = factory(Talk::class, 1)->create()->first();
-
         /** @var User $otherSpeaker */
         $otherSpeaker = factory(User::class, 1)->create()->first();
+
+        /** @var Talk $talk */
+        $talk = factory(Talk::class, 1)->create()->first();
 
         $response = $this
             ->asLoggedInSpeaker($otherSpeaker->id)
@@ -84,11 +84,11 @@ final class EditActionTest extends WebTestCase implements TransactionalTestCase
      */
     public function seeEditPageWhenAllowed()
     {
-        /** @var Talk $talk */
-        $talk = factory(Talk::class, 1)->create()->first();
-
         /** @var User $speaker */
-        $speaker = $talk->speaker->first();
+        $speaker = factory(User::class, 1)->create()->first();
+
+        /** @var Talk $talk */
+        $talk = factory(Talk::class, 1)->create(['user_id' => $speaker->id])->first();
 
         $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('edit_talk')

--- a/tests/Integration/Http/Action/Talk/UpdateActionTest.php
+++ b/tests/Integration/Http/Action/Talk/UpdateActionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Test\Integration\Http\Action\Talk;
 
+use OpenCFP\Domain\Model;
 use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
@@ -23,12 +24,15 @@ final class UpdateActionTest extends WebTestCase implements TransactionalTestCas
      */
     public function cantUpdateActionAFterCFPIsClosed()
     {
+        /** @var Model\User $speaker */
+        $speaker = factory(Model\User::class)->create()->first();
+
         $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('speaker_talk')
             ->getValue();
 
         $response = $this
-            ->asLoggedInSpeaker()
+            ->asLoggedInSpeaker($speaker->id)
             ->callForPapersIsClosed()
             ->post('/talk/update', [
                 'id'       => 2,
@@ -45,12 +49,15 @@ final class UpdateActionTest extends WebTestCase implements TransactionalTestCas
      */
     public function cantUpdateActionWithInvalidData()
     {
+        /** @var Model\User $speaker */
+        $speaker = factory(Model\User::class)->create()->first();
+
         $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('speaker_talk')
             ->getValue();
 
         $response = $this
-            ->asLoggedInSpeaker()
+            ->asLoggedInSpeaker($speaker->id)
             ->callForPapersIsOpen()
             ->post('/talk/update', [
                 'id'       => 2,
@@ -67,8 +74,11 @@ final class UpdateActionTest extends WebTestCase implements TransactionalTestCas
      */
     public function cantUpdateActionWithBadToken()
     {
+        /** @var Model\User $speaker */
+        $speaker = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asLoggedInSpeaker()
+            ->asLoggedInSpeaker($speaker->id)
             ->callForPapersIsOpen()
             ->post('/talk/update', [
                 'id'       => 2,

--- a/tests/Integration/Infrastructure/Event/AuthenticationListenerTest.php
+++ b/tests/Integration/Infrastructure/Event/AuthenticationListenerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP\Test\Integration\Infrastructure\Event;
 
+use OpenCFP\Domain\Model;
 use OpenCFP\Test\Integration\WebTestCase;
 
 use Symfony\Component\HttpFoundation;
@@ -37,8 +38,11 @@ final class AuthenticationListenerTest extends WebTestCase
 
     public function testTalksRouteWithLogin()
     {
+        /** @var Model\User $speaker */
+        $speaker = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asLoggedInSpeaker()
+            ->asLoggedInSpeaker($speaker->id)
             ->get('/talk/create');
 
         $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_OK, $response);
@@ -55,8 +59,11 @@ final class AuthenticationListenerTest extends WebTestCase
 
     public function testReviewerDashboardRequiresReviewer()
     {
+        /** @var Model\User $speaker */
+        $speaker = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asLoggedInSpeaker()
+            ->asLoggedInSpeaker($speaker->id)
             ->get('/reviewer/');
 
         $url = $this->container->get('router')->generate('dashboard');
@@ -66,8 +73,11 @@ final class AuthenticationListenerTest extends WebTestCase
 
     public function testReviewerDashboardAsReviewer()
     {
+        /** @var Model\User $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asReviewer()
+            ->asReviewer($reviewer->id)
             ->get('/reviewer/');
 
         $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_OK, $response);
@@ -84,8 +94,11 @@ final class AuthenticationListenerTest extends WebTestCase
 
     public function testAdminDashboardRequiresAdmin()
     {
+        /** @var Model\User $speaker */
+        $speaker = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asLoggedInSpeaker()
+            ->asLoggedInSpeaker($speaker->id)
             ->get('/admin/');
 
         $url = $this->container->get('router')->generate('dashboard');
@@ -95,8 +108,11 @@ final class AuthenticationListenerTest extends WebTestCase
 
     public function testAdminDashboardAsAdmin()
     {
+        /** @var Model\User $admin */
+        $admin = factory(Model\User::class)->create()->first();
+
         $response = $this
-            ->asAdmin()
+            ->asAdmin($admin->id)
             ->get('/admin/');
 
         $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_OK, $response);

--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -168,7 +168,7 @@ abstract class WebTestCase extends KernelTestCase
         return $this;
     }
 
-    final protected function asLoggedInSpeaker(int $id = 1): self
+    final protected function asLoggedInSpeaker(int $id): self
     {
         $user = Mockery::mock(UserInterface::class);
         $user->shouldReceive('id')->andReturn($id);
@@ -190,7 +190,7 @@ abstract class WebTestCase extends KernelTestCase
         return $this;
     }
 
-    final protected function asAdmin(int $id = 1): self
+    final protected function asAdmin(int $id): self
     {
         $user = Mockery::mock(UserInterface::class);
         $user->shouldReceive('id')->andReturn($id);
@@ -211,7 +211,7 @@ abstract class WebTestCase extends KernelTestCase
         return $this;
     }
 
-    final protected function asReviewer(int $id = 1): self
+    final protected function asReviewer(int $id): self
     {
         $user = Mockery::mock(UserInterface::class);
         $user->shouldReceive('id')->andReturn($id);


### PR DESCRIPTION
This PR

* [x] removes default values for identifiers when setting up signed in users in tests

  