### PR TITLE
Enhancement: Pass model as constructor argument

### DIFF
--- a/classes/Domain/Model/Talk.php
+++ b/classes/Domain/Model/Talk.php
@@ -26,6 +26,9 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @method Builder ratedPlusOneBy(int $userId)
  * @method Builder viewedBy(int $userId)
  * @method Builder favoritedBy(int $userId)
+ *
+ * This is needed for Prophecy to mock the method, because it can't find it otherwise
+ * @method count()
  */
 class Talk extends Eloquent
 {

--- a/classes/Http/Action/Page/HomePageAction.php
+++ b/classes/Http/Action/Page/HomePageAction.php
@@ -23,9 +23,15 @@ final class HomePageAction
      */
     private $showSubmissionCount;
 
-    public function __construct(bool $showSubmissionCount)
+    /**
+     * @var Talk
+     */
+    private $talk;
+
+    public function __construct(bool $showSubmissionCount, Talk $talk)
     {
         $this->showSubmissionCount = $showSubmissionCount;
+        $this->talk                = $talk;
     }
 
     /**
@@ -34,7 +40,7 @@ final class HomePageAction
     public function __invoke(): array
     {
         return [
-            'number_of_talks' => $this->showSubmissionCount ? Talk::count() : '',
+            'number_of_talks' => $this->showSubmissionCount ? $this->talk->count() : '',
         ];
     }
 }

--- a/tests/Unit/Http/Action/Page/HomePageActionTest.php
+++ b/tests/Unit/Http/Action/Page/HomePageActionTest.php
@@ -13,17 +13,42 @@ declare(strict_types=1);
 
 namespace OpenCFP\Test\Unit\Http\Action\Page;
 
+use Localheinz\Test\Util\Helper;
+use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Http\Action\Page\HomePageAction;
 use PHPUnit\Framework\TestCase;
 
 final class HomePageActionTest extends TestCase
 {
+    use Helper;
+
     public function testItReturnsTheCorrectContentIfNoSubmissionCountNeedsToBeShown()
     {
-        $action = new HomePageAction(false);
+        $talk   = $this->prophesize(Talk::class);
+        $action = new HomePageAction(false, $talk->reveal());
 
         $expected = [
             'number_of_talks' => '',
+        ];
+
+        $this->assertSame($expected, $action());
+    }
+
+    public function testItReturnsTheCorrectAmountOfTalksIfRequired()
+    {
+        $faker     = $this->faker();
+        $talkCount = $faker->numberBetween(1);
+
+        $talk = $this->prophesize(Talk::class);
+
+        $talk->count()
+            ->shouldBeCalled()
+            ->willReturn($talkCount);
+
+        $action = new HomePageAction(true, $talk->reveal());
+
+        $expected = [
+            'number_of_talks' => $talkCount,
         ];
 
         $this->assertSame($expected, $action());


### PR DESCRIPTION
This PR

* [x] Passes the Talk Model to the constructor of the HomePageAction, instead of statically accessing it

This should make the code base more testable since we can easily mock models.

Let me know if we want to do this for the other actions, or if this is a bad idea


  