### PR TITLE
Fix github actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 OpenCFP is a PHP-based conference talk submission system.
 
 ---
-![](https://github.com/opencfp/opencfp/workflows/OpenCFP%20CI/badge.svg)
-
-[![GitHub release](https://img.shields.io/github/release/opencfp/opencfp.svg)](https://github.com/opencfp/opencfp/releases/latest)
+![](https://github.com/opencfp/opencfp/workflows/OpenCFP%20CI/badge.svg) [![GitHub release](https://img.shields.io/github/release/opencfp/opencfp.svg)](https://github.com/opencfp/opencfp/releases/latest)
 
 ## README Contents
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 OpenCFP is a PHP-based conference talk submission system.
 
 ---
-![](https://github.com/opencfp/opencfp/.github/workflows/ci.yml/badge.svg)
+![](https://github.com/opencfp/opencfp/workflows/OpenCFP%20CI/badge.svg)
 
 [![GitHub release](https://img.shields.io/github/release/opencfp/opencfp.svg)](https://github.com/opencfp/opencfp/releases/latest)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 OpenCFP is a PHP-based conference talk submission system.
 
 ---
-![](https://github.com/opencfp/opencfp/workflows/OpenCFP%20CI/badge.svg) [![GitHub release](https://img.shields.io/github/release/opencfp/opencfp.svg)](https://github.com/opencfp/opencfp/releases/latest)
+[![GitHub Actions](https://github.com/opencfp/opencfp/workflows/OpenCFP%20CI/badge.svg)](https://github.com/opencfp/opencfp/actions) [![GitHub release](https://img.shields.io/github/release/opencfp/opencfp.svg)](https://github.com/opencfp/opencfp/releases/latest)
 
 ## README Contents
 


### PR DESCRIPTION
This PR fixes the broken badge URL and use the name of the action instead of the file name. Also, remove the line break between the badges.

PS: generating GH Actions badge is a slow process, thats why the readme file may take a bit to load.