### PR TITLE
Allow for periods to be present in the joind.in username

### DIFF
--- a/src/Http/Form/SignupForm.php
+++ b/src/Http/Form/SignupForm.php
@@ -203,7 +203,7 @@ class SignupForm extends Form
 
     public function validateUrl(): bool
     {
-        if (\preg_match('/^https:\/\/joind\.in\/user\/[a-zA-Z0-9\-_]{1,100}$/', $this->cleanData['url'])
+        if (\preg_match('/^https:\/\/joind\.in\/user\/[a-zA-Z0-9\-_\.]{1,100}$/', $this->cleanData['url'])
             || !isset($this->cleanData['url'])
             || $this->cleanData['url'] == ''
         ) {

--- a/tests/Unit/Http/Form/SignupFormTest.php
+++ b/tests/Unit/Http/Form/SignupFormTest.php
@@ -332,6 +332,8 @@ final class SignupFormTest extends \PHPUnit\Framework\TestCase
             [$validBaseUrl . 'do re mi', false],
             [$validBaseUrl . '_FirstLast', true],
             [$validBaseUrl . 'first-last', true],
+            [$validBaseUrl . 'firstname.last', true],
+            [$validBaseUrl . '._name_.', true],
             [$validBaseUrl . $longUrl, false],
         ];
     }


### PR DESCRIPTION
This PR fixes #1161 by permitting periods to be present in the joind.in link.