### PR TITLE
Fix: Default to production when environment could not be determined from environment variable

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -84,7 +84,7 @@ class Environment
      */
     public static function fromServer(array $server): self
     {
-        $type = $server['CFP_ENV'] ?? self::TYPE_DEVELOPMENT;
+        $type = $server['CFP_ENV'] ?? self::TYPE_PRODUCTION;
 
         return new self($type);
     }

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -104,6 +104,17 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
+     */
+    public function fromServerDefaultsToDevelopment()
+    {
+        $environment = Environment::fromServer([]);
+
+        $this->assertInstanceOf(Environment::class, $environment);
+        $this->assertTrue($environment->isDevelopment());
+    }
+    
+    /**
+     * @test
      * @dataProvider providerEnvironment
      *
      * @param string $type

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -112,7 +112,7 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Environment::class, $environment);
         $this->assertTrue($environment->isDevelopment());
     }
-    
+
     /**
      * @test
      * @dataProvider providerEnvironment

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -105,12 +105,12 @@ final class EnvironmentTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function fromServerDefaultsToDevelopment()
+    public function fromServerDefaultsToProduction()
     {
         $environment = Environment::fromServer([]);
 
         $this->assertInstanceOf(Environment::class, $environment);
-        $this->assertTrue($environment->isDevelopment());
+        $this->assertTrue($environment->isProduction());
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] adds a missing test for `Environment::fromServer()`
* [x] defaults to production environment if the environment could not be determined from the environment variable

Fixes #1151.

💁‍♂️ Apologies for the clunky work - on vacation and working from an iPad. 
