### PR TITLE
fixing deprecation of Twig_Environment class

### DIFF
--- a/src/Http/Action/Admin/Talk/ViewAction.php
+++ b/src/Http/Action/Admin/Talk/ViewAction.php
@@ -16,7 +16,7 @@ namespace OpenCFP\Http\Action\Admin\Talk;
 use OpenCFP\Domain\Talk;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ViewAction
 {
@@ -26,7 +26,7 @@ final class ViewAction
     private $talkHandler;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -37,7 +37,7 @@ final class ViewAction
 
     public function __construct(
         Talk\TalkHandler $talkHandler,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->talkHandler  = $talkHandler;

--- a/src/Http/Action/Forgot/ResetProcessAction.php
+++ b/src/Http/Action/Forgot/ResetProcessAction.php
@@ -17,7 +17,7 @@ use OpenCFP\Domain\Services;
 use Symfony\Component\Form;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ResetProcessAction
 {
@@ -32,7 +32,7 @@ final class ResetProcessAction
     private $accountManagement;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -44,7 +44,7 @@ final class ResetProcessAction
     public function __construct(
         Form\FormInterface $resetForm,
         Services\AccountManagement $accountManagement,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->resetForm         = $resetForm;

--- a/src/Http/Action/Forgot/UpdatePasswordAction.php
+++ b/src/Http/Action/Forgot/UpdatePasswordAction.php
@@ -17,7 +17,7 @@ use OpenCFP\Domain\Services;
 use Symfony\Component\Form;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class UpdatePasswordAction
 {
@@ -32,7 +32,7 @@ final class UpdatePasswordAction
     private $accountManagement;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -44,7 +44,7 @@ final class UpdatePasswordAction
     public function __construct(
         Form\FormInterface $resetForm,
         Services\AccountManagement $accountManagement,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->resetForm         = $resetForm;

--- a/src/Http/Action/Profile/EditAction.php
+++ b/src/Http/Action/Profile/EditAction.php
@@ -18,7 +18,7 @@ use OpenCFP\Domain\Services;
 use OpenCFP\PathInterface;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class EditAction
 {
@@ -33,7 +33,7 @@ final class EditAction
     private $path;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -45,7 +45,7 @@ final class EditAction
     public function __construct(
         Services\Authentication $authentication,
         PathInterface $path,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->authentication = $authentication;

--- a/src/Http/Action/Profile/ProcessAction.php
+++ b/src/Http/Action/Profile/ProcessAction.php
@@ -19,7 +19,7 @@ use OpenCFP\Domain\Services;
 use OpenCFP\Http\Form\SignupForm;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ProcessAction
 {
@@ -39,7 +39,7 @@ final class ProcessAction
     private $profileImageProcessor;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -52,7 +52,7 @@ final class ProcessAction
         Services\Authentication $authentication,
         HTMLPurifier $purifier,
         Services\ProfileImageProcessor $profileImageProcessor,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->authentication        = $authentication;

--- a/src/Http/Action/Reviewer/Talk/ViewAction.php
+++ b/src/Http/Action/Reviewer/Talk/ViewAction.php
@@ -16,7 +16,7 @@ namespace OpenCFP\Http\Action\Reviewer\Talk;
 use OpenCFP\Domain\Talk;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ViewAction
 {
@@ -26,7 +26,7 @@ final class ViewAction
     private $talkHandler;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -37,7 +37,7 @@ final class ViewAction
 
     public function __construct(
         Talk\TalkHandler $talkHandler,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->talkHandler  = $talkHandler;

--- a/src/Http/Action/Security/LogInAction.php
+++ b/src/Http/Action/Security/LogInAction.php
@@ -18,7 +18,7 @@ use OpenCFP\Domain\ValidationException;
 use OpenCFP\Infrastructure\Auth\UserNotFoundException;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class LogInAction
 {
@@ -28,7 +28,7 @@ final class LogInAction
     private $authentication;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -39,7 +39,7 @@ final class LogInAction
 
     public function __construct(
         Services\Authentication $authentication,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->authentication = $authentication;

--- a/src/Http/Action/Security/ShowLogInAction.php
+++ b/src/Http/Action/Security/ShowLogInAction.php
@@ -16,7 +16,7 @@ namespace OpenCFP\Http\Action\Security;
 use OpenCFP\Domain\Services;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ShowLogInAction
 {
@@ -26,7 +26,7 @@ final class ShowLogInAction
     private $authentication;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -40,7 +40,7 @@ final class ShowLogInAction
 
     public function __construct(
         Services\Authentication $authentication,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator,
         string $sso
     ) {

--- a/src/Http/Action/Signup/IndexAction.php
+++ b/src/Http/Action/Signup/IndexAction.php
@@ -17,7 +17,7 @@ use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Domain\Services;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class IndexAction
 {
@@ -32,7 +32,7 @@ final class IndexAction
     private $callForPapers;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -44,7 +44,7 @@ final class IndexAction
     public function __construct(
         Services\Authentication $authentication,
         CallForPapers $callForPapers,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->authentication = $authentication;

--- a/src/Http/Action/Signup/PrivacyAction.php
+++ b/src/Http/Action/Signup/PrivacyAction.php
@@ -14,16 +14,16 @@ declare(strict_types=1);
 namespace OpenCFP\Http\Action\Signup;
 
 use Symfony\Component\HttpFoundation;
-use Twig_Environment;
+use Twig\Environment;
 
 final class PrivacyAction
 {
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
-    public function __construct(Twig_Environment $twig)
+    public function __construct(Environment $twig)
     {
         $this->twig = $twig;
     }

--- a/src/Http/Action/Talk/CreateAction.php
+++ b/src/Http/Action/Talk/CreateAction.php
@@ -17,7 +17,7 @@ use OpenCFP\Domain\CallForPapers;
 use OpenCFP\Http\View;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class CreateAction
 {
@@ -32,7 +32,7 @@ final class CreateAction
     private $callForPapers;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -44,7 +44,7 @@ final class CreateAction
     public function __construct(
         View\TalkHelper $talkHelper,
         CallForPapers $callForPapers,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator
     ) {
         $this->talkHelper    = $talkHelper;

--- a/src/Http/Action/Talk/UpdateAction.php
+++ b/src/Http/Action/Talk/UpdateAction.php
@@ -24,7 +24,7 @@ use Swift_Mailer;
 use Swift_Message;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class UpdateAction
 {
@@ -69,7 +69,7 @@ final class UpdateAction
     private $applicationEndDate;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -84,7 +84,7 @@ final class UpdateAction
         CallForPapers $callForPapers,
         HTMLPurifier $purifier,
         Swift_Mailer $swiftMailer,
-        Twig_Environment $twig,
+        Environment $twig,
         Routing\Generator\UrlGeneratorInterface $urlGenerator,
         string $applicationEmail,
         string $applicationTitle,

--- a/src/Http/Controller/Admin/ExportsController.php
+++ b/src/Http/Controller/Admin/ExportsController.php
@@ -18,7 +18,7 @@ use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class ExportsController extends BaseController
 {
@@ -27,7 +27,7 @@ class ExportsController extends BaseController
      */
     private $session;
 
-    public function __construct(Twig_Environment $twig, UrlGeneratorInterface $urlGenerator, SessionInterface $session)
+    public function __construct(Environment $twig, UrlGeneratorInterface $urlGenerator, SessionInterface $session)
     {
         $this->session = $session;
 

--- a/src/Http/Controller/Admin/SpeakersController.php
+++ b/src/Http/Controller/Admin/SpeakersController.php
@@ -25,7 +25,7 @@ use OpenCFP\Http\Controller\BaseController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class SpeakersController extends BaseController
 {
@@ -69,7 +69,7 @@ class SpeakersController extends BaseController
         AccountManagement $accounts,
         AirportInformationDatabase $airports,
         Capsule $capsule,
-        Twig_Environment $twig,
+        Environment $twig,
         UrlGeneratorInterface $urlGenerator,
         string $applicationAirport,
         int $applicationArrival,

--- a/src/Http/Controller/Admin/TalksController.php
+++ b/src/Http/Controller/Admin/TalksController.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class TalksController extends BaseController
 {
@@ -28,7 +28,7 @@ class TalksController extends BaseController
      */
     private $talkHandler;
 
-    public function __construct(TalkHandler $talkHandler, Twig_Environment $twig, UrlGeneratorInterface $urlGenerator)
+    public function __construct(TalkHandler $talkHandler, Environment $twig, UrlGeneratorInterface $urlGenerator)
     {
         $this->talkHandler = $talkHandler;
 

--- a/src/Http/Controller/BaseController.php
+++ b/src/Http/Controller/BaseController.php
@@ -17,12 +17,12 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 abstract class BaseController
 {
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     protected $twig;
 
@@ -31,7 +31,7 @@ abstract class BaseController
      */
     protected $urlGenerator;
 
-    public function __construct(Twig_Environment $twig, UrlGeneratorInterface $urlGenerator)
+    public function __construct(Environment $twig, UrlGeneratorInterface $urlGenerator)
     {
         $this->twig         = $twig;
         $this->urlGenerator = $urlGenerator;

--- a/src/Http/Controller/ForgotController.php
+++ b/src/Http/Controller/ForgotController.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class ForgotController extends BaseController
 {
@@ -44,7 +44,7 @@ class ForgotController extends BaseController
         FormFactoryInterface $formFactory,
         AccountManagement $accounts,
         ResetEmailer $resetEmailer,
-        Twig_Environment $twig,
+        Environment $twig,
         UrlGeneratorInterface $urlGenerator
     ) {
         $this->formFactory  = $formFactory;

--- a/src/Infrastructure/Event/TwigGlobalsListener.php
+++ b/src/Infrastructure/Event/TwigGlobalsListener.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Twig_Environment;
+use Twig\Environment;
 
 class TwigGlobalsListener implements EventSubscriberInterface
 {
@@ -40,7 +40,7 @@ class TwigGlobalsListener implements EventSubscriberInterface
     private $session;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -48,7 +48,7 @@ class TwigGlobalsListener implements EventSubscriberInterface
         Authentication $authentication,
         CallForPapers $callForPapers,
         SessionInterface $session,
-        Twig_Environment $twig
+        Environment $twig
     ) {
         $this->authentication = $authentication;
         $this->callForPapers  = $callForPapers;

--- a/tests/Integration/Infrastructure/Event/TwigGlobalsListenerTest.php
+++ b/tests/Integration/Infrastructure/Event/TwigGlobalsListenerTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Twig_Environment;
+use Twig\Environment;
 
 final class TwigGlobalsListenerTest extends TestCase
 {
@@ -37,7 +37,7 @@ final class TwigGlobalsListenerTest extends TestCase
      */
     public function globals(Authentication $authentication, bool $isOpen, string $uri, string $flash = null, string $fixture)
     {
-        $twig    = new Twig_Environment(new \Twig_Loader_Filesystem(__DIR__ . '/Fixtures'));
+        $twig    = new Environment(new \Twig_Loader_Filesystem(__DIR__ . '/Fixtures'));
         $session = new Session(new MockArraySessionStorage());
 
         if ($flash !== null) {

--- a/tests/Integration/Infrastructure/Templating/TwigExtensionTest.php
+++ b/tests/Integration/Infrastructure/Templating/TwigExtensionTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
+use Twig\Environment;
 
 final class TwigExtensionTest extends TestCase
 {
@@ -40,7 +41,7 @@ final class TwigExtensionTest extends TestCase
         $routes->add('dashboard', new Route('/dashboard'));
         $urlGenerator = new UrlGenerator($routes, new RequestContext());
 
-        $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__ . '/Fixtures'));
+        $twig = new Environment(new \Twig_Loader_Filesystem(__DIR__ . '/Fixtures'));
         $twig->addExtension(new TwigExtension(
             $requestStack,
             $urlGenerator,

--- a/tests/Unit/Http/Action/AbstractActionTestCase.php
+++ b/tests/Unit/Http/Action/AbstractActionTestCase.php
@@ -18,7 +18,7 @@ use OpenCFP\Domain\Services;
 use PHPUnit\Framework;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 /**
  * @deprecated
@@ -30,11 +30,11 @@ abstract class AbstractActionTestCase extends Framework\TestCase
     /**
      * @deprecated
      *
-     * @return Framework\MockObject\MockObject|Twig_Environment
+     * @return Environment|Framework\MockObject\MockObject
      */
-    final protected function createTwigMock(): Twig_Environment
+    final protected function createTwigMock(): Environment
     {
-        return $this->createMock(Twig_Environment::class);
+        return $this->createMock(Environment::class);
     }
 
     /**

--- a/tests/Unit/Http/Action/Admin/Talk/ViewActionTest.php
+++ b/tests/Unit/Http/Action/Admin/Talk/ViewActionTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ViewActionTest extends Framework\TestCase
 {
@@ -81,7 +81,7 @@ final class ViewActionTest extends Framework\TestCase
 
         $action = new ViewAction(
             $talkHandler->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 
@@ -128,7 +128,7 @@ final class ViewActionTest extends Framework\TestCase
             ->shouldBeCalled()
             ->willReturn($talkProfile);
 
-        $twig = $this->prophesize(Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         $twig
             ->render(

--- a/tests/Unit/Http/Action/Forgot/ResetProcessActionTest.php
+++ b/tests/Unit/Http/Action/Forgot/ResetProcessActionTest.php
@@ -22,7 +22,7 @@ use Prophecy\Argument;
 use Symfony\Component\Form;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ResetProcessActionTest extends Framework\TestCase
 {
@@ -54,7 +54,7 @@ final class ResetProcessActionTest extends Framework\TestCase
         $action = new ResetProcessAction(
             $this->prophesize(Form\FormInterface::class)->reveal(),
             $this->prophesize(Services\AccountManagement::class)->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $this->prophesize(Routing\Generator\UrlGeneratorInterface::class)->reveal()
         );
 
@@ -145,7 +145,7 @@ final class ResetProcessActionTest extends Framework\TestCase
             ->shouldBeCalled()
             ->willReturn($resetFormView);
 
-        $twig = $this->prophesize(Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         $twig
             ->render(
@@ -240,7 +240,7 @@ final class ResetProcessActionTest extends Framework\TestCase
             ->shouldBeCalled()
             ->willReturn($resetFormView);
 
-        $twig = $this->prophesize(Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         $twig
             ->render(
@@ -341,7 +341,7 @@ final class ResetProcessActionTest extends Framework\TestCase
         $action = new ResetProcessAction(
             $resetForm->reveal(),
             $accountManagement->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 
@@ -435,7 +435,7 @@ final class ResetProcessActionTest extends Framework\TestCase
         $action = new ResetProcessAction(
             $resetForm->reveal(),
             $accountManagement->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 
@@ -511,7 +511,7 @@ final class ResetProcessActionTest extends Framework\TestCase
         $action = new ResetProcessAction(
             $resetForm->reveal(),
             $accountManagement->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 

--- a/tests/Unit/Http/Action/Forgot/UpdatePasswordActionTest.php
+++ b/tests/Unit/Http/Action/Forgot/UpdatePasswordActionTest.php
@@ -22,7 +22,7 @@ use Prophecy\Argument;
 use Symfony\Component\Form;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class UpdatePasswordActionTest extends Framework\TestCase
 {
@@ -55,7 +55,7 @@ final class UpdatePasswordActionTest extends Framework\TestCase
             ->shouldBeCalled()
             ->willReturn($resetFormView);
 
-        $twig = $this->prophesize(Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         $twig
             ->render(
@@ -113,7 +113,7 @@ final class UpdatePasswordActionTest extends Framework\TestCase
             ->shouldBeCalled()
             ->willReturn($resetFormView);
 
-        $twig = $this->prophesize(Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         $twig
             ->render(
@@ -183,7 +183,7 @@ final class UpdatePasswordActionTest extends Framework\TestCase
         $action = new UpdatePasswordAction(
             $resetForm->reveal(),
             $this->prophesize(Services\AccountManagement::class)->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $this->prophesize(Routing\Generator\UrlGeneratorInterface::class)->reveal()
         );
 
@@ -292,7 +292,7 @@ final class UpdatePasswordActionTest extends Framework\TestCase
         $action = new UpdatePasswordAction(
             $resetForm->reveal(),
             $accountManagement->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 
@@ -393,7 +393,7 @@ final class UpdatePasswordActionTest extends Framework\TestCase
         $action = new UpdatePasswordAction(
             $resetForm->reveal(),
             $accountManagement->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 
@@ -495,7 +495,7 @@ final class UpdatePasswordActionTest extends Framework\TestCase
         $action = new UpdatePasswordAction(
             $resetForm->reveal(),
             $accountManagement->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 

--- a/tests/Unit/Http/Action/Profile/EditActionTest.php
+++ b/tests/Unit/Http/Action/Profile/EditActionTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class EditActionTest extends Framework\TestCase
 {
@@ -89,7 +89,7 @@ final class EditActionTest extends Framework\TestCase
         $action = new EditAction(
             $authentication->reveal(),
             $this->prophesize(PathInterface::class)->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 

--- a/tests/Unit/Http/Action/Profile/ProcessActionTest.php
+++ b/tests/Unit/Http/Action/Profile/ProcessActionTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ProcessActionTest extends Framework\TestCase
 {
@@ -90,7 +90,7 @@ final class ProcessActionTest extends Framework\TestCase
             $authentication->reveal(),
             $this->prophesize(HTMLPurifier::class)->reveal(),
             $this->prophesize(Services\ProfileImageProcessor::class)->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 

--- a/tests/Unit/Http/Action/Reviewer/Talk/ViewActionTest.php
+++ b/tests/Unit/Http/Action/Reviewer/Talk/ViewActionTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ViewActionTest extends Framework\TestCase
 {
@@ -81,7 +81,7 @@ final class ViewActionTest extends Framework\TestCase
 
         $action = new ViewAction(
             $talkHandler->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 
@@ -128,7 +128,7 @@ final class ViewActionTest extends Framework\TestCase
             ->shouldBeCalled()
             ->willReturn($talkProfile);
 
-        $twig = $this->prophesize(Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         $twig
             ->render(

--- a/tests/Unit/Http/Action/Security/LogInActionTest.php
+++ b/tests/Unit/Http/Action/Security/LogInActionTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class LogInActionTest extends Framework\TestCase
 {
@@ -80,7 +80,7 @@ final class LogInActionTest extends Framework\TestCase
             ->shouldBeCalled()
             ->willThrow(new Services\AuthenticationException($exceptionMessage));
 
-        $twig = $this->prophesize(Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         $twig
             ->render(
@@ -176,7 +176,7 @@ final class LogInActionTest extends Framework\TestCase
 
         $action = new LogInAction(
             $authentication->reveal(),
-            $this->prophesize(Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal()
         );
 

--- a/tests/Unit/Http/Action/Security/ShowLogInActionTest.php
+++ b/tests/Unit/Http/Action/Security/ShowLogInActionTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
-use Twig_Environment;
+use Twig\Environment;
 
 final class ShowLogInActionTest extends Framework\TestCase
 {
@@ -53,7 +53,7 @@ final class ShowLogInActionTest extends Framework\TestCase
             )
             ->shouldBeCalled();
 
-        $twig = $this->prophesize(Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         $url_generator = $this->prophesize(Routing\Generator\UrlGenerator::class);
         $url_generator->generate(Argument::exact('dashboard'))->willReturn('/dashboard');
@@ -102,7 +102,7 @@ final class ShowLogInActionTest extends Framework\TestCase
 
         $sso = 'on';
 
-        $twig = $this->prophesize(Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
         $twig
             ->render('security/login.twig', ['sso' => $sso])
             ->shouldBeCalled();

--- a/tests/Unit/Http/Action/Talk/CreateProcessActionTest.php
+++ b/tests/Unit/Http/Action/Talk/CreateProcessActionTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
+use Twig\Environment;
 
 final class CreateProcessActionTest extends Framework\TestCase
 {
@@ -68,7 +69,7 @@ final class CreateProcessActionTest extends Framework\TestCase
             ->shouldBeCalled()
             ->willReturn(false);
 
-        $twig = $this->prophesize(\Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         $urlGenerator = $this->prophesize(Routing\Generator\UrlGeneratorInterface::class);
 

--- a/tests/Unit/Http/Action/Talk/UpdateActionTest.php
+++ b/tests/Unit/Http/Action/Talk/UpdateActionTest.php
@@ -24,6 +24,7 @@ use Prophecy\Argument;
 use Swift_Mailer;
 use Symfony\Component\HttpFoundation;
 use Symfony\Component\Routing;
+use Twig\Environment;
 
 final class UpdateActionTest extends Framework\TestCase
 {
@@ -93,7 +94,7 @@ final class UpdateActionTest extends Framework\TestCase
             $callForPapers->reveal(),
             $this->prophesize(HTMLPurifier::class)->reveal(),
             $this->prophesize(Swift_Mailer::class)->reveal(),
-            $this->prophesize(\Twig_Environment::class)->reveal(),
+            $this->prophesize(Environment::class)->reveal(),
             $urlGenerator->reveal(),
             $applicationEmail,
             $applicationTitle,


### PR DESCRIPTION
This PR

Fixes deprecation of Twig_Envinronment class as provided in https://twig.symfony.com/doc/2.x/deprecated.html.
