### PR TITLE
Fix: Remove @ from Twitter link and title

### DIFF
--- a/resources/views/dashboard.twig
+++ b/resources/views/dashboard.twig
@@ -45,7 +45,7 @@ function deleteTalk(tid) {
                     <p>{{ profile.company }}</p>
                 {% endif %}
                 {% if profile.twitter %}
-                    <a class="text-white text-xs" href="https://twitter.com/@{{ profile.twitter }}" title="@{{ profile.name }} on Twitter"><i class="fa fa-twitter"></i> @{{ profile.twitter }}</a>
+                    <a class="text-white text-xs" href="https://twitter.com/{{ profile.twitter }}" title="{{ profile.name }} on Twitter"><i class="fa fa-twitter"></i> @{{ profile.twitter }}</a>
                 {% endif %}
                 {% if profile.url %}
                     | <a class="text-white text-xs" href="{{ profile.url }}">{{ profile.url }}</a>


### PR DESCRIPTION
This PR

* [x] removes `@` from links and titles where they don't make any sense

Hardly related to #1083.

### Before

![screen shot 2018-01-20 at 21 15 15](https://user-images.githubusercontent.com/605483/35187633-30d7ca28-fe27-11e7-862f-34acec6f800e.png)

### After

![screen shot 2018-01-20 at 21 16 17](https://user-images.githubusercontent.com/605483/35187635-355d1f94-fe27-11e7-9a72-80bacd095f93.png)
