### PR TITLE
Fix talk form validation

### DIFF
--- a/classes/Http/Form/TalkForm.php
+++ b/classes/Http/Form/TalkForm.php
@@ -56,7 +56,14 @@ class TalkForm extends Form
 
     public function validateAll(string $action = 'create'): bool
     {
-        return $this->validateTitle() && $this->validateDescription() && $this->validateLevel() && $this->validateCategory();
+        $title       = $this->validateTitle();
+        $description = $this->validateDescription();
+        $level       = $this->validateLevel();
+        $category    = $this->validateCategory();
+        $slides      = $this->validateSlides();
+        $type        = $this->validateType();
+
+        return $title && $description && $level && $category && $slides && $type;
     }
 
     public function validateTitle(): bool
@@ -139,6 +146,21 @@ class TalkForm extends Form
 
         if (!isset($validCategories[$this->cleanData['category']])) {
             $this->addErrorMessage('You did not choose a valid talk category');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public function validateSlides(): bool
+    {
+        if (!isset($this->cleanData['slides']) || empty($this->cleanData['slides'])) {
+            return true;
+        }
+
+        if (\strlen(($this->cleanData['slides'])) >= 255) {
+            $this->addErrorMessage('Your slides url has to be less than 255 characters long');
 
             return false;
         }

--- a/tests/Unit/Http/Form/TalkFormTest.php
+++ b/tests/Unit/Http/Form/TalkFormTest.php
@@ -371,4 +371,39 @@ final class TalkFormTest extends \PHPUnit\Framework\TestCase
             [true, false],
         ];
     }
+
+    /**
+     * @test
+     * @dataProvider slidesProvider
+     *
+     * @param $slides
+     * @param $expectedResponse
+     */
+    public function slidesValidatesCorrectly($slides, $expectedResponse)
+    {
+        $data = ['slides' => $slides];
+        $form = new \OpenCFP\Http\Form\TalkForm($data, $this->purifier);
+        $form->sanitize();
+
+        $this->assertSame(
+            $expectedResponse,
+            $form->validateSlides(),
+            \sprintf(
+                '%s::validateSlides() did not apply validation rules correctly',
+                \OpenCFP\Http\Form\TalkForm::class
+            )
+        );
+    }
+
+    public function slidesProvider(): array
+    {
+        return [
+            [null, true],
+            ['', true],
+            ['google.nl', true],
+            ['http://www.slides-longer-than-255-characters.com/01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345', false],
+            ['http://www.slides-longer-than-255-characters.com/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234', true],
+
+        ];
+    }
 }


### PR DESCRIPTION
This PR

* [x] Makes sure slides cant be over 255 characters, as this would cause a db error down the line
* [x] Validates Type 
* [x] Makes sure all checks are ran when validating. 
  * Before you would only see the first thing that caused an error, now you get to see all the errors in your form submission.
