### PR TITLE
Laravel Valet unique file

### DIFF
--- a/.opencfp
+++ b/.opencfp
@@ -1,0 +1,1 @@
+DO NOT DELETE


### PR DESCRIPTION
In order for Laravel valet to work we need to unique file to determine if the project is opencfp or not

Fixes: 
[1.5.1+] Need a unique file to OpenCFP for Laravel Valet Custom Driver #1101

