### PR TITLE
Markdown-format talk comments

### DIFF
--- a/resources/views/admin/talks/view.twig
+++ b/resources/views/admin/talks/view.twig
@@ -58,7 +58,7 @@
                     <div class="p-3 border-b border-grey bg-blue-lightest flex justify-between">
                         <span class="font-bold">{{ user.first_name }} {{ user.last_name }}</span><span>{{ comment.created|date("F jS \\a\\t g:ia") }}</span>
                     </div>
-                    <div class="p-3">{{ comment.message }}</div>
+                    <div class="p-3">{{ comment.message | striptags | markdown }}</div>
                 </div>
             </div>
         {% endfor %}

--- a/resources/views/reviewer/talks/view.twig
+++ b/resources/views/reviewer/talks/view.twig
@@ -58,7 +58,7 @@
                     <div class="p-3 border-b border-grey bg-blue-lightest flex justify-between">
                         <span class="font-bold">{{ comment.user.first_name }} {{ comment.user.last_name }}</span><span>{{ comment.created|date("F jS \\a\\t g:ia") }}</span>
                     </div>
-                    <div class="p-3">{{ comment.message }}</div>
+                    <div class="p-3">{{ comment.message | striptags | markdown }}</div>
                 </div>
             </div>
         {% endfor %}

--- a/tests/Integration/Http/Action/Talk/EditActionTest.php
+++ b/tests/Integration/Http/Action/Talk/EditActionTest.php
@@ -96,6 +96,7 @@ final class EditActionTest extends WebTestCase implements TransactionalTestCase
 
         $response = $this
             ->asLoggedInSpeaker($speaker->id)
+            ->callForPapersIsOpen()
             ->get('/talk/edit/' . $talk->id . '?token_id=edit_talk&token=' . $csrfToken);
 
         $this->assertResponseIsSuccessful($response);


### PR DESCRIPTION
Otherwise they get formatted as plain text, losing spacing etc.