### PR TITLE
Set testing CFP close date to far into future

### DIFF
--- a/config/testing.yml.dist
+++ b/config/testing.yml.dist
@@ -4,7 +4,7 @@ application:
   email: contact@openconf.com
   eventurl: http://localhost
   event_location: Miami, FL
-  enddate: Oct. 14th, 2018
+  enddate: Dec. 31st, 2100
   show_submission_count: false
   airport: MIA
   arrival: 2014-10-26


### PR DESCRIPTION
This PR addresses #1194 by setting the CFP closing date for testing far into the future (which was causing issues when testing if talks could be edited).

cc @chartjes 