### PR TITLE
Redirects users with emails not in the system to the signup page

### DIFF
--- a/resources/views/security/signup.twig
+++ b/resources/views/security/signup.twig
@@ -10,7 +10,9 @@
 
         <form method="post" action="{{ url('user_create') }}">
             <label class="text-white text-sm">Email</label>
-            <input type="email" name="email" placeholder="you@example.com">
+            <input type="email" name="email"
+                   value="{% if flash.old_email %}{{ flash.old_email | escape }}{% endif %}"
+                   placeholder="you@example.com">
             <label class="text-white text-sm">Password</label>
             <input type="password" name="password" placeholder="•••••••">
             <ul class="list-reset">

--- a/src/Domain/Services/Authentication.php
+++ b/src/Domain/Services/Authentication.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Domain\Services;
 
 use OpenCFP\Infrastructure\Auth\UserInterface;
+use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 
 interface Authentication
 {
@@ -24,6 +25,7 @@ interface Authentication
      * @param string $password
      *
      * @throws AuthenticationException
+     * @throws UserNotFoundException
      */
     public function authenticate($username, $password);
 

--- a/src/Http/Action/Security/LogInAction.php
+++ b/src/Http/Action/Security/LogInAction.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Action\Security;
 
 use OpenCFP\Domain\Services;
+use OpenCFP\Domain\ValidationException;
+use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
 use Twig_Environment;
@@ -48,9 +50,46 @@ final class LogInAction
     public function __invoke(HttpFoundation\Request $request): HttpFoundation\Response
     {
         try {
+            // Validate that the email address is a valid email before attempting to log in
+            // This will prevent improperly-formed emails from potentially getting recognized
+            // as a missing user, not invalid input.
+            if (\filter_var($request->get('email'), FILTER_VALIDATE_EMAIL) === false) {
+                throw ValidationException::withErrors(['The email address is improperly formatted.']);
+            }
+
             $this->authentication->authenticate(
                 $request->get('email'),
                 $request->get('password')
+            );
+        } catch (UserNotFoundException $exception) {
+            $flash = [
+                'type'  => 'error',
+                'short' => 'Error',
+                'ext'   => 'User does not exist in the system; you can sign up below!',
+
+                // Used to pre-populate the email field on the signup form
+                'old_email' => $request->get('email'),
+            ];
+
+            $request->getSession()->set('flash', $flash);
+
+            return new HttpFoundation\RedirectResponse($this->urlGenerator->generate('user_new'));
+        } catch (ValidationException $exception) {
+            $flash = [
+                'type'  => 'error',
+                'short' => 'Error',
+                'ext'   => \implode('<br />', $exception->errors()),
+            ];
+
+            $request->getSession()->set('flash', $flash);
+
+            $content = $this->twig->render('security/login.twig', [
+                'flash' => $flash,
+            ]);
+
+            return new HttpFoundation\Response(
+                $content,
+                HttpFoundation\Response::HTTP_BAD_REQUEST
             );
         } catch (Services\AuthenticationException $exception) {
             $flash = [

--- a/src/Infrastructure/Auth/SentinelAuthentication.php
+++ b/src/Infrastructure/Auth/SentinelAuthentication.php
@@ -51,6 +51,8 @@ final class SentinelAuthentication implements Authentication
             if (!$success) {
                 throw AuthenticationException::loginFailure();
             }
+        } catch (UserNotFoundException $e) {
+            throw $e;
         } catch (\Throwable $e) {
             throw AuthenticationException::loginFailure();
         }

--- a/tests/Integration/Http/Action/Security/LogInActionTest.php
+++ b/tests/Integration/Http/Action/Security/LogInActionTest.php
@@ -40,4 +40,40 @@ final class LogInActionTest extends WebTestCase implements TransactionalTestCase
         $this->assertResponseBodyContains('Password', $response);
         $this->assertResponseBodyContains('Login', $response);
     }
+
+    /**
+     * @test
+     */
+    public function rendersLoginFormIfInvalidEmail()
+    {
+        $response = $this
+            ->post('/login', [
+                'email'    => $this->faker()->password,
+                'password' => $this->faker()->password,
+            ]);
+
+        $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_BAD_REQUEST, $response);
+        $this->assertResponseBodyContains('Email', $response);
+        $this->assertResponseBodyContains('Password', $response);
+        $this->assertResponseBodyContains('Login', $response);
+    }
+
+    /**
+     * @test
+     */
+    public function rendersSignInFormIfEmailDoesNotExist()
+    {
+        $randomEmail = $this->faker()->unique()->email;
+        $response    = $this
+            ->post('/login', [
+                'email'    => $randomEmail,
+                'password' => $this->faker()->password,
+            ]);
+
+        $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_FOUND, $response);
+        $this->assertResponseBodyContains($randomEmail, $response);
+        $this->assertResponseBodyContains('Email', $response);
+        $this->assertResponseBodyContains('Password', $response);
+        $this->assertResponseBodyContains('Signup', $response);
+    }
 }

--- a/tests/Integration/Http/Action/Security/LogInActionTest.php
+++ b/tests/Integration/Http/Action/Security/LogInActionTest.php
@@ -70,10 +70,8 @@ final class LogInActionTest extends WebTestCase implements TransactionalTestCase
                 'password' => $this->faker()->password,
             ]);
 
-        $this->assertResponseStatusCode(HttpFoundation\Response::HTTP_FOUND, $response);
-        $this->assertResponseBodyContains($randomEmail, $response);
-        $this->assertResponseBodyContains('Email', $response);
-        $this->assertResponseBodyContains('Password', $response);
-        $this->assertResponseBodyContains('Signup', $response);
+        $this->assertResponseIsRedirect($response);
+        $this->assertRedirectResponseUrlEquals('/signup', $response);
+        $this->assertSessionHasFlashMessage('User does not exist in the system; you can sign up below!', $this->session());
     }
 }

--- a/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Integration/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -17,6 +17,7 @@ use Cartalyst\Sentinel\Native\Facades\Sentinel;
 use OpenCFP\Domain\Services\AuthenticationException;
 use OpenCFP\Infrastructure\Auth\SentinelAccountManagement;
 use OpenCFP\Infrastructure\Auth\SentinelAuthentication;
+use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
@@ -53,9 +54,9 @@ final class SentinelAuthenticationTest extends WebTestCase implements Transactio
     /**
      * @test
      */
-    public function wrongUserCanNotAuthenticate()
+    public function missingUserIsNotFoundCantAuthenticate()
     {
-        $this->expectException(AuthenticationException::class);
+        $this->expectException(UserNotFoundException::class);
         $this->sut->authenticate('wrong@user.com', 'secret');
     }
 

--- a/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
+++ b/tests/Unit/Infrastructure/Auth/SentinelAuthenticationTest.php
@@ -51,13 +51,13 @@ final class SentinelAuthenticationTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function authenticateWillThrowCorrectError()
+    public function authenticateWillThrowCorrectErrorForMissingAccount()
     {
         $sentinel = Mockery::mock(Sentinel::class);
         $account  = Mockery::mock(AccountManagement::class);
         $account->shouldReceive('findByLogin')->andThrow(new UserNotFoundException());
         $auth = new SentinelAuthentication($sentinel, $account);
-        $this->expectException(AuthenticationException::class);
+        $this->expectException(UserNotFoundException::class);
         $auth->authenticate('mail', 'pass');
     }
 


### PR DESCRIPTION
This PR addresses #1091 by redirecting users who attempt to log in with an email address that is not present in the system to the signup page, while also pre-populating the email field. It also validates that some semblance of an email address is provided, and keeps the user on the login page if not.
