### PR TITLE
Fix: Remove duplicated tests

### DIFF
--- a/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
+++ b/tests/Integration/Http/Controller/Reviewer/TalksControllerTest.php
@@ -31,35 +31,6 @@ final class TalksControllerTest extends WebTestCase
 
     /**
      * @test
-     */
-    public function viewActionWillRedirectWhenTalkNotFound()
-    {
-        $response = $this
-            ->asReviewer()
-            ->get('/reviewer/talks/255');
-
-        $this->assertResponseBodyNotContains('title="I want to see this talk"', $response);
-        $this->assertResponseIsRedirect($response);
-    }
-
-    /**
-     * @test
-     */
-    public function viewActionWillShowTalk()
-    {
-        $talk = self::$talks->first();
-
-        $response = $this
-            ->asReviewer()
-            ->get('/reviewer/talks/' . $talk->id);
-
-        $this->assertResponseIsSuccessful($response);
-        $this->assertResponseBodyContains($talk->title, $response);
-        $this->assertResponseBodyContains($talk->description, $response);
-    }
-
-    /**
-     * @test
      * @dataProvider providerValidRating
      *
      * @param mixed $rating


### PR DESCRIPTION
This PR

* [x] removes duplicated tests

Follows #924.

🤷‍♂️ Should have removed these tests in #924. Also see [`ViewActionTest`](https://github.com/opencfp/opencfp/blob/6102f17445eabb9287f1807976dde7c3897db5d7/tests/Integration/Http/Action/Reviewer/Talk/ViewActionTest.php).