### PR TITLE
Make sure login is not too thin on mobile

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -143,5 +143,6 @@ div:empty {
   .opencfp-signup {
     @apply .text-white;
     @apply .w-1/6;
+    min-width: 20rem;
   }
 }


### PR DESCRIPTION
Before: 
<img width="442" alt="screen shot 2018-02-15 at 10 18 40" src="https://user-images.githubusercontent.com/1275206/36249020-b73d9a54-1239-11e8-83e2-c080f3bd3efc.png">

After: 
<img width="445" alt="screen shot 2018-02-15 at 10 18 36" src="https://user-images.githubusercontent.com/1275206/36249026-baa32dc6-1239-11e8-9a59-476d6c3997c8.png">


