### PR TITLE
upgrade tailwind to version 0.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sass": "^1.23.6",
     "sass-loader": "^8.0.0",
     "suitcss-base": "^4.0.0",
-    "tailwindcss": "^0.4.0"
+    "tailwindcss": "0.7.4"
   },
   "dependencies": {
     "js-yaml": "^3.13.1",


### PR DESCRIPTION
This PR upgrades tailwindcss to version 0.7.4 to match the avaliable docs https://v0.tailwindcss.com/docs/what-is-tailwind/
