### PR TITLE
Enhancement: Make cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
-.PHONY: asset composer coverage cs database infection integration it test test-env unit
+.PHONY: asset cache composer coverage cs database infection integration it test test-env unit
 
 it: cs test
 
 asset:
 	yarn install
 	yarn run production
+
+cache:
+	bin/console cache:clear --env=development
+	bin/console cache:clear --env=testing
 
 composer:
 	composer install
@@ -24,7 +28,7 @@ database: test-env composer
 infection: composer database
 	vendor/bin/infection
 
-integration: test-env composer database
+integration: test-env composer database cache
 	vendor/bin/phpunit --testsuite integration
 
 test: integration unit


### PR DESCRIPTION
This PR

* [x] Adds the `make cache` command, which clears testing and development cache
* [x] Has `make integration` run the cache command before executing

Unit tests shouldn't interact with the cache, so no need to clear it before those, since it is quite slow to run these commands.

This should make sure we don't run our tests against an old cache