### PR TITLE
Fix: Add missing test annotation

### DIFF
--- a/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
+++ b/tests/Unit/Domain/Speaker/SpeakerProfileTest.php
@@ -323,6 +323,9 @@ final class SpeakerProfileTest extends Framework\TestCase
         }, $values);
     }
 
+    /**
+     * @test
+     */
     public function getTwitterUrlReturnsTwitterUrlWhenTwitterPropertyIsNeitherHiddenNorEmpty(): void
     {
         $value = $this->faker()->userName;


### PR DESCRIPTION
This PR

* [x] adds a missing `@test` annotation

Follows #1172.
Follows #1176.