### PR TITLE
Enhancement: Move responsibilty to construct Twitter URL upstream

### DIFF
--- a/resources/views/admin/speaker/index.twig
+++ b/resources/views/admin/speaker/index.twig
@@ -31,7 +31,7 @@
                     </h2>
                     <div>
                         {% if speaker.company %}<span class="mr-3"><i class="fa fa-building"></i> {{ speaker.company }}</span>{% endif %}
-                        {% if speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="https://twitter.com/{{ speaker.twitter }}" rel="noopener noreferrer"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
+                        {% if speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="{{ speaker.twitterUrl }}" rel="noopener noreferrer"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
                         {% if speaker.email %}<span class="mr-3"><i class="fa fa-envelope"></i> {{ speaker.email }}</span>{% endif %}
                     </div>
                 </div>

--- a/resources/views/admin/speaker/view.twig
+++ b/resources/views/admin/speaker/view.twig
@@ -14,7 +14,7 @@
             </h1>
             <div>
                 {% if speaker.company %}<span class="mr-3"><i class="fa fa-building"></i> {{ speaker.company }}</span>{% endif %}
-                {% if speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="https://twitter.com/{{ speaker.twitter }}" rel="noopener noreferrer"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
+                {% if speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="{{ speaker.twitterUrl }}" rel="noopener noreferrer"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
                 {% if speaker.email %}<span class="mr-3"><i class="fa fa-envelope"></i> {{ speaker.email }}</span>{% endif %}
             </div>
         </div>

--- a/resources/views/reviewer/speaker/index.twig
+++ b/resources/views/reviewer/speaker/index.twig
@@ -26,7 +26,7 @@
                     </h2>
                     <div>
                         {% if speaker.company %}<span class="mr-3"><i class="fa fa-building"></i> {{ speaker.company }}</span>{% endif %}
-                        {% if speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="https://twitter.com/{{ speaker.twitter }}" rel="noopener noreferrer"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
+                        {% if speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="{{ speaker.twitterUrl }}" rel="noopener noreferrer"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
                         {% if speaker.email %}<span class="mr-3"><i class="fa fa-envelope"></i> {{ speaker.email }}</span>{% endif %}
                     </div>
                 </div>

--- a/resources/views/reviewer/speaker/view.twig
+++ b/resources/views/reviewer/speaker/view.twig
@@ -10,7 +10,7 @@
 
             <div>
                 {% if speaker.isAllowedToSee('company') and speaker.company %}<span class="mr-3"><i class="fa fa-building"></i> {{ speaker.company }}</span>{% endif %}
-                {% if speaker.isAllowedToSee('twitter') and speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="https://twitter.com/{{ speaker.twitter }}" rel="noopener noreferrer"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
+                {% if speaker.isAllowedToSee('twitter') and speaker.twitter %}<span class="mr-3"><a class="hover:text-brand" target="_blank" href="{{ speaker.twitterUrl }}" rel="noopener noreferrer"><i class="fa fa-twitter"></i> @{{ speaker.twitter }}</a></span>{% endif %}
                 {% if speaker.isAllowedToSee('email') and speaker.email %}<span class="mr-3"><i class="fa fa-envelope"></i> {{ speaker.email }}</span>{% endif %}
             </div>
         </div>

--- a/src/Domain/Speaker/SpeakerProfile.php
+++ b/src/Domain/Speaker/SpeakerProfile.php
@@ -125,6 +125,24 @@ class SpeakerProfile
     /**
      * @throws NotAllowedException
      *
+     * @return string
+     */
+    public function getTwitterUrl(): string
+    {
+        $this->assertAllowedToSee('twitter');
+
+        $twitter = $this->speaker->twitter;
+
+        if ($twitter === null || \trim($twitter) === '') {
+            return '';
+        }
+
+        return 'https:://twitter.com/' . $twitter;
+    }
+
+    /**
+     * @throws NotAllowedException
+     *
      * @return null|string
      */
     public function getUrl()

--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -276,6 +276,71 @@ final class SpeakerProfileTest extends Framework\TestCase
     /**
      * @test
      */
+    public function getTwitterUrlThrowsNotAllowedExceptionIfPropertyIsHidden(): void
+    {
+        $hiddenProperties = [
+            'twitter',
+        ];
+
+        $speaker = $this->createUserMock();
+
+        $profile = new SpeakerProfile($speaker, $hiddenProperties);
+
+        $this->expectException(NotAllowedException::class);
+
+        $profile->getTwitterUrl();
+    }
+
+    /**
+     * @test
+     * @dataProvider providerEmptyValue
+     *
+     * @param null|string $value
+     */
+    public function getTwitterUrlReturnsEmptyStringWhenTwitterPropertyIsNotHiddenButEmpty($value): void
+    {
+        $speaker = $this->createUserMock([
+            'twitter' => $value,
+        ]);
+
+        $profile = new SpeakerProfile($speaker);
+
+        $this->assertSame('', $profile->getTwitterUrl());
+    }
+
+    public function providerEmptyValue(): array
+    {
+        $values = [
+            'null'         => null,
+            'string-empty' => '',
+            'string-blank' => '  ',
+        ];
+
+        return \array_map(function ($value) {
+            return [
+                $value,
+            ];
+        }, $values);
+    }
+
+    public function getTwitterUrlReturnsTwitterUrlWhenTwitterPropertyIsNeitherHiddenNorEmpty(): void
+    {
+        $value = $this->faker()->userName;
+
+        $speaker = $this->createUserMock([
+            'twitter' => $value,
+        ]);
+
+        $profile = new SpeakerProfile($speaker);
+
+        $expected = 'https://twitter.com/' . $value;
+
+        $this->assertSame($expected, $profile->getTwitterUrl());
+    }
+
+    /**
+     * @test
+     */
     public function getUrlThrowsNotAllowedExceptionIfPropertyIsHidden()
     {
         $hiddenProperties = [


### PR DESCRIPTION
This PR

* [x] moves the responsibility to construct a Twitter URL from view scripts to `SpeakerProfile`

Related to the suggestion in https://github.com/opencfp/opencfp/pull/1166/files#r223808752.

/cc @chrisforrence