### PR TITLE
Use global date format for CFP end date in submission email

### DIFF
--- a/resources/config/config.yml
+++ b/resources/config/config.yml
@@ -25,6 +25,7 @@ wouterj_eloquent:
 twig:
   default_path: '%kernel.project_dir%/resources/views'
   debug: '%kernel.debug%'
+  base_template_class: 'OpenCFP\Infrastructure\Templating\Template'
   globals:
     site:       '%config.application%'
     talkHelper: '@OpenCFP\Http\View\TalkHelper'

--- a/resources/views/emails/talk_submit.twig
+++ b/resources/views/emails/talk_submit.twig
@@ -5,7 +5,7 @@
 
 {% block body_html %}
 <p>
-    Thank you for the awesome talk submission. When the call for papers is over on {{ enddate }} talk selection will begin. We'll be in touch soon.
+    Thank you for the awesome talk submission. When the call for papers is over on {{ enddate | date(site.date_format) }} talk selection will begin. We'll be in touch soon.
 </p>
 <p>
     Submitted Talk Title: "{{ talk }}"
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block body_text %}
-    Thank you for the awesome talk submission. When the call for papers is over on {{ enddate }} talk selection will begin. We'll be in touch soon.
+    Thank you for the awesome talk submission. When the call for papers is over on {{ enddate | date(site.date_format) }} talk selection will begin. We'll be in touch soon.
 
 Submitted Talk Title: "{{ talk }}"
 

--- a/src/Domain/Services/ResetEmailer.php
+++ b/src/Domain/Services/ResetEmailer.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace OpenCFP\Domain\Services;
 
+use OpenCFP\Infrastructure\Templating\Template;
+
 class ResetEmailer
 {
     /**
@@ -99,19 +101,19 @@ class ResetEmailer
     {
         $message = new \Swift_Message();
 
-        /** @var \Twig_Template $template */
+        /** @var Template $template */
         $template = $this->twig->loadTemplate('emails/reset_password.twig');
 
         $message->setTo($email);
         $message->setFrom(
-            $template->renderBlock('from', $parameters),
-            $template->renderBlock('from_name', $parameters)
+            $template->renderBlockWithContext('from', $parameters),
+            $template->renderBlockWithContext('from_name', $parameters)
         );
 
-        $message->setSubject($template->renderBlock('subject', $parameters));
-        $message->setBody($template->renderBlock('body_text', $parameters));
+        $message->setSubject($template->renderBlockWithContext('subject', $parameters));
+        $message->setBody($template->renderBlockWithContext('body_text', $parameters));
         $message->addPart(
-            $template->renderBlock('body_html', $parameters),
+            $template->renderBlockWithContext('body_html', $parameters),
             'text/html'
         );
 

--- a/src/Http/Action/Talk/CreateProcessAction.php
+++ b/src/Http/Action/Talk/CreateProcessAction.php
@@ -19,6 +19,7 @@ use OpenCFP\Domain\Model;
 use OpenCFP\Domain\Services;
 use OpenCFP\Http\Form;
 use OpenCFP\Http\View;
+use OpenCFP\Infrastructure\Templating\Template;
 use Swift_Mailer;
 use Swift_Message;
 use Symfony\Component\HttpFoundation;
@@ -197,6 +198,7 @@ final class CreateProcessAction
     {
         $talk = Model\Talk::find($talkId, ['title']);
 
+        /** @var Template $template */
         $template = $this->twig->loadTemplate('emails/talk_submit.twig');
 
         $parameters = [
@@ -211,14 +213,14 @@ final class CreateProcessAction
 
             $message->setTo($email);
             $message->setFrom(
-                $template->renderBlock('from', $parameters),
-                $template->renderBlock('from_name', $parameters)
+                $template->renderBlockWithContext('from', $parameters),
+                $template->renderBlockWithContext('from_name', $parameters)
             );
 
-            $message->setSubject($template->renderBlock('subject', $parameters));
-            $message->setBody($template->renderBlock('body_text', $parameters));
+            $message->setSubject($template->renderBlockWithContext('subject', $parameters));
+            $message->setBody($template->renderBlockWithContext('body_text', $parameters));
             $message->addPart(
-                $template->renderBlock('body_html', $parameters),
+                $template->renderBlockWithContext('body_html', $parameters),
                 'text/html'
             );
 

--- a/src/Http/Action/Talk/UpdateAction.php
+++ b/src/Http/Action/Talk/UpdateAction.php
@@ -19,6 +19,7 @@ use OpenCFP\Domain\Model;
 use OpenCFP\Domain\Services;
 use OpenCFP\Http\Form;
 use OpenCFP\Http\View;
+use OpenCFP\Infrastructure\Templating\Template;
 use Swift_Mailer;
 use Swift_Message;
 use Symfony\Component\HttpFoundation;
@@ -201,7 +202,7 @@ final class UpdateAction
 
     private function sendSubmitEmail(Model\Talk $talk, string $email): int
     {
-        /** @var \Twig_Template $template */
+        /** @var Template $template */
         $template = $this->twig->loadTemplate('emails/talk_submit.twig');
 
         $parameters = [
@@ -216,14 +217,14 @@ final class UpdateAction
 
             $message->setTo($email);
             $message->setFrom(
-                $template->renderBlock('from', $parameters),
-                $template->renderBlock('from_name', $parameters)
+                $template->renderBlockWithContext('from', $parameters),
+                $template->renderBlockWithContext('from_name', $parameters)
             );
 
-            $message->setSubject($template->renderBlock('subject', $parameters));
-            $message->setBody($template->renderBlock('body_text', $parameters));
+            $message->setSubject($template->renderBlockWithContext('subject', $parameters));
+            $message->setBody($template->renderBlockWithContext('body_text', $parameters));
             $message->addPart(
-                $template->renderBlock('body_html', $parameters),
+                $template->renderBlockWithContext('body_html', $parameters),
                 'text/html'
             );
 

--- a/src/Infrastructure/Templating/Template.php
+++ b/src/Infrastructure/Templating/Template.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2018 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
+namespace OpenCFP\Infrastructure\Templating;
+
+abstract class Template extends \Twig_Template
+{
+    /**
+     * Renders a block, including global context variables, so it can be used directly
+     * and still get expected results.
+     *
+     * @param string $name      The block name to render
+     * @param array  $context   The context
+     * @param array  $blocks    The current set of blocks
+     * @param bool   $useBlocks Whether to use the current set of blocks
+     *
+     * @return string The rendered block
+     */
+    public function renderBlockWithContext(string $name, array $context, array $blocks = [], bool $useBlocks = true)
+    {
+        return $this->renderBlock($name, $this->env->mergeGlobals($context), $blocks, $useBlocks);
+    }
+}


### PR DESCRIPTION
Everything else uses the global date format, so it looks like this is a bit of an omission as it stands.