### PR TITLE
Add http codes to the talk create process action

### DIFF
--- a/classes/Http/Action/Talk/CreateProcessAction.php
+++ b/classes/Http/Action/Talk/CreateProcessAction.php
@@ -157,7 +157,7 @@ final class CreateProcessAction
                 'flash'          => $request->getSession()->get('flash'),
             ]);
 
-            return new HttpFoundation\Response($content);
+            return new HttpFoundation\Response($content, HttpFoundation\Response::HTTP_BAD_REQUEST);
         }
 
         $talk = Model\Talk::create(\array_merge($form->getCleanData(), [
@@ -177,7 +177,7 @@ final class CreateProcessAction
 
         $url = $this->urlGenerator->generate('dashboard');
 
-        return new HttpFoundation\RedirectResponse($url);
+        return new HttpFoundation\RedirectResponse($url, HttpFoundation\Response::HTTP_CREATED);
     }
 
     private function createTalkForm(array $data): Form\TalkForm

--- a/tests/Integration/Http/Action/Talk/CreateProcessActionTest.php
+++ b/tests/Integration/Http/Action/Talk/CreateProcessActionTest.php
@@ -16,6 +16,7 @@ namespace OpenCFP\Test\Integration\Http\Action\Talk;
 use OpenCFP\Domain\Model;
 use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
 
 final class CreateProcessActionTest extends WebTestCase implements TransactionalTestCase
 {
@@ -28,7 +29,7 @@ final class CreateProcessActionTest extends WebTestCase implements Transactional
         $user = factory(Model\User::class)->create()->first();
 
         $csrfToken = $this->container->get('security.csrf.token_manager')
-            ->getToken('edit_talk');
+            ->getToken('speaker_talk');
 
         $response = $this
             ->asLoggedInSpeaker($user->id)
@@ -46,6 +47,8 @@ final class CreateProcessActionTest extends WebTestCase implements Transactional
             ]);
 
         $this->assertResponseIsRedirect($response);
+        $this->assertRedirectResponseUrlContains('dashboard', $response);
+        $this->assertResponseStatusCode(Response::HTTP_CREATED, $response);
     }
 
     /**
@@ -68,7 +71,7 @@ final class CreateProcessActionTest extends WebTestCase implements Transactional
                 'token_id' => 'speaker_talk',
             ]);
 
-        $this->assertResponseIsRedirect($response);
+        $this->assertResponseStatusCode(Response::HTTP_FOUND, $response);
         $this->assertResponseBodyNotContains('Create Your Talk', $response);
         $this->assertSessionHasFlashMessage('You cannot create talks once the call for papers has ended', $this->session());
     }
@@ -94,7 +97,7 @@ final class CreateProcessActionTest extends WebTestCase implements Transactional
                 'token_id'    => 'speaker_talk',
             ]);
 
-        $this->assertResponseIsSuccessful($response);
+        $this->assertResponseStatusCode(Response::HTTP_BAD_REQUEST, $response);
         $this->assertResponseBodyContains('Create Your Talk', $response);
         $this->assertSessionHasFlashMessage('Error', $this->session());
     }
@@ -116,7 +119,7 @@ final class CreateProcessActionTest extends WebTestCase implements Transactional
                 'token_id'    => 'speaker_talk',
             ]);
 
-        $this->assertResponseIsRedirect($response);
+        $this->assertResponseStatusCode(Response::HTTP_FOUND, $response);
         $this->assertRedirectResponseUrlContains('/dashboard', $response);
     }
 }


### PR DESCRIPTION
This PR

* [x] Adds Proper HTTP response codes to the `CreateProcessAction`
* [x] Updates its test to explicitly check for correct HTTP codes

Related to #1068