### PR TITLE
Load WebServerBundle in development only

### DIFF
--- a/classes/Kernel.php
+++ b/classes/Kernel.php
@@ -46,7 +46,6 @@ final class Kernel extends SymfonyKernel
             new TwigBundle(),
             new SwiftmailerBundle(),
             new WouterJEloquentBundle(),
-            new WebServerBundle(),
         ];
 
         if ($this->getEnvironment() !== Environment::TYPE_PRODUCTION) {
@@ -54,6 +53,7 @@ final class Kernel extends SymfonyKernel
         }
 
         if ($this->getEnvironment() === Environment::TYPE_DEVELOPMENT) {
+            $bundles[] = new WebServerBundle();
             $bundles[] = new WebProfilerBundle();
         }
 


### PR DESCRIPTION
This PR moves the registration of `WebServerBundle` to the development environment section.

It should be possible to run the application in production environment with only production dependencies. This is currently not the case because the kernel tries to register the `WebServerBundle` which is a dev dependency.

Since you probably don't want to run the production system on php's built-in webserver, the bundle is now only available in the development environment.

Follows #992.