### PR TITLE
Fix: Remove references to undefined classes

### DIFF
--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -56,8 +56,6 @@ final class ProjectCodeTest extends Framework\TestCase
                 Http\Controller\ProfileController::class,
                 Http\Controller\Reviewer\SpeakersController::class,
                 Http\Controller\Reviewer\TalksController::class,
-                Http\Controller\SecurityController::class,
-                Http\Controller\TalkController::class,
                 Http\Form\ForgotFormType::class,
                 Http\Form\ResetFormType::class,
                 Infrastructure\DependencyInjection\TestingPass::class,


### PR DESCRIPTION
This PR

* [x] removes references to undefined classes

Follows #1021.
Follows #1041.

💁‍♂️ Forgot to remove them here.