### PR TITLE
Fixed joind in username column migration

### DIFF
--- a/migrations/20181002234013_create_user_joind_in_username_column.php
+++ b/migrations/20181002234013_create_user_joind_in_username_column.php
@@ -46,7 +46,7 @@ class CreateUserJoindInUsernameColumn extends AbstractMigration
         $users = EloquentUser::all();
 
         foreach ($users as $user) {
-            if (\preg_match($joindInRegex, $user->url, $matches) === 1) {
+            if ($user->url !== null && \preg_match($joindInRegex, $user->url, $matches) === 1) {
                 $user->joindin_username = $matches[1];
                 $user->url              = null;
                 $user->save();


### PR DESCRIPTION
This PR

* [x] Fixes error when running migration if any of the speaker urls is null in the database