### PR TITLE
Fix: Provide attribute replacement to avoid offensive message

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -103,5 +103,7 @@ return [
     |
     */
 
-    'attributes' => [],
+    'attributes' => [
+        'coc' => 'code of conduct',
+    ],
 ];


### PR DESCRIPTION
This PR

* [x] provides an attribute replacement to avoid a potentially offensive validation message

Fixes #1095.

### Before

![screen shot 2018-04-21 at 17 41 44](https://user-images.githubusercontent.com/605483/39085982-5ef8b970-458b-11e8-8e09-39bf0796edcc.png)

### After

![screen shot 2018-04-21 at 17 41 59](https://user-images.githubusercontent.com/605483/39085983-62a8b336-458b-11e8-829c-5832f41d102d.png)

