### PR TITLE
Upgraded Phinx to 0.9.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "michelf/php-markdown": "~1.7",
         "monolog/monolog": "~1.22",
         "pagerfanta/pagerfanta": "1.0.*@dev",
-        "robmorgan/phinx": "*",
+        "robmorgan/phinx": "~0.9.2",
         "sensio/framework-extra-bundle": "^5.1.3",
         "symfony/config": "^3.4",
         "symfony/console": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5887bd3e147c4c6669e62fcfcd5950d3",
+    "content-hash": "c8fa9b2b89fe2253751e35284d3b4042",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -1939,26 +1939,27 @@
         },
         {
             "name": "robmorgan/phinx",
-            "version": "v0.9.1",
+            "version": "0.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/phinx.git",
-                "reference": "c1d51fd065af3aa3fabd684ce561cd9c38281eb8"
+                "reference": "e1698319ad55157c233b658c08f7a10617e797ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/phinx/zipball/c1d51fd065af3aa3fabd684ce561cd9c38281eb8",
-                "reference": "c1d51fd065af3aa3fabd684ce561cd9c38281eb8",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/e1698319ad55157c233b658c08f7a10617e797ca",
+                "reference": "e1698319ad55157c233b658c08f7a10617e797ca",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "symfony/config": "~2.8|~3.0",
-                "symfony/console": "~2.8|~3.0",
-                "symfony/yaml": "~2.8|~3.0"
+                "symfony/config": "^2.8|^3.0|^4.0",
+                "symfony/console": "^2.8|^3.0|^4.0",
+                "symfony/yaml": "^2.8|^3.0|^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.26|^5.0"
+                "cakephp/cakephp-codesniffer": "^3.0",
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.5"
             },
             "bin": [
                 "bin/phinx"
@@ -2005,7 +2006,7 @@
                 "migrations",
                 "phinx"
             ],
-            "time": "2017-09-09T13:54:33+00:00"
+            "time": "2017-12-23T06:48:51+00:00"
         },
         {
             "name": "sensio/framework-extra-bundle",


### PR DESCRIPTION
This PR upgrades Phinx to 0.9.2. The main difference for us is that the new release is compatible with Symfony 4.

Related to #618.