### PR TITLE
✨ first draft of adding homestead for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ deployment.xml
 infection-log.txt
 infection.json
 docker-compose.yml
+Homestead.yaml

--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -1,0 +1,19 @@
+ip: 192.168.10.10
+memory: 2048
+cpus: 1
+provider: virtualbox
+authorize: ~/.ssh/id_rsa.pub
+keys:
+    - ~/.ssh/id_rsa
+folders:
+    -
+        map: /path/to/opencfp
+        to: /home/vagrant/opencfp
+sites:
+    -
+        map: opencfp.test
+        to: /home/vagrant/opencfp/web
+databases:
+    - cfp
+name: opencfp
+hostname: opencfp

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ OpenCFP is a PHP-based conference talk submission system.
    * [Create a Database](#create-a-database)
    * [Configure Environment](#configure-environment)
    * [Run Migrations](#run-migrations)
+   * [Using Vagrant](#using-vagrant)
    * [Final Touches](#final-touches)
  * [Command-line Utilities](#command-line-utilities)
    * [Admin Group Management](#admin-group-management)
@@ -240,6 +241,40 @@ $ CFP_ENV=production vendor/bin/phinx migrate
 ```
 
 Note: For updating previously installed instances only run migrations as needed.
+
+### [Using Vagrant](#using-vagrant)
+
+After running `$ script/setup` from the project root run `php vendor/bin/homestead make`. This will create a `Homestead.yaml` based on settings from `Homestead.yaml.example`. Do not version control `Homestead.yaml`
+
+Run `vagrant up`
+Add `192.168.10.10 opencfp.test` to your operating system's hosts file (/etc/hosts)
+Point your browser to `http://opencfp.test`
+
+Edit your `config/development.yml` to use Homestead's database & mail settings:
+
+```
+database:
+  host: 127.0.0.1
+  database: cfp
+  dsn: mysql:dbname=cfp;host=127.0.0.1
+  user: homestead
+  password: secret
+
+log:
+  level: debug
+
+mail:
+  host: localhost
+  port: 1025
+  username: ~
+  password: ~
+  encryption: ~
+  auth_mode: ~
+```
+
+Mailhog (local mail catching) can be viewed at http://opencfp.test:8025
+
+For more usage information please see the [Laravel Homestead Docs](http://laravel.com/docs/homestead)
 
 ### [Final Touches](#final-touches)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,44 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'json'
+require 'yaml'
+
+VAGRANTFILE_API_VERSION ||= "2"
+confDir = $confDir ||= File.expand_path("vendor/laravel/homestead", File.dirname(__FILE__))
+
+homesteadYamlPath = File.expand_path("Homestead.yaml", File.dirname(__FILE__))
+homesteadJsonPath = File.expand_path("Homestead.json", File.dirname(__FILE__))
+afterScriptPath = "after.sh"
+aliasesPath = "aliases"
+
+require File.expand_path(confDir + '/scripts/homestead.rb')
+
+Vagrant.require_version '>= 1.9.0'
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    if File.exist? aliasesPath then
+        config.vm.provision "file", source: aliasesPath, destination: "/tmp/bash_aliases"
+        config.vm.provision "shell" do |s|
+            s.inline = "awk '{ sub(\"\r$\", \"\"); print }' /tmp/bash_aliases > /home/vagrant/.bash_aliases"
+        end
+    end
+
+    if File.exist? homesteadYamlPath then
+        settings = YAML::load(File.read(homesteadYamlPath))
+    elsif File.exist? homesteadJsonPath then
+        settings = JSON.parse(File.read(homesteadJsonPath))
+    else
+        abort "Homestead settings file not found in #{confDir}"
+    end
+
+    Homestead.configure(config, settings)
+
+    if File.exist? afterScriptPath then
+        config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
+    end
+
+    if defined? VagrantPlugins::HostsUpdater
+        config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
+    end
+end

--- a/after.sh
+++ b/after.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# If you would like to do some extra provisioning you may
+# add any commands you wish to this file and they will
+# be run after the Homestead machine is provisioned.

--- a/aliases
+++ b/aliases
@@ -1,0 +1,250 @@
+alias ..="cd .."
+alias ...="cd ../.."
+
+alias h='cd ~'
+alias c='clear'
+alias art=artisan
+
+alias phpspec='vendor/bin/phpspec'
+alias phpunit='vendor/bin/phpunit'
+alias serve=serve-laravel
+
+alias xoff='sudo phpdismod -s cli xdebug'
+alias xon='sudo phpenmod -s cli xdebug'
+
+function artisan() {
+    php artisan "$@"
+}
+
+function dusk() {
+    pids=$(pidof /usr/bin/Xvfb)
+
+    if [ ! -n "$pids" ]; then
+        Xvfb :0 -screen 0 1280x960x24 &
+    fi
+
+    php artisan dusk "$@"
+}
+
+function php56() {
+    sudo update-alternatives --set php /usr/bin/php5.6
+}
+
+function php70() {
+    sudo update-alternatives --set php /usr/bin/php7.0
+}
+
+function php71() {
+    sudo update-alternatives --set php /usr/bin/php7.1
+}
+
+function php72() {
+    sudo update-alternatives --set php /usr/bin/php7.2
+}
+
+function serve-apache() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
+        sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-apache.sh
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-apache.sh "$1" "$2" 80 443 "${3:-7.1}"
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-apache domain path"
+    fi
+}
+
+function serve-laravel() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
+        sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-laravel.sh
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-laravel.sh "$1" "$2" 80 443 "${3:-7.1}"
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve domain path"
+    fi
+}
+
+function serve-proxy() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-proxy.sh
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-proxy.sh "$1" "$2" 80 443 "${3:-7.1}"
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-proxy domain port"
+    fi
+}
+
+function serve-silverstripe() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
+        sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-silverstripe.sh
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-silverstripe.sh "$1" "$2" 80 443 "${3:-7.1}"
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-silverstripe domain path"
+    fi
+}
+
+function serve-spa() {
+  if [[ "$1" && "$2" ]]
+  then
+    sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
+    sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-spa.sh
+    sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-spa.sh "$1" "$2" 80 443 "${3:-7.1}"
+  else
+    echo "Error: missing required parameters."
+    echo "Usage: "
+    echo "  serve-spa domain path"
+  fi
+}
+
+function serve-statamic() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
+        sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-statamic.sh
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-statamic.sh "$1" "$2" 80 443 "${3:-7.1}"
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-statamic domain path"
+    fi
+}
+
+function serve-symfony2() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
+        sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-symfony2.sh
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-symfony2.sh "$1" "$2" 80 443 "${3:-7.1}"
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-symfony2 domain path"
+    fi
+}
+
+function serve-symfony4() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
+        sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-symfony4.sh
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-symfony4.sh "$1" "$2" 80 443 "${3:-7.1}"
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-symfony4 domain path"
+    fi
+}
+
+function serve-pimcore() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
+        sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-pimcore.sh
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-pimcore.sh "$1" "$2" 80 443 "${3:-7.1}"
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-pimcore domain path"
+    fi
+}
+
+function share() {
+    if [[ "$1" ]]
+    then
+        ngrok http ${@:2} -host-header="$1" 80
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  share domain"
+        echo "Invocation with extra params passed directly to ngrok"
+        echo "  share domain -region=eu -subdomain=test1234"
+    fi
+}
+
+function flip() {
+    sudo bash /vagrant/vendor/laravel/homestead/scripts/flip-webserver.sh
+}
+
+function __has_pv() {
+    $(hash pv 2>/dev/null);
+
+    return $?
+}
+
+function __pv_install_message() {
+    if ! __has_pv; then
+        echo $1
+        echo "Install pv with \`sudo apt-get install -y pv\` then run this command again."
+        echo ""
+    fi
+}
+
+function dbexport() {
+    FILE=${1:-/vagrant/mysqldump.sql.gz}
+
+    # This gives an estimate of the size of the SQL file
+    # It appears that 80% is a good approximation of
+    # the ratio of estimated size to actual size
+    SIZE_QUERY="select ceil(sum(data_length) * 0.8) as size from information_schema.TABLES"
+
+    __pv_install_message "Want to see export progress?"
+
+    echo "Exporting databases to '$FILE'"
+
+    if __has_pv; then
+        ADJUSTED_SIZE=$(mysql --vertical -uhomestead -psecret -e "$SIZE_QUERY" 2>/dev/null | grep 'size' | awk '{print $2}')
+        HUMAN_READABLE_SIZE=$(numfmt --to=iec-i --suffix=B --format="%.3f" $ADJUSTED_SIZE)
+
+        echo "Estimated uncompressed size: $HUMAN_READABLE_SIZE"
+        mysqldump -uhomestead -psecret --all-databases --skip-lock-tables 2>/dev/null | pv  --size=$ADJUSTED_SIZE | gzip > "$FILE"
+    else
+        mysqldump -uhomestead -psecret --all-databases --skip-lock-tables 2>/dev/null | gzip > "$FILE"
+    fi
+
+    echo "Done."
+}
+
+function dbimport() {
+    FILE=${1:-/vagrant/mysqldump.sql.gz}
+
+    __pv_install_message "Want to see import progress?"
+
+    echo "Importing databases from '$FILE'"
+
+    if __has_pv; then
+        pv "$FILE" --progress --eta | zcat | mysql -uhomestead -psecret 2>/dev/null
+    else
+        cat "$FILE" | zcat | mysql -uhomestead -psecret 2>/dev/null
+    fi
+
+    echo "Done."
+}
+
+function xphp() {
+    (php -m | grep -q xdebug)
+    if [[ $? -eq 0 ]]
+    then
+        XDEBUG_ENABLED=true
+    else
+        XDEBUG_ENABLED=false
+    fi
+
+    if ! $XDEBUG_ENABLED; then xon; fi
+
+    php \
+        -dxdebug.remote_host=192.168.10.1 \
+        -dxdebug.remote_autostart=1 \
+        "$@"
+
+    if ! $XDEBUG_ENABLED; then xoff; fi
+}

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "friendsofphp/php-cs-fixer": "^2.10.2",
         "fzaninotto/faker": "^1.5.0",
         "infection/infection": "^0.7.0",
+        "laravel/homestead": "^7.4",
         "localheinz/composer-normalize": "^0.6.0",
         "localheinz/test-util": "0.6.0",
         "mikey179/vfsStream": "^1.6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc0b288211485c0c0e6ea92a3aa4e633",
+    "content-hash": "2c4ad12c55beef4efbb4ed29f0e11fcd",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -5904,6 +5904,56 @@
                 "schema"
             ],
             "time": "2018-02-14T22:26:30+00:00"
+        },
+        {
+            "name": "laravel/homestead",
+            "version": "v7.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/homestead.git",
+                "reference": "5b421129fa2cba574e69fdeac093a428b4ef17a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/homestead/zipball/5b421129fa2cba574e69fdeac093a428b4ef17a3",
+                "reference": "5b421129fa2cba574e69fdeac093a428b4ef17a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "symfony/console": "~3.3|~4.0",
+                "symfony/process": "~3.3|~4.0",
+                "symfony/yaml": "~3.3|~4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "bin": [
+                "bin/homestead"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Homestead\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com"
+                }
+            ],
+            "description": "A virtual machine for web artisans.",
+            "time": "2018-04-30T13:35:07+00:00"
         },
         {
             "name": "localheinz/classy",


### PR DESCRIPTION
Add [laravel/homestead](http://laravel.com/docs/homestead) as a local development option.

### Set up and Usage

After running `$ script/setup` from the project root run `php vendor/bin/homestead make`. This will create a `Homestead.yaml` based on settings from `Homestead.yaml.example`. Do not version control `Homestead.yaml`

Run `vagrant up`
Add `192.168.10.10 opencfp.test` to your operating system's hosts file (/etc/hosts)
Point your browser to `http://opencfp.test`

Edit your `config/development.yml` to use Homestead's database & mail settings:
```
database:
  host: 127.0.0.1
  database: cfp
  dsn: mysql:dbname=cfp;host=127.0.0.1
  user: homestead
  password: secret

log:
  level: debug

mail:
  host: localhost
  port: 1025
  username: ~
  password: ~
  encryption: ~
  auth_mode: ~
```

Mailhog (local mail catching) can be viewed at http://opencfp.test:8025

For more usage information please see the [Laravel Homestead Docs](http://laravel.com/docs/homestead)