### PR TITLE
Enhancement: Configure visibility_required fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -138,6 +138,11 @@ return PhpCsFixer\Config::create()
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
+        'visibility_required' => [
+            'const',
+            'method',
+            'property',
+        ],
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
             'equal' => false,

--- a/src/Domain/Model/Favorite.php
+++ b/src/Domain/Model/Favorite.php
@@ -19,8 +19,8 @@ class Favorite extends Eloquent
 {
     protected $table = 'favorites';
 
-    const CREATED_AT = 'created';
-    const UPDATED_AT = null;
+    public const CREATED_AT = 'created';
+    public const UPDATED_AT = null;
 
     public function talk(): BelongsTo
     {

--- a/src/Domain/Model/TalkComment.php
+++ b/src/Domain/Model/TalkComment.php
@@ -19,8 +19,8 @@ class TalkComment extends Eloquent
 {
     protected $table = 'talk_comments';
 
-    const CREATED_AT = 'created';
-    const UPDATED_AT = null;
+    public const CREATED_AT = 'created';
+    public const UPDATED_AT = null;
 
     public function user(): BelongsTo
     {

--- a/src/Domain/Model/TalkMeta.php
+++ b/src/Domain/Model/TalkMeta.php
@@ -19,11 +19,11 @@ class TalkMeta extends Eloquent
 {
     protected $table = 'talk_meta';
 
-    const CREATED_AT = 'created';
-    const UPDATED_AT = null;
+    public const CREATED_AT = 'created';
+    public const UPDATED_AT = null;
 
-    const DEFAULT_RATING = 0;
-    const DEFAULT_VIEWED = 0;
+    public const DEFAULT_RATING = 0;
+    public const DEFAULT_VIEWED = 0;
 
     protected $attributes = [
         'rating' => self::DEFAULT_RATING,

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -15,9 +15,9 @@ namespace OpenCFP;
 
 class Environment
 {
-    const TYPE_PRODUCTION  = 'production';
-    const TYPE_DEVELOPMENT = 'development';
-    const TYPE_TESTING     = 'testing';
+    public const TYPE_PRODUCTION  = 'production';
+    public const TYPE_DEVELOPMENT = 'development';
+    public const TYPE_TESTING     = 'testing';
 
     /**
      * The specified environment.

--- a/tests/Unit/Application/SpeakersTest.php
+++ b/tests/Unit/Application/SpeakersTest.php
@@ -25,7 +25,7 @@ final class SpeakersTest extends \PHPUnit\Framework\TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    const SPEAKER_ID = '1';
+    public const SPEAKER_ID = '1';
 
     /** @var Speakers */
     private $sut;


### PR DESCRIPTION
This PR

* [x] configures the `visibility_required` fixer to also require visibility for constants
* [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.10.2#usage:

> **visibility_required** [`@PSR2`, `@Symfony`, `@PHP71Migration`]
>
>Visibility MUST be declared on all properties and methods; abstract and final MUST be declared before the visibility; static MUST be declared after the visibility.
>
>Configuration options:
>
>* `elements` (`array`): the structural elements to fix (PHP >= 7.1 required for `const`); defaults to `['property', 'method']`