### PR TITLE
Updates the regex for joind.in to better match valid characters

### DIFF
--- a/classes/Http/Form/SignupForm.php
+++ b/classes/Http/Form/SignupForm.php
@@ -201,9 +201,9 @@ class SignupForm extends Form
         return $validationResponse;
     }
 
-    private function validateUrl(): bool
+    public function validateUrl(): bool
     {
-        if (\preg_match('/https:\/\/joind\.in\/user\/[a-zA-Z0-9]{1,25}/', $this->cleanData['url'])
+        if (\preg_match('/^https:\/\/joind\.in\/user\/[a-zA-Z0-9\-_]{1,100}$/', $this->cleanData['url'])
             || !isset($this->cleanData['url'])
             || $this->cleanData['url'] == ''
         ) {

--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -286,6 +286,57 @@ final class SignupFormTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that the Joind.in URL is being validated correctly
+     *
+     * @test
+     *
+     * @param string $url
+     * @param bool   $expectedResponse
+     * @dataProvider urlProvider
+     */
+    public function urlIsValidatedCorrectly($url, $expectedResponse)
+    {
+        $data['url'] = $url;
+        $form        = new \OpenCFP\Http\Form\SignupForm($data, $this->purifier);
+        $form->sanitize();
+
+        $this->assertSame(
+            $expectedResponse,
+            $form->validateUrl(),
+            'Did not validate URL as expected'
+        );
+    }
+
+    /**
+     * Data provider for urlIsValidatedCorrectly
+     *
+     * @return array
+     */
+    public function urlProvider(): array
+    {
+        $validBaseUrl = 'https://joind.in/user/';
+        $longUrl      = '';
+
+        for ($x = 1; $x <= 256; ++$x) {
+            $longUrl .= 'X';
+        }
+
+        return [
+            [$validBaseUrl . 'abc123', true],
+            [$validBaseUrl, false],
+            [null, true],
+            [false, true],
+            ['', true],
+            ['http://example.net', false],
+            ['http://joind.in/user/abc123', false],
+            [$validBaseUrl . 'do re mi', false],
+            [$validBaseUrl . '_FirstLast', true],
+            [$validBaseUrl . 'first-last', true],
+            [$validBaseUrl . $longUrl, false],
+        ];
+    }
+
+    /**
      * Test that verifies that our wrapper method for validating all
      * fields works correctly
      *


### PR DESCRIPTION
This PR addresses #1119.

The joind.in username validation is relatively [permissive](https://github.com/joindin/joindin-web2/blob/master/app/src/User/RegisterFormType.php#L42), only checking that it's not blank and it's a maximum of 100 characters. Without spinning up a joind.in instance, I wasn't comfortable testing their site for possible usernames (emoji, other special characters), hence why I'm still relatively restrictive in this PR.