### PR TITLE
Show additional talk info on speaker view (post-conf-close)

### DIFF
--- a/resources/views/talk/view.twig
+++ b/resources/views/talk/view.twig
@@ -6,5 +6,9 @@
         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-graduation-cap"></i> {{ talkHelper.getCategoryDisplayName(talk.category) }}</span>
         <span class="bg-brand text-white text-xs rounded-full py-2 px-3">{{ talkHelper.getLevelDisplayName(talk.level) }}</span>
     </div>
-    <p class="text-sm text-dark-soft">{{ talk.description | markdown }}</p>
+    <p class="text-sm text-dark-soft">{{ talk.description | striptags | markdown }}</p>
+    {% if talk.other is not empty %}
+        <h4 class="mb-2 mt-4">Other Information</h4>
+        <p class="text-sm text-dark-soft">{{ talk.other | striptags | markdown }}</p>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
As a speaker, I've wanted to access the additional talk info after the CFP has closed, but post-new-theme that info has been hidden, as it's only been available on the edit page (which of course goes away post CFP close).

Fingers crossed that this gets merged quickly, so I can start bugging other organizers to cherry-pick it into their forks (and so confs pulling from master will get it), so I'll be able to see that information on their confs for my talks :). Naturally, Longhorn has this bit already built in.