### PR TITLE
Enhancement: Update friendsofphp/php-cs-fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -76,6 +76,9 @@ return PhpCsFixer\Config::create()
         'increment_style' => true,
         'is_null' => true,
         'method_separation' => true,
+        'multiline_whitespace_before_semicolons' => [
+            'strategy' => 'no_multi_line',
+        ],
         'native_function_invocation' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
@@ -99,7 +102,6 @@ return PhpCsFixer\Config::create()
             ],
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
-        'no_multiline_whitespace_before_semicolons' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_superfluous_elseif' => true,
         'no_trailing_comma_in_singleline_array' => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -82,7 +82,7 @@ return PhpCsFixer\Config::create()
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_empty_phpdoc' => true,
-        'no_extra_consecutive_blank_lines' => [
+        'no_extra_blank_lines' => [
             'tokens' => [
                 'break',
                 'case',

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -74,9 +74,7 @@ return PhpCsFixer\Config::create()
             'header' => $header,
         ],
         'increment_style' => true,
-        'is_null' => [
-            'use_yoda_style' => false,
-        ],
+        'is_null' => true,
         'method_separation' => true,
         'native_function_invocation' => true,
         'new_with_braces' => true,

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require-dev": {
         "codedungeon/phpunit-result-printer": "^0.4.2",
-        "friendsofphp/php-cs-fixer": "^2.9.0",
+        "friendsofphp/php-cs-fixer": "^2.10.0",
         "fzaninotto/faker": "^1.5.0",
         "infection/infection": "^0.7.0",
         "localheinz/test-util": "0.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9587098a1c720f2c52c544a627af1b55",
+    "content-hash": "08859005c9e39259b19c83559b8e1ad4",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -4879,16 +4879,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.9.0",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "454ddbe65da6a9297446f442bad244e8a99a9a38"
+                "reference": "513a3765b56dd029175f9f32995566657ee89dda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/454ddbe65da6a9297446f442bad244e8a99a9a38",
-                "reference": "454ddbe65da6a9297446f442bad244e8a99a9a38",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/513a3765b56dd029175f9f32995566657ee89dda",
+                "reference": "513a3765b56dd029175f9f32995566657ee89dda",
                 "shasum": ""
             },
             "require": {
@@ -4915,10 +4915,12 @@
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0@dev",
                 "justinrainbow/json-schema": "^5.0",
+                "keradus/cli-executor": "^1.0",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.0",
                 "php-cs-fixer/accessible-object": "^1.0",
                 "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "phpunitgoodpractices/traits": "^1.0",
                 "symfony/phpunit-bridge": "^3.2.2 || ^4.0"
             },
             "suggest": {
@@ -4929,16 +4931,22 @@
                 "php-cs-fixer"
             ],
             "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
                 },
                 "classmap": [
-                    "tests/Test/Assert/AssertTokensTrait.php",
                     "tests/Test/AbstractFixerTestCase.php",
                     "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/Assert/AssertTokensTrait.php",
                     "tests/Test/IntegrationCase.php",
-                    "tests/Test/IntegrationCaseFactory.php"
+                    "tests/Test/IntegrationCaseFactory.php",
+                    "tests/TestCase.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4956,7 +4964,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2017-12-08T16:36:20+00:00"
+            "time": "2018-01-10T17:16:15+00:00"
         },
         {
             "name": "fzaninotto/faker",


### PR DESCRIPTION
This PR

* [x] updates `friendsofphp/php-cs-fixer`
* [x] removes a deprecated configuration for the `is_null` fixer
* [x] uses the `no_extra_blank_lines` fixer instead of the deprecated `no_extra_consecutive_blank_lines` fixer
* [x] uses the `multiline_whitespace_before_semicolons` fixer instead of the deprecated `no_multiline_whitespace_before_semicolons` fixer

Blocks #905.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/v2.9.0...v2.10.0.