### PR TITLE
Fix: make infection 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ database: test-env composer
 	mysqldump -uroot cfp_test > tests/dump.sql
 
 infection: composer database
-	vendor/bin/infection
+	vendor/bin/infection --test-framework-options="--printer PHPUnit\\\TextUI\\\ResultPrinter"
 
 integration: test-env composer database
 	vendor/bin/phpunit --testsuite integration


### PR DESCRIPTION
This PR

* [x] updates the `make infection` command 

Due to the new printer infection was not working correctly, this PR forces phpunit to use the default printer for infection

Follows #1040.
