### PR TITLE
Fix configs to use credentials defined in parameters instead of hardcoded ones

### DIFF
--- a/resources/config/config_development.yml
+++ b/resources/config/config_development.yml
@@ -22,7 +22,7 @@ oneup_flysystem:
 
 doctrine:
   dbal:
-    url: mysql://root:@127.0.0.1:3306/cfp
+    url: mysql://%database.user%:%database.password%@%database.host%/%database.database%
     default_table_options:
       charset: utf8mb4
       collate: utf8mb4_unicode_ci

--- a/resources/config/config_production.yml
+++ b/resources/config/config_production.yml
@@ -14,7 +14,7 @@ oneup_flysystem:
 
 doctrine:
   dbal:
-    url: mysql://root:@127.0.0.1:3306/cfp
+    url: mysql://%database.user%:%database.password%@%database.host%/%database.database%
     default_table_options:
       charset: utf8mb4
       collate: utf8mb4_unicode_ci


### PR DESCRIPTION
Currently speakers list doesn't work if database isn't default one.