### PR TITLE
Fix: Drop support for PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
 
       language: php
 
-      php: 7.0
+      php: 7.1
 
       before_install:
         - phpenv config-rm xdebug.ini
@@ -44,7 +44,7 @@ jobs:
 
       language: php
 
-      php: 7.0
+      php: 7.1
 
       before_install:
         - source .travis/xdebug.sh
@@ -74,14 +74,10 @@ jobs:
 
     - <<: *TEST
 
-      php: 7.1
+      php: 7.2
 
       env:
         - WITH_COVERAGE=true
-
-    - <<: *TEST
-
-      php: 7.2
 
     - stage: Asset
 

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "platform": {
-            "php": "7.0.25"
+            "php": "7.1.3"
         }
     },
     "require": {
-        "php": ">=7",
+        "php": "^7.1",
         "aptoma/twig-markdown": "^3.0.0",
         "cartalyst/sentinel": "^2.0.17",
         "ezyang/htmlpurifier": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "347b3c8919f2702f0ed03e7779b19e1f",
+    "content-hash": "aa097b97e8d7590778839bb62a044ae7",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -8361,10 +8361,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7"
+        "php": "^7.1"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0.25"
+        "php": "7.1.3"
     }
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.0

For reference, see http://php.net/supported-versions.php:

![screen shot 2018-02-18 at 23 08 58](https://user-images.githubusercontent.com/605483/36357620-c08b05c8-1500-11e8-81c9-105b348c1364.png)
