### PR TITLE
Implements and tests anonymized reviews setting

### DIFF
--- a/config/ci.yml.dist
+++ b/config/ci.yml.dist
@@ -15,6 +15,7 @@ application:
   coc_link: http://confcodeofconduct.com
   venue_image_path: /assets/img/venue.jpg
   user_image_size: 300
+  anonymized_reviews: false
 
 database:
   host: localhost

--- a/config/development.yml.dist
+++ b/config/development.yml.dist
@@ -16,6 +16,7 @@ application:
   coc_link: http://confcodeofconduct.com/
   venue_image_path: /assets/img/venue.jpg
   user_image_size: 300
+  anonymized_reviews: false
 
 database:
   host: database

--- a/config/docker.yml.dist
+++ b/config/docker.yml.dist
@@ -16,6 +16,7 @@ application:
   coc_link: http://confcodeofconduct.com/
   venue_image_path: /assets/img/venue.jpg
   user_image_size: 300
+  anonymized_reviews: false
 
 database:
   host: database

--- a/config/production.yml.dist
+++ b/config/production.yml.dist
@@ -16,6 +16,7 @@ application:
   coc_link: http://confcodeofconduct.com/
   venue_image_path: /assets/img/venue.jpg
   user_image_size: 300
+  anonymized_reviews: false
 
 database:
   host: 127.0.0.1

--- a/config/testing.yml.dist
+++ b/config/testing.yml.dist
@@ -15,6 +15,7 @@ application:
   coc_link: http://confcodeofconduct.com
   venue_image_path: /assets/img/venue.jpg
   user_image_size: 300
+  anonymized_reviews: false
 
 database:
   host: 127.0.0.1

--- a/resources/views/reviewer/index.twig
+++ b/resources/views/reviewer/index.twig
@@ -54,7 +54,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a>{% if not site.anonymized_reviews %}<span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span>{% endif %}</h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>

--- a/resources/views/reviewer/talks/index.twig
+++ b/resources/views/reviewer/talks/index.twig
@@ -61,7 +61,7 @@
         {% for talk in talks %}
             <div id="talk-{{ talk.id }}" class="flex items-center justify-between mb-8">
                 <div class="w-5/6">
-                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a><span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span></h3>
+                    <h3 class="m-0"><a class="hover:text-brand" href="{{ url('reviewer_talk_view', { id: talk.id }) }}">{{ talk.title|raw }}</a>{% if not site.anonymized_reviews %}<span class="text-sm text-grey-dark"> &mdash; {{ talk.speaker.name }}</span>{% endif %}</h3>
                     <p class="text-sm text-dark-soft mb-3">{{ talk.description | truncate(200) }}</p>
                     <div>
                         <span class="bg-brand text-white text-xs rounded-full py-2 px-3 mr-2"><i class="fa fa-clock-o"></i> {{ talkHelper.getTypeDisplayName(talk.type) }}</span>

--- a/resources/views/reviewer/talks/view.twig
+++ b/resources/views/reviewer/talks/view.twig
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between">
         <div>
             <h2 class="mb-2">
-                {{ talk.title|raw }} {% if talk.speaker.isAllowedToSee('name') %}<span class="text-grey-dark">&mdash; {{ talk.speaker.name }}</span> {% endif %}
+                {{ talk.title|raw }} {% if talk.speaker.isAllowedToSee('name') and not site.anonymized_reviews %}<span class="text-grey-dark">&mdash; {{ talk.speaker.name }}</span> {% endif %}
             </h2>
             {% if talk.slides is defined and talk.slides is not empty %}
                 <div><i class="fa fa-television mr-1"></i> <a class="hover:text-brand" href="{{ talk.slides }}">{{ talk.slides }}</a></div>

--- a/tests/Integration/Http/Action/Reviewer/DashboardActionTest.php
+++ b/tests/Integration/Http/Action/Reviewer/DashboardActionTest.php
@@ -15,6 +15,7 @@ namespace OpenCFP\Test\Integration\Http\Action\Reviewer;
 
 use Illuminate\Database\Eloquent;
 use OpenCFP\Domain\Model;
+use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
@@ -42,5 +43,30 @@ final class DashboardActionTest extends WebTestCase implements TransactionalTest
         }
 
         $this->assertSessionHasNoFlashMessage($this->session());
+    }
+
+    /**
+     * @test
+     */
+    public function speakerNameNotDisplayedWhenAnonymizedReviews()
+    {
+        /** @var Model\User[] $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
+        /** @var Eloquent\Collection|Model\Talk[] $talks */
+        $talks = factory(Model\Talk::class, 2)->create();
+
+        $response = $this
+            ->asReviewer($reviewer->id)
+            ->isAnonymizedReviews()
+            ->get('/reviewer/');
+
+        $this->assertResponseIsSuccessful($response);
+
+        foreach ($talks as $talk) {
+            $speaker = new SpeakerProfile($talk->speaker);
+            $this->assertResponseBodyNotContains($speaker->getName(), $response);
+        }
+
     }
 }

--- a/tests/Integration/Http/Action/Reviewer/Talk/IndexActionTest.php
+++ b/tests/Integration/Http/Action/Reviewer/Talk/IndexActionTest.php
@@ -15,6 +15,7 @@ namespace OpenCFP\Test\Integration\Http\Action\Reviewer\Talk;
 
 use Cartalyst\Support\Collection;
 use OpenCFP\Domain\Model;
+use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
@@ -39,9 +40,33 @@ final class IndexActionTest extends WebTestCase implements TransactionalTestCase
         $this->assertResponseBodyContains('<h2 class="headline">Submitted Talks</h2>', $response);
 
         foreach ($talks as $talk) {
+            $speaker = new SpeakerProfile($talk->speaker);
             $this->assertResponseBodyContains($talk->title, $response);
+            $this->assertResponseBodyContains($speaker->getName(), $response);
         }
 
         $this->assertResponseBodyNotContains('Recent Talks', $response);
+    }
+
+    /**
+     * @test
+     */
+    public function speakerIsHiddenIfAnonymizedReviews()
+    {
+        /** @var Model\User $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
+        /** @var Model\Talk $talk */
+        $talk = factory(Model\Talk::class)->create();
+        $speaker = new SpeakerProfile($talk->speaker);
+
+        $response = $this
+            ->asReviewer($reviewer->id)
+            ->isAnonymizedReviews()
+            ->get('/reviewer/talks');
+
+        $this->assertResponseIsSuccessful($response);
+        $this->assertResponseBodyContains('<h2 class="headline">Submitted Talks</h2>', $response);
+        $this->assertResponseBodyNotContains($speaker->getName(), $response);
     }
 }

--- a/tests/Integration/Http/Action/Reviewer/Talk/ViewActionTest.php
+++ b/tests/Integration/Http/Action/Reviewer/Talk/ViewActionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace OpenCFP\Test\Integration\Http\Action\Reviewer\Talk;
 
 use OpenCFP\Domain\Model;
+use OpenCFP\Domain\Speaker\SpeakerProfile;
 use OpenCFP\Test\Integration\TransactionalTestCase;
 use OpenCFP\Test\Integration\WebTestCase;
 
@@ -55,5 +56,28 @@ final class ViewActionTest extends WebTestCase implements TransactionalTestCase
         $this->assertResponseIsSuccessful($response);
         $this->assertResponseBodyContains($talk->title, $response);
         $this->assertResponseBodyContains($talk->description, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function viewActionWillNotShowSpeakerIfAnonymizedReviews()
+    {
+        /** @var Model\User $reviewer */
+        $reviewer = factory(Model\User::class)->create()->first();
+
+        /** @var Model\Talk $talk */
+        $talk = factory(Model\Talk::class)->create()->first();
+
+        $speaker = new SpeakerProfile($talk->speaker);
+
+        $response = $this
+            ->asReviewer($reviewer->id)
+            ->isAnonymizedReviews()
+            ->get('/reviewer/talks/' . $talk->id);
+
+        $this->assertResponseIsSuccessful($response);
+        $this->assertResponseBodyContains($talk->title, $response);
+        $this->assertResponseBodyNotContains($speaker->getName(), $response);
     }
 }

--- a/tests/Integration/WebTestCase.php
+++ b/tests/Integration/WebTestCase.php
@@ -164,6 +164,15 @@ abstract class WebTestCase extends KernelTestCase
         return $this;
     }
 
+    final protected function isAnonymizedReviews(): self
+    {
+        $config                       = self::$container->getParameter('config.application');
+        $config['anonymized_reviews'] = true;
+        self::$container->get('twig')->addGlobal('site', $config);
+
+        return $this;
+    }
+
     final protected function asLoggedInSpeaker(int $id): self
     {
         $user = Mockery::mock(UserInterface::class);


### PR DESCRIPTION
Some conferences have attempted to remove a source of bias in speaker selection by hiding the names of speakers from reviewers. This PR introduces a new configuration option to enable this behavior. The default behavior is unchanged, so it is an opt-in solution for users.

Fixes #1075.
