### PR TITLE
Fix wrong css file name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ For more usage information please see the [Laravel Homestead Docs](http://larave
     * `/log`
  * You may need to alter the `memory_limit` of the web server to allow image processing of head-shots. This is largely
    dictated by the size of the images people upload. Typically 512M works.
- * Customize templates and `/web/assets/css/site.css` to your heart's content.
+ * Customize templates and `/web/assets/css/app.css` to your heart's content.
 
 ### [Building Docker Image](#building-docker-image)
 


### PR DESCRIPTION
The `README.md` references the wrong filename for the css file.

Also, the actual file (`app.css`) is the result of a build, hence not really human readable, another PR might be necessary in order to make a real update to the doc, explaining customisation.