### PR TITLE
Fix: Split try-and-catch block

### DIFF
--- a/tests/Integration/Http/Action/Admin/Speaker/PromoteActionTest.php
+++ b/tests/Integration/Http/Action/Admin/Speaker/PromoteActionTest.php
@@ -25,6 +25,8 @@ final class PromoteActionTest extends WebTestCase implements TransactionalTestCa
      */
     public function promoteActionFailsOnUserNotFound()
     {
+        $id = $this->faker()->numberBetween(500);
+
         /** @var Model\User $admin */
         $admin = factory(Model\User::class, 1)->create()->first();
 
@@ -37,7 +39,7 @@ final class PromoteActionTest extends WebTestCase implements TransactionalTestCa
             ->get(
                 \sprintf(
                     '/admin/speakers/%s/promote',
-                    $this->faker()->numberBetween(500)
+                    $id
                 ),
                 [
                     'role'     => 'Admin',
@@ -48,7 +50,13 @@ final class PromoteActionTest extends WebTestCase implements TransactionalTestCa
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('admin/speakers', $response);
-        $this->assertSessionHasFlashMessage('We were unable to promote the Admin. Please try again.', $this->session());
+
+        $flashMessage = \sprintf(
+            'User with id "%s" could not be found.',
+            $id
+        );
+
+        $this->assertSessionHasFlashMessage($flashMessage, $this->session());
     }
 
     /**
@@ -90,7 +98,7 @@ final class PromoteActionTest extends WebTestCase implements TransactionalTestCa
 
         $this->assertResponseIsRedirect($response);
         $this->assertRedirectResponseUrlContains('admin/speakers', $response);
-        $this->assertSessionHasFlashMessage('User already is in the Admin group.', $this->session());
+        $this->assertSessionHasFlashMessage('User already is in the "Admin" group.', $this->session());
     }
 
     /**

--- a/tests/Unit/Http/Action/Admin/Speaker/PromoteActionTest.php
+++ b/tests/Unit/Http/Action/Admin/Speaker/PromoteActionTest.php
@@ -44,8 +44,8 @@ final class PromoteActionTest extends Framework\TestCase
                     'type'  => 'error',
                     'short' => 'Error',
                     'ext'   => \sprintf(
-                        'We were unable to promote the %s. Please try again.',
-                        $role
+                        'User with id "%s" could not be found.',
+                        $id
                     ),
                 ])
             )
@@ -113,7 +113,7 @@ final class PromoteActionTest extends Framework\TestCase
                     'type'  => 'error',
                     'short' => 'Error',
                     'ext'   => \sprintf(
-                        'User already is in the %s group.',
+                        'User already is in the "%s" group.',
                         $role
                     ),
                 ])
@@ -190,7 +190,7 @@ final class PromoteActionTest extends Framework\TestCase
                     'type'  => 'error',
                     'short' => 'Error',
                     'ext'   => \sprintf(
-                        'We were unable to promote the %s. Please try again.',
+                        'Role "%s" could not be found.',
                         $role
                     ),
                 ])


### PR DESCRIPTION
This PR

* [x] splits a `try`-and-`catch` block

Follows https://github.com/opencfp/opencfp/pull/1048#discussion_r158587123.