### PR TITLE
Using show_contrib_banner parameter on splash layout

### DIFF
--- a/resources/views/layouts/splash.twig
+++ b/resources/views/layouts/splash.twig
@@ -13,6 +13,8 @@
         {% block scripts %}
         {% endblock %}
 
-        {% include "_forkme.twig" %}
+        {% if site.show_contrib_banner %}
+            {% include "_forkme.twig" %}
+        {% endif %}
     </body>
 </html>


### PR DESCRIPTION
Using site.show_contrib_banner parameter on splash layout for enable/disable fork me banner on signup, login and forgot_password pages.
