### PR TITLE
Don't override the global app template variable

### DIFF
--- a/classes/Kernel.php
+++ b/classes/Kernel.php
@@ -113,7 +113,6 @@ final class Kernel extends SymfonyKernel
 
     private function bindConfiguration(ContainerBuilder $container, array $config)
     {
-        $container->setParameter('config.all', $config);
         $container->setParameter('config.application', $config['application']);
 
         foreach ($config as $groupName => $groupConfig) {

--- a/resources/config/config.yml
+++ b/resources/config/config.yml
@@ -26,8 +26,6 @@ twig:
   default_path: '%kernel.project_dir%/resources/views'
   debug: '%kernel.debug%'
   globals:
-    app:
-      config: '%config.all%'
     site:       '%config.application%'
     talkHelper: '@OpenCFP\Http\View\TalkHelper'
 

--- a/resources/views/dashboard.twig
+++ b/resources/views/dashboard.twig
@@ -25,7 +25,7 @@ function deleteTalk(tid) {
     {% if profile.needsProfile() %}
     <div class="text-center">
         <i class="fa fa-user-circle text-soft fa-5x"></i>
-        <h1 class="font-serif font-thin text-5xl">Welcome to {{ app.config.application.title }}!</h1>
+        <h1 class="font-serif font-thin text-5xl">Welcome to {{ site.title }}!</h1>
         <p class="text-soft mb-8">It looks like this is your first time here ...</p>
         <a href="{{ url('user_edit', { id: user.id }) }}" class="btn btn-brand">Fill out your profile</a>
     </div>

--- a/resources/views/home.twig
+++ b/resources/views/home.twig
@@ -1,7 +1,7 @@
 {% extends "layouts/default.twig" %}
 
 {% block header %}
-    <header id="hero" class="bg-cover p-24" style="background:linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url({{ app.config.application.venue_image_path }}) no-repeat center -300px / cover fixed;">
+    <header id="hero" class="bg-cover p-24" style="background:linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url({{ site.venue_image_path }}) no-repeat center -300px / cover fixed;">
         <div class="container mx-auto flex">
             <div class="p-8 bg-brand text-white">
                 {% if cfp_open %}

--- a/resources/views/layouts/default.twig
+++ b/resources/views/layouts/default.twig
@@ -50,7 +50,7 @@
                     crossorigin="anonymous"></script>
         {% endblock %}
 
-        {% if app.config.application.show_contrib_banner %}
+        {% if site.show_contrib_banner %}
         {% include "_forkme.twig" %}
         {% endif %}
     </body>

--- a/resources/views/layouts/splash.twig
+++ b/resources/views/layouts/splash.twig
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="{{ assets('css/app.css') }}" rel="stylesheet" media="screen">
     </head>
-    <body class="h-full border-t-4 border-brand bg-cover flex items-center justify-center" style="background:linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url({{ app.config.application.venue_image_path }}) no-repeat center center / cover fixed;">
+    <body class="h-full border-t-4 border-brand bg-cover flex items-center justify-center" style="background:linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url({{ site.venue_image_path }}) no-repeat center center / cover fixed;">
 
         {% block content %}
         {% endblock %}

--- a/resources/views/security/signup.twig
+++ b/resources/views/security/signup.twig
@@ -15,7 +15,7 @@
             <input type="password" name="password" placeholder="•••••••">
             <div class="text-sm my-4 flex items-center">
                 <input id="coc" class="mr-2" name="coc" type="checkbox">
-                <label for="coc" class="text-white">I agree to abide by the <a href="{{ app.config.application.coc_link }}" target="_blank" class="text-brand text-bold text-underline" rel="noopener noreferrer">Code of Conduct</a></label>
+                <label for="coc" class="text-white">I agree to abide by the <a href="{{ site.coc_link }}" target="_blank" class="text-brand text-bold text-underline" rel="noopener noreferrer">Code of Conduct</a></label>
             </div>
             <button type="submit" class="btn btn-brand w-full">Signup</button>
         </form>


### PR DESCRIPTION
This PR removes our global `app` template variable.

The reason for this change is that Symfony uses that variable to provide access to certain objects like the environment, the current request or whether the application runs in debug mode. If we override it like we currently do, we cannot make use of that functionality.

Reference: https://symfony.com/doc/3.4/templating/app_variable.html

Furthermore, the information that is currently being queried from that variables is already redundantly present in another global variable, `site`. Our `app` contains more information than `site`, but I could not find a twig line where information from `app` is accessed that `site` doesn't also contain. So, from my point of view, if safe to redirect all access to the `site` variable and drop `app`.