### PR TITLE
Fix: Remove extra empty lines

### DIFF
--- a/resources/config/routing.yml
+++ b/resources/config/routing.yml
@@ -174,7 +174,6 @@ login:
   methods: [GET]
   controller: OpenCFP\Http\Action\Security\ShowLogInAction
 
-
 login_check:
   path: /login
   methods: [POST]
@@ -266,4 +265,3 @@ sso_redirect:
   path: /sso/redirect
   methods: [GET]
   controller: OpenCFP\Http\Action\Security\SsoRedirectAction
-


### PR DESCRIPTION
This PR

* [x] removes extra empty lines from a configuration file

Follows #1164.