### PR TITLE
phinx: CFP_ENV is passed via enviroment variable instead of $_SERVER

### DIFF
--- a/phinx.php
+++ b/phinx.php
@@ -15,7 +15,7 @@ use OpenCFP\Kernel;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$kernel = new Kernel((string) Environment::fromServer($_SERVER), false);
+$kernel = new Kernel((string) Environment::fromServer(\getenv()), false);
 $kernel->boot();
 
 $container = $kernel->getContainer();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,7 @@
         <env name="COLUMNS" value="120"/>
         <ini name="memory_limit" value="768M"/>
         <server name="CFP_ENV" value="testing"/>
+        <env name="CFP_ENV" value="testing"/>
     </php>
     <filter>
         <whitelist>


### PR DESCRIPTION
In `script/test` the `CFP_ENV` is passed via envirmoment variable. `phinx.php` should only be used on cli anyway.
