### PR TITLE
Fix: Add missing description to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "opencfp/opencfp",
+    "description": "OpenCFP is a PHP-based conference talk submission system.",
     "license": "MIT",
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
This PR

* [x] adds a missing description to `composer.json`

💁‍♂️ Running

```
$ composer validate
```

yields

```
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required
require.ezyang/htmlpurifier : unbound version constraints (dev-master) should be avoided
```