### PR TITLE
Markdown-format additional speaker info

### DIFF
--- a/resources/views/admin/speaker/view.twig
+++ b/resources/views/admin/speaker/view.twig
@@ -51,7 +51,7 @@
 
             {% if speaker.info is not empty %}
                 <h3>Additional Notes</h3>
-                <p>{{ speaker.info }}</p>
+                <p>{{ speaker.info | striptags | markdown }}</p>
             {% endif %}
         </div>
     </div>

--- a/resources/views/reviewer/speaker/view.twig
+++ b/resources/views/reviewer/speaker/view.twig
@@ -38,7 +38,7 @@
 
             {% if speaker.isAllowedToSee('info') and  speaker.info is not empty %}
                 <h3>Additional Notes</h3>
-                <p>{{ speaker.info }}</p>
+                <p>{{ speaker.info | striptags | markdown }}</p>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
Fixes inconsistency where speaker bio can be Markdown formatted but additional info can't be, despite ostensibly having that ability (see input box hint).