### PR TITLE
Moved request validation into a service

### DIFF
--- a/classes/Http/Action/Admin/Talk/RateAction.php
+++ b/classes/Http/Action/Admin/Talk/RateAction.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Action\Admin\Talk;
 
-use Illuminate\Container\Container;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Translation;
-use Illuminate\Validation;
 use OpenCFP\Domain\Talk;
 use OpenCFP\Domain\ValidationException;
+use OpenCFP\Infrastructure\Validation\RequestValidator;
 use Symfony\Component\HttpFoundation;
 
 final class RateAction
@@ -28,15 +25,21 @@ final class RateAction
      */
     private $talkHandler;
 
-    public function __construct(Talk\TalkHandler $talkHandler)
+    /**
+     * @var RequestValidator
+     */
+    private $requestValidator;
+
+    public function __construct(Talk\TalkHandler $talkHandler, RequestValidator $requestValidator)
     {
-        $this->talkHandler = $talkHandler;
+        $this->talkHandler      = $talkHandler;
+        $this->requestValidator = $requestValidator;
     }
 
     public function __invoke(HttpFoundation\Request $request): HttpFoundation\Response
     {
         try {
-            $this->validate($request, [
+            $this->requestValidator->validate($request, [
                 'rating' => 'required|integer',
             ]);
         } catch (ValidationException $exception) {
@@ -48,42 +51,5 @@ final class RateAction
             ->rate((int) $request->get('rating'));
 
         return new HttpFoundation\Response($content);
-    }
-
-    /**
-     * @param HttpFoundation\Request $request
-     * @param array                  $rules
-     * @param array                  $messages
-     * @param array                  $customAttributes
-     *
-     * @throws ValidationException
-     */
-    private function validate(HttpFoundation\Request $request, $rules = [], $messages = [], $customAttributes = [])
-    {
-        $data = $request->query->all() + $request->request->all() + $request->files->all();
-
-        $validation = new Validation\Factory(
-            new Translation\Translator(
-                new Translation\FileLoader(
-                    new Filesystem(),
-                    __DIR__ . '/../../../resources/lang'
-                ),
-                'en'
-            ),
-            new Container()
-        );
-
-        $validator = $validation->make(
-            $data,
-            $rules,
-            $messages,
-            $customAttributes
-        );
-
-        if ($validator->fails()) {
-            throw ValidationException::withErrors(array_flatten($validator->errors()->toArray()));
-        }
-
-        unset($validation, $validator);
     }
 }

--- a/classes/Http/Action/Reviewer/Talk/RateAction.php
+++ b/classes/Http/Action/Reviewer/Talk/RateAction.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 
 namespace OpenCFP\Http\Action\Reviewer\Talk;
 
-use Illuminate\Container\Container;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Translation;
-use Illuminate\Validation;
 use OpenCFP\Domain\Talk;
 use OpenCFP\Domain\ValidationException;
+use OpenCFP\Infrastructure\Validation\RequestValidator;
 use Symfony\Component\HttpFoundation;
 
 final class RateAction
@@ -28,15 +25,21 @@ final class RateAction
      */
     private $talkHandler;
 
-    public function __construct(Talk\TalkHandler $talkHandler)
+    /**
+     * @var RequestValidator
+     */
+    private $requestValidator;
+
+    public function __construct(Talk\TalkHandler $talkHandler, RequestValidator $requestValidator)
     {
-        $this->talkHandler = $talkHandler;
+        $this->talkHandler      = $talkHandler;
+        $this->requestValidator = $requestValidator;
     }
 
     public function __invoke(HttpFoundation\Request $request): HttpFoundation\Response
     {
         try {
-            $this->validate($request, [
+            $this->requestValidator->validate($request, [
                 'rating' => 'required|integer',
             ]);
         } catch (ValidationException $exception) {
@@ -48,42 +51,5 @@ final class RateAction
             ->rate((int) $request->get('rating'));
 
         return new HttpFoundation\Response($content);
-    }
-
-    /**
-     * @param HttpFoundation\Request $request
-     * @param array                  $rules
-     * @param array                  $messages
-     * @param array                  $customAttributes
-     *
-     * @throws ValidationException
-     */
-    private function validate(HttpFoundation\Request $request, $rules = [], $messages = [], $customAttributes = [])
-    {
-        $data = $request->query->all() + $request->request->all() + $request->files->all();
-
-        $validation = new Validation\Factory(
-            new Translation\Translator(
-                new Translation\FileLoader(
-                    new Filesystem(),
-                    __DIR__ . '/../../../resources/lang'
-                ),
-                'en'
-            ),
-            new Container()
-        );
-
-        $validator = $validation->make(
-            $data,
-            $rules,
-            $messages,
-            $customAttributes
-        );
-
-        if ($validator->fails()) {
-            throw ValidationException::withErrors(array_flatten($validator->errors()->toArray()));
-        }
-
-        unset($validation, $validator);
     }
 }

--- a/classes/Infrastructure/Validation/RequestValidator.php
+++ b/classes/Infrastructure/Validation/RequestValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2018 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Infrastructure\Validation;
+
+use Illuminate\Validation\Factory;
+use OpenCFP\Domain\ValidationException;
+use Symfony\Component\HttpFoundation\Request;
+
+class RequestValidator
+{
+    /**
+     * @var Factory
+     */
+    private $factory;
+
+    public function __construct(Factory $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * @param Request $request
+     * @param array   $rules
+     *
+     * @throws ValidationException
+     */
+    public function validate(Request $request, array $rules)
+    {
+        $data = $request->query->all() + $request->request->all() + $request->files->all();
+
+        $validator = $this->factory->make($data, $rules);
+
+        if ($validator->fails()) {
+            throw ValidationException::withErrors(array_flatten($validator->errors()->toArray()));
+        }
+    }
+}

--- a/resources/config/services/infrastructure.yml
+++ b/resources/config/services/infrastructure.yml
@@ -19,3 +19,24 @@ services:
       OpenCFP\Domain\Services\RequestValidator: '@OpenCFP\Infrastructure\Auth\CsrfValidator'
 
   OpenCFP\Infrastructure\Repository\IlluminateUserRepository: ~
+
+  OpenCFP\Infrastructure\Validation\RequestValidator: ~
+
+  Illuminate\Validation\Factory: ~
+
+  Illuminate\Filesystem\Filesystem: ~
+
+  Illuminate\Contracts\Container\Container:
+    class: Illuminate\Container\Container
+
+  Illuminate\Contracts\Translation\Translator:
+    class: Illuminate\Translation\Translator
+    autowire: false
+    arguments:
+      - '@translation_loader'
+      - 'en'
+
+  translation_loader:
+    class: Illuminate\Translation\FileLoader
+    arguments:
+      $path: '%kernel.project_dir%/resources/lang'

--- a/tests/Unit/Infrastructure/Validation/RequestValidatorTest.php
+++ b/tests/Unit/Infrastructure/Validation/RequestValidatorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2018 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\Unit\Infrastructure\Validation;
+
+use Illuminate\Support\MessageBag;
+use Illuminate\Validation\Factory;
+use Illuminate\Validation\Validator;
+use OpenCFP\Domain\ValidationException;
+use OpenCFP\Infrastructure\Validation\RequestValidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class RequestValidatorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function requestIsValid()
+    {
+        $request = new Request();
+        $request->request->set('foo', 'bar');
+
+        $validator = $this->prophesize(Validator::class);
+        $validator->fails()->willReturn(false);
+
+        $factory = $this->prophesize(Factory::class);
+        $factory->make(['foo' => 'bar'], ['foo' => 'required'])
+            ->willReturn($validator->reveal());
+
+        $requestValidator = new RequestValidator($factory->reveal());
+        $requestValidator->validate($request, ['foo' => 'required']);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function requestIsInvalid()
+    {
+        $request = new Request();
+        $request->request->set('foo', 'bar');
+
+        $validator = $this->prophesize(Validator::class);
+        $validator->fails()->willReturn(true);
+        $validator->errors()->willReturn(new MessageBag());
+
+        $factory = $this->prophesize(Factory::class);
+        $factory->make(['foo' => 'bar'], ['foo' => 'required'])
+            ->willReturn($validator->reveal());
+
+        $requestValidator = new RequestValidator($factory->reveal());
+
+        $this->expectException(ValidationException::class);
+        $requestValidator->validate($request, ['foo' => 'required']);
+    }
+}


### PR DESCRIPTION
This PR extracts the `validate()` method, that has been copied into three action classes, into a separate class that is loaded as a service.

Follows: #1045, #1043, #1022
Relates to: #1023