### PR TITLE
Fix phinx configuration filename in script/test

### DIFF
--- a/script/test
+++ b/script/test
@@ -11,7 +11,7 @@ cd "$(dirname "$0")/.."
 script/bootstrap
 
 echo "==> Creating test db..."
-CFP_ENV=testing vendor/bin/phinx --configuration=phinx.yml migrate
+CFP_ENV=testing vendor/bin/phinx --configuration=phinx.php migrate
 
 if [ ! -f "phpunit.xml" ]; then
     cp phpunit.xml.dist phpunit.xml


### PR DESCRIPTION
The script/test file refers to the old phinx.yml instead of phinx.php configuration file.

This PR

* Replaces the old phinx configuration filename extension `.yml` with `.php` in `script/test`.

Fixes #1080
