### PR TITLE
fixing cs errors and adding migrations on exclude list

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,7 +14,8 @@ TXT;
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->name('opencfp')
-    ->exclude('cache');
+    ->exclude('cache')
+    ->exclude('migrations');
 
 return PhpCsFixer\Config::create()
     ->setUsingCache(true)

--- a/migrations.php
+++ b/migrations.php
@@ -1,13 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2013-2019 OpenCFP
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/opencfp/opencfp
+ */
+
 return [
-    'name' => 'OpenCFP Migrations',
-    'migrations_namespace' => 'OpenCFP\Migrations',
-    'table_name' => 'migration_versions',
-    'column_name' => 'version',
-    'column_length' => 14,
+    'name'                    => 'OpenCFP Migrations',
+    'migrations_namespace'    => 'OpenCFP\Migrations',
+    'table_name'              => 'migration_versions',
+    'column_name'             => 'version',
+    'column_length'           => 14,
     'executed_at_column_name' => 'executed_at',
-    'migrations_directory' => '/migrations',
-    'all_or_nothing' => true,
+    'migrations_directory'    => '/migrations',
+    'all_or_nothing'          => true,
     'check_database_platform' => true,
 ];

--- a/tests/Integration/Domain/Model/UserTest.php
+++ b/tests/Integration/Domain/Model/UserTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Integration\Domain\Model;
 
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use OpenCFP\Domain\Model\Talk;
 use OpenCFP\Domain\Model\TalkComment;
 use OpenCFP\Domain\Model\TalkMeta;
@@ -74,8 +73,8 @@ final class UserTest extends WebTestCase implements TransactionalTestCase
      */
     public function scopeSearchWillReturnAllWhenNoSearch()
     {
-        $initialCount = count(User::search()->get());
-        $count = $this->faker()->numberBetween(3, 5);
+        $initialCount = \count(User::search()->get());
+        $count        = $this->faker()->numberBetween(3, 5);
 
         factory(User::class, $count)->create();
         $totalExpectedCount = $initialCount + $count;

--- a/tests/Integration/Http/Action/Admin/Speaker/PromoteActionTest.php
+++ b/tests/Integration/Http/Action/Admin/Speaker/PromoteActionTest.php
@@ -28,7 +28,7 @@ final class PromoteActionTest extends WebTestCase implements TransactionalTestCa
         $id = $this->faker()->numberBetween(500);
 
         /** @var Model\User $admin */
-        $admin = factory(Model\User::class, 1)->create()->first();
+        $admin     = factory(Model\User::class, 1)->create()->first();
         $csrfToken = $this->container->get('security.csrf.token_manager')
             ->getToken('admin_speaker_promote')
             ->getValue();


### PR DESCRIPTION
This PR

Fixes cs errors that were presented by running `make cs`.
Migrations are added on the exclude list since they are generated via command.
