### PR TITLE
Enhancement: Move TestingPass to Test namespace

### DIFF
--- a/classes/Kernel.php
+++ b/classes/Kernel.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace OpenCFP;
 
-use OpenCFP\Infrastructure\DependencyInjection\TestingPass;
+use OpenCFP\Test\Helper\DependencyInjection\TestingPass;
 use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;

--- a/tests/Helper/DependencyInjection/TestingPass.php
+++ b/tests/Helper/DependencyInjection/TestingPass.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/opencfp/opencfp
  */
 
-namespace OpenCFP\Infrastructure\DependencyInjection;
+namespace OpenCFP\Test\Helper\DependencyInjection;
 
 use Cartalyst\Sentinel\Sentinel;
 use Illuminate\Database\Capsule\Manager as Capsule;

--- a/tests/Unit/ProjectCodeTest.php
+++ b/tests/Unit/ProjectCodeTest.php
@@ -60,7 +60,6 @@ final class ProjectCodeTest extends Framework\TestCase
                 Http\Controller\ProfileController::class,
                 Http\Form\ForgotFormType::class,
                 Http\Form\ResetFormType::class,
-                Infrastructure\DependencyInjection\TestingPass::class,
                 Infrastructure\Event\AuthenticationListener::class,
                 Infrastructure\Event\CsrfValidationListener::class,
                 Infrastructure\Event\ExceptionListener::class,


### PR DESCRIPTION
This PR

* [x] Moves `TestingPass` to the `OpenCFP\Test\Helper\DependencyInjection` namespace