### PR TITLE
Fix: No need to install SQLite on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,13 +46,6 @@ jobs:
 
       php: 7.0
 
-      addons:
-        apt:
-          sources:
-            - travis-ci/sqlite3
-          packages:
-            - sqlite3
-
       before_install:
         - source .travis/xdebug.sh
         - xdebug-disable


### PR DESCRIPTION
This PR

* [x] removes configuration to install SQLite on Travis