### PR TITLE
Enhancement: Extract AutoReview test-suite and split tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ jobs:
         - mysqldump -uroot $TRAVIS_DB > tests/dump.sql
 
       script:
+        - vendor/bin/phpunit --testsuite auto-review
         - vendor/bin/phpunit --testsuite integration
         - if [[ "$WITH_COVERAGE" == "true" ]]; then xdebug-enable; fi
         - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/phpunit --testsuite unit --coverage-clover build/logs/clover.xml; else vendor/bin/phpunit --testsuite unit; fi

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: asset cache coverage cs database infection integration it stan test test-env unit
+.PHONY: asset auto-review cache coverage cs database infection integration it stan test test-env unit
 
 it: cs test
 
 asset:
 	yarn install
 	yarn run production
+
+auto-review: vendor
+	vendor/bin/phpunit --testsuite auto-review
 
 cache: vendor
 	bin/console cache:clear --env=development
@@ -31,7 +34,7 @@ integration: test-env vendor database cache
 stan: vendor
 	vendor/bin/phpstan analyse --level=2 src tests
 
-test: integration unit
+test: auto-review integration unit
 
 test-env:
 	if [ ! -f "config/testing.yml" ]; then cp config/testing.yml.dist config/testing.yml; fi

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,9 @@
         </whitelist>
     </filter>
     <testsuites>
+        <testsuite name="auto-review">
+            <directory>tests/AutoReview</directory>
+        </testsuite>
         <testsuite name="unit">
             <directory>tests/Unit</directory>
         </testsuite>

--- a/tests/AutoReview/SrcCodeTest.php
+++ b/tests/AutoReview/SrcCodeTest.php
@@ -11,78 +11,22 @@ declare(strict_types=1);
  * @see https://github.com/opencfp/opencfp
  */
 
-namespace OpenCFP\Test\Unit;
+namespace OpenCFP\Test\AutoReview;
 
 use Localheinz\Classy;
 use Localheinz\Test\Util\Helper;
-use OpenCFP\Domain;
 use OpenCFP\Http;
-use OpenCFP\Infrastructure;
-use OpenCFP\Kernel;
 use PHPUnit\Framework;
 use Symfony\Component\HttpFoundation;
 
-final class ProjectCodeTest extends Framework\TestCase
+final class SrcCodeTest extends Framework\TestCase
 {
     use Helper;
 
     /**
      * @test
      */
-    public function productionClassesHaveUnitTests()
-    {
-        $this->assertClassesHaveTests(
-            __DIR__ . '/../../src',
-            'OpenCFP\\',
-            'OpenCFP\\Test\\Unit\\',
-            [
-                Domain\Model\Airport::class,
-                Domain\Model\Eloquent::class,
-                Domain\Model\Favorite::class,
-                Domain\Model\Persistence::class,
-                Domain\Model\Reminder::class,
-                Domain\Model\Talk::class,
-                Domain\Model\TalkComment::class,
-                Domain\Model\TalkMeta::class,
-                Domain\Model\Throttle::class,
-                Domain\Model\User::class,
-                Domain\Services\ProfileImageProcessor::class,
-                Domain\Talk\TalkFormatter::class,
-                Domain\Talk\TalkHandler::class,
-                Http\Action\Admin\DashboardAction::class,
-                Http\Action\Admin\Talk\IndexAction::class,
-                Http\Action\Admin\Talk\RateAction::class,
-                Http\Action\Profile\ChangePasswordProcessAction::class,
-                Http\Action\Profile\DeleteAction::class,
-                Http\Action\Profile\ProcessDeleteAction::class,
-                Http\Action\Reviewer\DashboardAction::class,
-                Http\Action\Reviewer\Speaker\IndexAction::class,
-                Http\Action\Reviewer\Speaker\ViewAction::class,
-                Http\Action\Reviewer\Talk\IndexAction::class,
-                Http\Action\Reviewer\Talk\RateAction::class,
-                Http\Action\Signup\PrivacyAction::class,
-                Http\Action\Signup\ProcessAction::class,
-                Http\Controller\Admin\ExportsController::class,
-                Http\Controller\Admin\SpeakersController::class,
-                Http\Controller\Admin\TalksController::class,
-                Http\Controller\ForgotController::class,
-                Http\Form\ForgotFormType::class,
-                Http\Form\ResetFormType::class,
-                Infrastructure\Event\AuthenticationListener::class,
-                Infrastructure\Event\CsrfValidationListener::class,
-                Infrastructure\Event\ExceptionListener::class,
-                Infrastructure\Event\RequestCleanerListener::class,
-                Infrastructure\Event\TwigGlobalsListener::class,
-                Infrastructure\Templating\TwigExtension::class,
-                Kernel::class,
-            ]
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function controllerActionsUseResponseReturnType()
+    public function controllerActionsUseResponseReturnType(): void
     {
         $actionsWithoutReturnTypes = $this->methodNames(\array_filter($this->controllerActions(), function (\ReflectionMethod $method) {
             $returnType = (string) $method->getReturnType();
@@ -100,7 +44,7 @@ final class ProjectCodeTest extends Framework\TestCase
     /**
      * @test
      */
-    public function controllerActionsUseActionSuffix()
+    public function controllerActionsUseActionSuffix(): void
     {
         $actionsWithoutSuffix = $this->methodNames(\array_filter($this->controllerActions(), function (\ReflectionMethod $method) {
             return \preg_match('/Action$/', $method->getName()) === 0;
@@ -161,21 +105,13 @@ final class ProjectCodeTest extends Framework\TestCase
     }
 
     /**
-     * @test
-     */
-    public function classesAreAbstractOrFinal()
-    {
-        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..');
-    }
-
-    /**
      * @dataProvider providerProductionClassesAreAbstractOrFinal
      *
      * @param string $directory
      *
      * @test
      */
-    public function productionClassesAreAbstractOrFinal(string $directory)
+    public function productionClassesAreAbstractOrFinal(string $directory): void
     {
         $this->assertClassesAreAbstractOrFinal($directory);
     }

--- a/tests/AutoReview/TestCodeTest.php
+++ b/tests/AutoReview/TestCodeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2018 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Test\AutoReview;
+
+use Localheinz\Test\Util\Helper;
+use OpenCFP\Domain;
+use OpenCFP\Http;
+use OpenCFP\Infrastructure;
+use OpenCFP\Kernel;
+use PHPUnit\Framework;
+
+final class TestCodeTest extends Framework\TestCase
+{
+    use Helper;
+
+    /**
+     * @test
+     */
+    public function productionClassesHaveUnitTests(): void
+    {
+        $this->assertClassesHaveTests(
+            __DIR__ . '/../../src',
+            'OpenCFP\\',
+            'OpenCFP\\Test\\Unit\\',
+            [
+                Domain\Model\Airport::class,
+                Domain\Model\Eloquent::class,
+                Domain\Model\Favorite::class,
+                Domain\Model\Persistence::class,
+                Domain\Model\Reminder::class,
+                Domain\Model\Talk::class,
+                Domain\Model\TalkComment::class,
+                Domain\Model\TalkMeta::class,
+                Domain\Model\Throttle::class,
+                Domain\Model\User::class,
+                Domain\Services\ProfileImageProcessor::class,
+                Domain\Talk\TalkFormatter::class,
+                Domain\Talk\TalkHandler::class,
+                Http\Action\Admin\DashboardAction::class,
+                Http\Action\Admin\Talk\IndexAction::class,
+                Http\Action\Admin\Talk\RateAction::class,
+                Http\Action\Profile\ChangePasswordProcessAction::class,
+                Http\Action\Profile\DeleteAction::class,
+                Http\Action\Profile\ProcessDeleteAction::class,
+                Http\Action\Reviewer\DashboardAction::class,
+                Http\Action\Reviewer\Speaker\IndexAction::class,
+                Http\Action\Reviewer\Speaker\ViewAction::class,
+                Http\Action\Reviewer\Talk\IndexAction::class,
+                Http\Action\Reviewer\Talk\RateAction::class,
+                Http\Action\Signup\PrivacyAction::class,
+                Http\Action\Signup\ProcessAction::class,
+                Http\Controller\Admin\ExportsController::class,
+                Http\Controller\Admin\SpeakersController::class,
+                Http\Controller\Admin\TalksController::class,
+                Http\Controller\ForgotController::class,
+                Http\Form\ForgotFormType::class,
+                Http\Form\ResetFormType::class,
+                Infrastructure\Event\AuthenticationListener::class,
+                Infrastructure\Event\CsrfValidationListener::class,
+                Infrastructure\Event\ExceptionListener::class,
+                Infrastructure\Event\RequestCleanerListener::class,
+                Infrastructure\Event\TwigGlobalsListener::class,
+                Infrastructure\Templating\TwigExtension::class,
+                Kernel::class,
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function classesAreAbstractOrFinal(): void
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..');
+    }
+}


### PR DESCRIPTION
This PR

* [x] extracts an `auto-review` test-suite and splits tests out of `ProjectCodeTest`

💁‍♂️ In addition to what we already have it could probably be useful to verify test code in regard to `public` methods that are not used as data providers and aren't prefixed with `test` (perhaps they should be tests and are missing a `@test` annotation)