### PR TITLE
Don't double-escape talk titles on speaker view

### DIFF
--- a/resources/views/admin/speaker/view.twig
+++ b/resources/views/admin/speaker/view.twig
@@ -39,7 +39,7 @@
                 <h3><i class="fa fa-bullhorn"></i> Talk Submissions</h3>
 
                 {% for talk in talks %}
-                    <a class="text-brand block mb-3" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title }}</a>
+                    <a class="text-brand block mb-3" href="{{ url('admin_talk_view', { id: talk.id }) }}">{{ talk.title | raw }}</a>
                 {% endfor %}
             {% endif %}
 


### PR DESCRIPTION
Was tired of looking at &amp; every time a talk included a literal & in it.