### PR TITLE
Require airport code entry if requesting travel assistance

### DIFF
--- a/src/Http/Form/SignupForm.php
+++ b/src/Http/Form/SignupForm.php
@@ -62,7 +62,25 @@ class SignupForm extends Form
             $validSpeakerBio = $this->validateSpeakerBio();
         }
 
-        return $this->validateEmail() && $validPasswords && $this->validateFirstName() && $this->validateLastName() && $this->validateUrl() && $validSpeakerInfo && $validSpeakerBio && $this->validateSpeakerPhoto() && $agreeCoc && $this->validateJoindInUsername();
+        return $this->validateEmail() && $validPasswords &&
+            $this->validateFirstName() && $this->validateLastName() && $this->validateUrl() &&
+            $validSpeakerInfo && $validSpeakerBio && $this->validateSpeakerPhoto() && $agreeCoc &&
+            $this->validateJoindInUsername() && $this->validateTransportationRequests();
+    }
+
+    public function validateTransportationRequests()
+    {
+        if (!isset($this->taintedData['transportation']) || !$this->taintedData['transportation']) {
+            return true;
+        }
+
+        if (!isset($this->taintedData['airport']) || !$this->taintedData['airport']) {
+            $this->addErrorMessage("Since you specified that you'll need help with transportation costs, we need to know which airport you'll be departing from. You may specify additional information (e.g. alternate airports) in the Additional Notes field.");
+
+            return false;
+        }
+
+        return true;
     }
 
     public function validateSpeakerPhoto(): bool
@@ -298,7 +316,7 @@ class SignupForm extends Form
             return true;
         }
 
-        $this->addErrorMessage('You must agree to abide by our code of conduct in order to submit');
+        $this->addErrorMessage('You must agree to abide by our Code of Conduct in order to submit talks.');
 
         return false;
     }


### PR DESCRIPTION
Since flight prices vary significantly between a local hop and an intercontinental jaunt, requiring originating airport code will help conf organizers gauge what they can afford without having to manually ask speakers what their airport code is after the fact.

With the above said, I totally understand if we don't want this requirement to be on by default, in which case I can throw it behind a config variable (which we'll definitely have turned on for Longhorn).

Also s/Code of conduct/Code of Conduct; if I absolutely need to back out that change to get this PR through, I'll do it :)