### PR TITLE
Fix duplicate usage of command option shortcut "-e"

### DIFF
--- a/classes/Console/Command/UserCreateCommand.php
+++ b/classes/Console/Command/UserCreateCommand.php
@@ -42,7 +42,7 @@ final class UserCreateCommand extends Command
             ->setDefinition([
                 new InputOption('first_name', 'f', InputOption::VALUE_REQUIRED, 'First Name of the user to create', null),
                 new InputOption('last_name', 'l', InputOption::VALUE_REQUIRED, 'Last Name of the user to create', null),
-                new InputOption('email', 'e', InputOption::VALUE_REQUIRED, 'Email of the user to create', null),
+                new InputOption('email', 'm', InputOption::VALUE_REQUIRED, 'Email of the user to create', null),
                 new InputOption('password', 'p', InputOption::VALUE_REQUIRED, 'Password of the user to create', null),
                 new InputOption('admin', 'a', InputOption::VALUE_NONE, 'Promote to administrator', null),
                 new InputOption('reviewer', 'r', InputOption::VALUE_NONE, 'Promote to reviewer', null),

--- a/tests/Unit/Console/Command/UserCreateCommandTest.php
+++ b/tests/Unit/Console/Command/UserCreateCommandTest.php
@@ -86,7 +86,7 @@ final class UserCreateCommandTest extends Framework\TestCase
 
         $option = $inputDefinition->getOption('email');
 
-        $this->assertSame('e', $option->getShortcut());
+        $this->assertSame('m', $option->getShortcut());
         $this->assertSame('Email of the user to create', $option->getDescription());
         $this->assertTrue($option->isValueRequired());
         $this->assertNull($option->getDefault());


### PR DESCRIPTION
* "-e" shortcut is already used by the global --env option

This PR
* changes the shortcut for the `--email` option of `user:create` from "-e" to "-m".

Fixes #1078
