### PR TITLE
Adds the ability to store larger uploaded files

### DIFF
--- a/config/development.yml.dist
+++ b/config/development.yml.dist
@@ -16,6 +16,7 @@ application:
   coc_link: http://confcodeofconduct.com/
   show_contrib_banner: true
   venue_image_path: /assets/img/venue.jpg
+  user_image_size: 300
 
 database:
   host: 127.0.0.1

--- a/config/docker.yml.dist
+++ b/config/docker.yml.dist
@@ -16,6 +16,7 @@ application:
   coc_link: http://confcodeofconduct.com/
   show_contrib_banner: true
   venue_image_path: /assets/img/venue.jpg
+  user_image_size: 300
 
 database:
   host: database

--- a/config/production.yml.dist
+++ b/config/production.yml.dist
@@ -16,6 +16,7 @@ application:
   coc_link: http://confcodeofconduct.com/
   show_contrib_banner: true
   venue_image_path: /assets/img/venue.jpg
+  user_image_size: 300
 
 database:
   host: 127.0.0.1

--- a/config/testing.yml.dist
+++ b/config/testing.yml.dist
@@ -15,6 +15,7 @@ application:
   coc_link: http://confcodeofconduct.com
   show_contrib_banner: true
   venue_image_path: /assets/img/venue.jpg
+  user_image_size: 300
 
 database:
   host: 127.0.0.1

--- a/resources/config/services/domain.yml
+++ b/resources/config/services/domain.yml
@@ -31,6 +31,7 @@ services:
     bind:
       $publishDir: '%kernel.project_dir%/web/uploads'
       League\Flysystem\FilesystemInterface: '@upload_filesystem'
+      $applicationUserImageSize: '%application.user_image_size%'
 
   OpenCFP\Domain\Services\RandomStringGenerator:
     alias: OpenCFP\Infrastructure\Crypto\PseudoRandomStringGenerator

--- a/resources/views/dashboard.twig
+++ b/resources/views/dashboard.twig
@@ -37,7 +37,9 @@ function deleteTalk(tid) {
         <div class="flex items-center">
             <div class="mr-6">
                 {% if profile.photo is not empty %}
-                    <img src="{{ uploads(profile.photo) }}" class="rounded-full border-4 border-white w-32"/>
+                    <img src="{{ thumbnail(profile.photo) }}"
+                         onerror="this.onerror=null;this.src='{{ uploads(profile.photo) }}';"
+                         class="rounded-full border-4 border-white w-32"/>
                 {% else %}
                     <img src="{{ assets('img/dummyphoto.jpg') }}" class="rounded-full border-4 border-white w-32"/>
                 {% endif %}

--- a/resources/views/forms/_user.twig
+++ b/resources/views/forms/_user.twig
@@ -54,8 +54,8 @@
             <p class="text-xs text-em mb-2 text-dark-soft">Speaker notes can be written using <a href="https://daringfireball.net/projects/markdown/basics" target="_blank" class="text-underline" rel="noopener noreferrer">markdown</a> to support links</p>
 
             <label for="form-user-photo" class="btn btn-brand cursor-pointer inline-block"><i class="fa fa-upload"></i><span class="ml-2">Upload Photo</span></label>
-            <input type="file" id="form-user-photo" name="speaker_photo" placeholder="Photo at least 300px wide by 300px high" accept="image/jpg, image/jpeg, image/png" class="hidden">
-            <p class="text-xs text-em mb-2 text-dark-soft">Photo should be square, and must be at least 300px wide by 300px high. JPG and PNG are the only accepted formats.</p>
+            <input type="file" id="form-user-photo" name="speaker_photo" placeholder="Photo at least {{ site.user_image_size }}px wide by {{ site.user_image_size }}px high" accept="image/jpg, image/jpeg, image/png" class="hidden">
+            <p class="text-xs text-em mb-2 text-dark-soft">Photo should be square and will be resized to {{ site.user_image_size }}px wide by {{ site.user_image_size }}px high. JPG and PNG are the only accepted formats.</p>
             {% if speaker_photo is defined and speaker_photo is not empty %}
                 <img src="{{ uploads(speaker_photo) }}" class="rounded-pill">
             {% endif %}

--- a/src/Infrastructure/Templating/TwigExtension.php
+++ b/src/Infrastructure/Templating/TwigExtension.php
@@ -50,8 +50,16 @@ class TwigExtension extends AbstractExtension
             new Twig_SimpleFunction('uploads', function ($path) {
                 return $this->path->uploadPath() . $path;
             }),
+            new Twig_SimpleFunction('thumbnail', function ($path) {
+                // Add the "thumb" segment to the given path
+                $tmpThumbnailFilenameParts = \explode('.', $path);
+                \array_splice($tmpThumbnailFilenameParts, -1, 0, ['thumb']);
+                $path = \implode('.', $tmpThumbnailFilenameParts);
+
+                return $this->path->uploadPath() . $path;
+            }),
             new Twig_SimpleFunction('assets', function ($path) {
-                return  $this->path->assetsPath() . $path;
+                return $this->path->assetsPath() . $path;
             }),
 
             new Twig_SimpleFunction('active', function ($route) {


### PR DESCRIPTION
This PR removes the hard-coded image resize (250px) and allows it to be configured at the application configuration level. Furthermore, this also allows the application to generate 240x240 thumbnails to be used on the dashboard (instead of cramming a potentially-large file into a 120x120 space). If a thumbnail is not available for a particular image, an onerror handler swaps the image source out with the non-thumbnail version.

Related to #1199.
