### PR TITLE
Removed Silex-compatible service aliases

### DIFF
--- a/resources/config/config_testing.yml
+++ b/resources/config/config_testing.yml
@@ -13,15 +13,6 @@ services:
     decorates: OpenCFP\Domain\Services\IdentityProvider
     arguments: ['@OpenCFP\Test\Helper\MockIdentityProvider.inner']
 
-  # Compatibility for integration tests that still expect the service IDs as Silex registers them.
-  csrf.token_manager:
-    alias: security.csrf.token_manager
-    public: true
-
-  url_generator:
-    alias: router
-    public: true
-
 framework:
   session:
     storage_id: session.storage.mock_file

--- a/tests/Integration/Http/Action/Admin/Speaker/PromoteActionTest.php
+++ b/tests/Integration/Http/Action/Admin/Speaker/PromoteActionTest.php
@@ -30,7 +30,7 @@ final class PromoteActionTest extends WebTestCase implements TransactionalTestCa
         /** @var Model\User $admin */
         $admin = factory(Model\User::class, 1)->create()->first();
 
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('admin_speaker_promote')
             ->getValue();
 
@@ -78,7 +78,7 @@ final class PromoteActionTest extends WebTestCase implements TransactionalTestCa
             'admin'
         );
 
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('admin_speaker_promote')
             ->getValue();
 
@@ -112,7 +112,7 @@ final class PromoteActionTest extends WebTestCase implements TransactionalTestCa
         /** @var Model\User $speaker */
         $speaker = factory(Model\User::class, 1)->create()->first();
 
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('admin_speaker_promote')
             ->getValue();
 

--- a/tests/Integration/Http/Action/Talk/CreateProcessActionTest.php
+++ b/tests/Integration/Http/Action/Talk/CreateProcessActionTest.php
@@ -27,7 +27,7 @@ final class CreateProcessActionTest extends WebTestCase implements Transactional
         /** @var Model\User $user */
         $user = factory(Model\User::class)->create()->first();
 
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('edit_talk');
 
         $response = $this
@@ -56,7 +56,7 @@ final class CreateProcessActionTest extends WebTestCase implements Transactional
         /** @var Model\User $user */
         $user = factory(Model\User::class)->create()->first();
 
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('speaker_talk')
             ->getValue();
 
@@ -81,7 +81,7 @@ final class CreateProcessActionTest extends WebTestCase implements Transactional
         /** @var Model\User $user */
         $user = factory(Model\User::class)->create()->first();
 
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('speaker_talk')
             ->getValue();
 

--- a/tests/Integration/Http/Action/Talk/DeleteActionTest.php
+++ b/tests/Integration/Http/Action/Talk/DeleteActionTest.php
@@ -45,7 +45,7 @@ final class DeleteActionTest extends WebTestCase
      */
     public function notAllowedToDeleteAfterCFPIsOver()
     {
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('delete_talk')
             ->getValue();
 
@@ -68,7 +68,7 @@ final class DeleteActionTest extends WebTestCase
      */
     public function notAllowedToDeleteSomeoneElseTalk()
     {
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('delete_talk')
             ->getValue();
 

--- a/tests/Integration/Http/Action/Talk/EditActionTest.php
+++ b/tests/Integration/Http/Action/Talk/EditActionTest.php
@@ -45,7 +45,7 @@ final class EditActionTest extends WebTestCase
      */
     public function canNotEditTalkAfterCfpIsClosed()
     {
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('edit_talk');
 
         $response = $this
@@ -90,7 +90,7 @@ final class EditActionTest extends WebTestCase
      */
     public function seeEditPageWhenAllowed()
     {
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('edit_talk')
             ->getValue();
 

--- a/tests/Integration/Http/Action/Talk/UpdateActionTest.php
+++ b/tests/Integration/Http/Action/Talk/UpdateActionTest.php
@@ -23,7 +23,7 @@ final class UpdateActionTest extends WebTestCase implements TransactionalTestCas
      */
     public function cantUpdateActionAFterCFPIsClosed()
     {
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('speaker_talk')
             ->getValue();
 
@@ -45,7 +45,7 @@ final class UpdateActionTest extends WebTestCase implements TransactionalTestCas
      */
     public function cantUpdateActionWithInvalidData()
     {
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('speaker_talk')
             ->getValue();
 

--- a/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
+++ b/tests/Integration/Http/Controller/Admin/SpeakersControllerTest.php
@@ -81,7 +81,7 @@ final class SpeakersControllerTest extends WebTestCase
      */
     public function demoteActionFailsIfUserNotFound()
     {
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('admin_speaker_demote')
             ->getValue();
 
@@ -104,7 +104,7 @@ final class SpeakersControllerTest extends WebTestCase
     public function demoteActionFailsIfDemotingSelf()
     {
         $user      = $this->users->last();
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('admin_speaker_demote')
             ->getValue();
 
@@ -131,7 +131,7 @@ final class SpeakersControllerTest extends WebTestCase
         $this->container->get(AccountManagement::class)
             ->promoteTo($this->users->first()->email, 'admin');
 
-        $csrfToken = $this->container->get('csrf.token_manager')
+        $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('admin_speaker_demote')
             ->getValue();
 

--- a/tests/Integration/Infrastructure/Event/AuthenticationListenerTest.php
+++ b/tests/Integration/Infrastructure/Event/AuthenticationListenerTest.php
@@ -30,7 +30,7 @@ final class AuthenticationListenerTest extends WebTestCase
     {
         $response = $this->get('/talk/create');
 
-        $url = $this->container->get('url_generator')->generate('dashboard');
+        $url = $this->container->get('router')->generate('dashboard');
 
         $this->assertRedirectResponseUrlEquals($url, $response);
     }
@@ -48,7 +48,7 @@ final class AuthenticationListenerTest extends WebTestCase
     {
         $response = $this->get('/reviewer/');
 
-        $url = $this->container->get('url_generator')->generate('dashboard');
+        $url = $this->container->get('router')->generate('dashboard');
 
         $this->assertRedirectResponseUrlEquals($url, $response);
     }
@@ -59,7 +59,7 @@ final class AuthenticationListenerTest extends WebTestCase
             ->asLoggedInSpeaker()
             ->get('/reviewer/');
 
-        $url = $this->container->get('url_generator')->generate('dashboard');
+        $url = $this->container->get('router')->generate('dashboard');
 
         $this->assertRedirectResponseUrlEquals($url, $response);
     }
@@ -77,7 +77,7 @@ final class AuthenticationListenerTest extends WebTestCase
     {
         $response = $this->get('/admin/');
 
-        $url = $this->container->get('url_generator')->generate('dashboard');
+        $url = $this->container->get('router')->generate('dashboard');
 
         $this->assertRedirectResponseUrlEquals($url, $response);
     }
@@ -88,7 +88,7 @@ final class AuthenticationListenerTest extends WebTestCase
             ->asLoggedInSpeaker()
             ->get('/admin/');
 
-        $url = $this->container->get('url_generator')->generate('dashboard');
+        $url = $this->container->get('router')->generate('dashboard');
 
         $this->assertRedirectResponseUrlEquals($url, $response);
     }


### PR DESCRIPTION
This PR removes Silex-compatible service aliases.

In order to keep the diff of #895 low, I had added two service aliases, so I didn't have to adjust too many test cases when switching between Silex and Symfony. Now that Silex is gone for good, we can safely remove those aliases and use the Symfony service IDs in those tests.

Follows #895.